### PR TITLE
Option to return only specific properties from VectorRetriever.search results

### DIFF
--- a/src/neo4j_genai/retrievers.py
+++ b/src/neo4j_genai/retrievers.py
@@ -30,12 +30,12 @@ class VectorRetriever:
         driver: Driver,
         index_name: str,
         embedder: Optional[Embedder] = None,
-        pluck: Optional[list[str]] = None,
+        return_properties: Optional[list[str]] = None,
     ) -> None:
         self.driver = driver
         self._verify_version()
         self.index_name = index_name
-        self.pluck = pluck
+        self.return_properties = return_properties
         self.embedder = embedder
 
     def _verify_version(self) -> None:
@@ -114,9 +114,13 @@ class VectorRetriever:
         YIELD node, score
         """
 
-        if self.pluck:
-            pluck_properties = ", ".join([f".{prop}" for prop in self.pluck])
-            db_query_string += f"RETURN node {{{pluck_properties}}} as node, score"
+        if self.return_properties:
+            return_properties_cypher = ", ".join(
+                [f".{prop}" for prop in self.return_properties]
+            )
+            db_query_string += (
+                f"RETURN node {{{return_properties_cypher}}} as node, score"
+            )
 
         records, _, _ = self.driver.execute_query(db_query_string, parameters)
 

--- a/tests/test_retrievers.py
+++ b/tests/test_retrievers.py
@@ -130,7 +130,7 @@ def test_similarity_search_text_happy_path(_verify_version_mock, driver):
 
 
 @patch("neo4j_genai.VectorRetriever._verify_version")
-def test_similarity_search_text_pluck(_verify_version_mock, driver):
+def test_similarity_search_text_return_properties(_verify_version_mock, driver):
     embed_query_vector = [1.0 for _ in range(3)]
     custom_embeddings = MagicMock()
     custom_embeddings.embed_query.return_value = embed_query_vector
@@ -138,9 +138,11 @@ def test_similarity_search_text_pluck(_verify_version_mock, driver):
     index_name = "my-index"
     query_text = "may thy knife chip and shatter"
     top_k = 5
-    pluck = ["node-property-1", "node-property-2"]
+    return_properties = ["node-property-1", "node-property-2"]
 
-    retriever = VectorRetriever(driver, index_name, custom_embeddings, pluck=pluck)
+    retriever = VectorRetriever(
+        driver, index_name, custom_embeddings, return_properties=return_properties
+    )
 
     driver.execute_query.return_value = [
         [{"node": "dummy-node", "score": 1.0}],


### PR DESCRIPTION
To not return the full nodes on plain vector search for a faster and leaner retrieval and minimize the needed post processing.


Usage:

```python
index_name = "movie_plots"
pluck = ["title", "plot"]

retriever = VectorRetriever(driver, index_name, custom_embeddings, pluck=pluck)

query_text = "What's a movie about a wedding?"
results = retriever.search(query_text=query_text, top_k=2)
# [
#   Neo4jRecord(node={'title': 'The Wedding Ringer', 'plot': 'Two weeks shy of his wedding, a socially awkward guy enters into a charade by hiring the owner of a company that provides best men for grooms in need.'}, score=0.9319988489151001),
#   Neo4jRecord(node={'title': "My Best Friend's Wedding", 'plot': "When a woman's long-time friend says he's engaged, she realizes she loves him herself... and sets out to get him, with only days before the wedding."}, score=0.9314284324645996)
# ]
```