### PR TITLE
Removed job to publish to testpypi

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -46,27 +46,3 @@ jobs:
           path: dist/
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-
-  publish-to-test-pypi:
-    name: TestPyPI
-    needs:
-      - build
-    runs-on: ubuntu-latest
-
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/neo4j-graphrag
-
-    permissions:
-      id-token: write
-
-    steps:
-      - name: Download all the dists
-        uses: actions/download-artifact@v4
-        with:
-          name: python-package-distributions
-          path: dist/
-      - name: Publish distribution 📦 to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
# Description

Now that we have [published to testpypi](https://test.pypi.org/project/neo4j-graphrag/). This job is not needed. This also blocks publishing to pypi as we are unable to republish to testpypi.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [x] Project configuration change

## Complexity

Complexity: Low

## How Has This Been Tested?
- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
