### PR TITLE
Changed OnError default to 'CONTINUE'

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ kg_builder = SimpleKGPipeline(
     llm=llm,
     driver=driver,
     embedder=OpenAIEmbeddings(),
-    file_path=file_path,
     entities=entities,
     relations=relations,
 )

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -78,15 +78,23 @@ SinglePropertyExactMatchResolver
     :members: run
 
 
-
 .. _pipeline-section:
 
 ********
 Pipeline
 ********
 
+Pipeline
+========
+
 .. autoclass:: neo4j_graphrag.experimental.pipeline.Pipeline
     :members: run, add_component, connect, get_pygraphviz_graph
+
+SimpleKGPipeline
+================
+
+.. autoclass:: neo4j_graphrag.experimental.pipeline.kg_builder.SimpleKGPipeline
+    :members: run_async
 
 
 .. _retrievers-section:

--- a/src/neo4j_graphrag/experimental/pipeline/kg_builder.py
+++ b/src/neo4j_graphrag/experimental/pipeline/kg_builder.py
@@ -81,7 +81,7 @@ class SimpleKGPipeline:
         text_splitter (Optional[Any]): A text splitter component. Defaults to FixedSizeSplitter().
         pdf_loader (Optional[Any]): A PDF loader component. Defaults to PdfLoader().
         kg_writer (Optional[Any]): A knowledge graph writer component. Defaults to Neo4jWriter().
-        on_error (str): Error handling strategy. Defaults to "RAISE". Possible values: "RAISE" or "IGNORE".
+        on_error (str): Error handling strategy. Defaults to "CONTINUE". Possible values: "RAISE" or "IGNORE".
         perform_entity_resolution (bool): Merge entities with same label and name. Default: True
         text_splitter (Optional[Any]): A text splitter component. Defaults to FixedSizeSplitter().
         prompt_template (str): A custom prompt template to use for extraction.
@@ -99,7 +99,7 @@ class SimpleKGPipeline:
         text_splitter: Optional[Any] = None,
         pdf_loader: Optional[Any] = None,
         kg_writer: Optional[Any] = None,
-        on_error: str = "RAISE",
+        on_error: str = "CONTINUE",
         prompt_template: Union[ERExtractionTemplate, str] = ERExtractionTemplate(),
         perform_entity_resolution: bool = True,
     ):

--- a/src/neo4j_graphrag/experimental/pipeline/kg_builder.py
+++ b/src/neo4j_graphrag/experimental/pipeline/kg_builder.py
@@ -83,7 +83,6 @@ class SimpleKGPipeline:
         kg_writer (Optional[Any]): A knowledge graph writer component. Defaults to Neo4jWriter().
         on_error (str): Error handling strategy. Defaults to "CONTINUE". Possible values: "RAISE" or "CONTINUE".
         perform_entity_resolution (bool): Merge entities with same label and name. Default: True
-        text_splitter (Optional[Any]): A text splitter component. Defaults to FixedSizeSplitter().
         prompt_template (str): A custom prompt template to use for extraction.
     """
 

--- a/src/neo4j_graphrag/experimental/pipeline/kg_builder.py
+++ b/src/neo4j_graphrag/experimental/pipeline/kg_builder.py
@@ -81,7 +81,7 @@ class SimpleKGPipeline:
         text_splitter (Optional[Any]): A text splitter component. Defaults to FixedSizeSplitter().
         pdf_loader (Optional[Any]): A PDF loader component. Defaults to PdfLoader().
         kg_writer (Optional[Any]): A knowledge graph writer component. Defaults to Neo4jWriter().
-        on_error (str): Error handling strategy. Defaults to "CONTINUE". Possible values: "RAISE" or "IGNORE".
+        on_error (str): Error handling strategy. Defaults to "CONTINUE". Possible values: "RAISE" or "CONTINUE".
         perform_entity_resolution (bool): Merge entities with same label and name. Default: True
         text_splitter (Optional[Any]): A text splitter component. Defaults to FixedSizeSplitter().
         prompt_template (str): A custom prompt template to use for extraction.


### PR DESCRIPTION
# Description

Having `OnError`'s default set to `"RAISE"` frequently results in `LLMGenerationError` where one failed LLM response stops the entire execution of the program. This PR changes the default to `"CONTINUE"` to make using `SimpleKGPipeline` easier.

Also updates documentation.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity


Complexity:

## How Has This Been Tested?
- [x] Unit tests
- [x] E2E tests
- [x] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [ ] Unit tests have been updated
- [ ] E2E tests have been updated
- [x] Examples have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
