### PR TITLE
Add check to not use deprecated Cypher syntax when Neo4j version is >= 5.23.0

### DIFF
--- a/.github/workflows/pr-e2e-tests.yaml
+++ b/.github/workflows/pr-e2e-tests.yaml
@@ -16,10 +16,8 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.12']
-        neo4j-version:
-          - 5
-        neo4j-edition:
-          - enterprise
+        neo4j-tag:
+          - 'latest'
     services:
       t2v-transformers:
         image: cr.weaviate.io/semitechnologies/transformers-inference:sentence-transformers-all-MiniLM-L6-v2-onnx
@@ -37,7 +35,7 @@ jobs:
           - 8080:8080
           - 50051:50051
       neo4j:
-        image: neo4j:${{ matrix.neo4j-version }}-${{ matrix.neo4j-edition }}
+        image: neo4j:${{ matrix.neo4j-tag }}
         env:
           NEO4J_AUTH: neo4j/password
           NEO4J_ACCEPT_LICENSE_AGREEMENT: 'eval'
@@ -93,7 +91,7 @@ jobs:
       - name: Run tests
         shell: bash
         run: |
-          if [[ "${{ matrix.neo4j-edition }}" == "community" ]]; then
+          if [[ "${{ matrix.neo4j-tag }}" == "latest" || "${{ matrix.neo4j-tag }}" == *-community ]]; then
               poetry run pytest -m 'not enterprise_only' ./tests/e2e
           else
               poetry run pytest ./tests/e2e

--- a/.github/workflows/scheduled-e2e-tests.yaml
+++ b/.github/workflows/scheduled-e2e-tests.yaml
@@ -13,11 +13,10 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
-        neo4j-version:
-          - 5
-        neo4j-edition:
-          - community
-          - enterprise
+        neo4j-tag:
+          - '5-community'
+          - '5-enterprise'
+          - 'latest'
     services:
       t2v-transformers:
         image: cr.weaviate.io/semitechnologies/transformers-inference:sentence-transformers-all-MiniLM-L6-v2-onnx
@@ -41,7 +40,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       neo4j:
-        image: neo4j:${{ matrix.neo4j-version }}-${{ matrix.neo4j-edition }}
+        image: neo4j:${{ matrix.neo4j-tag }}
         env:
           NEO4J_AUTH: neo4j/password
           NEO4J_ACCEPT_LICENSE_AGREEMENT: 'eval'
@@ -100,7 +99,7 @@ jobs:
       - name: Run tests
         shell: bash
         run: |
-          if [[ "${{ matrix.neo4j-edition }}" == "community" ]]; then
+          if [[ "${{ matrix.neo4j-tag }}" == "latest" || "${{ matrix.neo4j-tag }}" == *-community ]]; then
               poetry run pytest -m 'not enterprise_only' ./tests/e2e
           else
               poetry run pytest ./tests/e2e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Made `relations` and `potential_schema` optional in `SchemaBuilder`.
+- Added a check to prevent the use of deprecated Cypher syntax for Neo4j versions 5.23.0 and above.
 
 ## 1.1.0
 

--- a/src/neo4j_graphrag/neo4j_queries.py
+++ b/src/neo4j_graphrag/neo4j_queries.py
@@ -115,19 +115,33 @@ UPSERT_VECTOR_ON_RELATIONSHIP_QUERY = (
 )
 
 
-def _get_hybrid_query() -> str:
-    return (
-        f"CALL {{ {VECTOR_INDEX_QUERY} "
-        f"WITH collect({{node:node, score:score}}) AS nodes, max(score) AS vector_index_max_score "
-        f"UNWIND nodes AS n "
-        f"RETURN n.node AS node, (n.score / vector_index_max_score) AS score "
-        f"UNION "
-        f"{FULL_TEXT_SEARCH_QUERY} "
-        f"WITH collect({{node:node, score:score}}) AS nodes, max(score) AS ft_index_max_score "
-        f"UNWIND nodes AS n "
-        f"RETURN n.node AS node, (n.score / ft_index_max_score) AS score }} "
-        f"WITH node, max(score) AS score ORDER BY score DESC LIMIT $top_k"
-    )
+def _get_hybrid_query(neo4j_version_is_5_23_or_above: bool) -> str:
+    if neo4j_version_is_5_23_or_above:
+        return (
+            f"CALL () {{ {VECTOR_INDEX_QUERY} "
+            f"WITH collect({{node:node, score:score}}) AS nodes, max(score) AS vector_index_max_score "
+            f"UNWIND nodes AS n "
+            f"RETURN n.node AS node, (n.score / vector_index_max_score) AS score "
+            f"UNION "
+            f"{FULL_TEXT_SEARCH_QUERY} "
+            f"WITH collect({{node:node, score:score}}) AS nodes, max(score) AS ft_index_max_score "
+            f"UNWIND nodes AS n "
+            f"RETURN n.node AS node, (n.score / ft_index_max_score) AS score }} "
+            f"WITH node, max(score) AS score ORDER BY score DESC LIMIT $top_k"
+        )
+    else:
+        return (
+            f"CALL {{ {VECTOR_INDEX_QUERY} "
+            f"WITH collect({{node:node, score:score}}) AS nodes, max(score) AS vector_index_max_score "
+            f"UNWIND nodes AS n "
+            f"RETURN n.node AS node, (n.score / vector_index_max_score) AS score "
+            f"UNION "
+            f"{FULL_TEXT_SEARCH_QUERY} "
+            f"WITH collect({{node:node, score:score}}) AS nodes, max(score) AS ft_index_max_score "
+            f"UNWIND nodes AS n "
+            f"RETURN n.node AS node, (n.score / ft_index_max_score) AS score }} "
+            f"WITH node, max(score) AS score ORDER BY score DESC LIMIT $top_k"
+        )
 
 
 def _get_filtered_vector_query(
@@ -168,6 +182,7 @@ def get_search_query(
     embedding_node_property: Optional[str] = None,
     embedding_dimension: Optional[int] = None,
     filters: Optional[dict[str, Any]] = None,
+    neo4j_version_is_5_23_or_above: bool = False,
 ) -> tuple[str, dict[str, Any]]:
     """Build the search query, including pre-filtering if needed, and return clause.
 
@@ -189,7 +204,7 @@ def get_search_query(
     if search_type == SearchType.HYBRID:
         if filters:
             raise Exception("Filters are not supported with Hybrid Search")
-        query = _get_hybrid_query()
+        query = _get_hybrid_query(neo4j_version_is_5_23_or_above)
         params: dict[str, Any] = {}
     elif search_type == SearchType.VECTOR:
         if filters:

--- a/src/neo4j_graphrag/retrievers/base.py
+++ b/src/neo4j_graphrag/retrievers/base.py
@@ -101,6 +101,14 @@ class Retriever(ABC, metaclass=RetrieverMetaclass):
             version_tuple = (*version_tuple, 0)
         return version_tuple, "aura" in version
 
+    def _check_if_version_5_23_or_above(self, version_tuple: tuple[int, ...]) -> bool:
+        """
+        Check if the connected Neo4j database version supports the required features.
+
+        Sets a flag if the connected Neo4j version is 5.23 or above.
+        """
+        return version_tuple >= (5, 23, 0)
+
     def _verify_version(self) -> None:
         """
         Check if the connected Neo4j database version supports vector indexing.
@@ -111,6 +119,9 @@ class Retriever(ABC, metaclass=RetrieverMetaclass):
         not supported.
         """
         version_tuple, is_aura = self._get_version()
+        self.neo4j_version_is_5_23_or_above = self._check_if_version_5_23_or_above(
+            version_tuple
+        )
 
         if is_aura:
             target_version = (5, 18, 0)

--- a/src/neo4j_graphrag/retrievers/external/pinecone/types.py
+++ b/src/neo4j_graphrag/retrievers/external/pinecone/types.py
@@ -17,10 +17,7 @@ from __future__ import annotations
 from typing import Any, Callable, Optional, Union
 
 import neo4j
-
-
 from pinecone import Pinecone
-
 from pydantic import (
     BaseModel,
     ConfigDict,

--- a/src/neo4j_graphrag/retrievers/external/weaviate/weaviate.py
+++ b/src/neo4j_graphrag/retrievers/external/weaviate/weaviate.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import neo4j
 import weaviate.classes as wvc

--- a/src/neo4j_graphrag/retrievers/hybrid.py
+++ b/src/neo4j_graphrag/retrievers/hybrid.py
@@ -184,7 +184,11 @@ class HybridRetriever(Retriever):
             query_vector = self.embedder.embed_query(query_text)
             parameters["query_vector"] = query_vector
 
-        search_query, _ = get_search_query(SearchType.HYBRID, self.return_properties)
+        search_query, _ = get_search_query(
+            SearchType.HYBRID,
+            self.return_properties,
+            neo4j_version_is_5_23_or_above=self.neo4j_version_is_5_23_or_above,
+        )
 
         logger.debug("HybridRetriever Cypher parameters: %s", parameters)
         logger.debug("HybridRetriever Cypher query: %s", search_query)
@@ -336,7 +340,9 @@ class HybridCypherRetriever(Retriever):
             del parameters["query_params"]
 
         search_query, _ = get_search_query(
-            SearchType.HYBRID, retrieval_query=self.retrieval_query
+            SearchType.HYBRID,
+            retrieval_query=self.retrieval_query,
+            neo4j_version_is_5_23_or_above=self.neo4j_version_is_5_23_or_above,
         )
 
         logger.debug("HybridCypherRetriever Cypher parameters: %s", parameters)

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     environment:
       ENABLE_CUDA: "0"
   neo4j:
-    image: neo4j:5-enterprise
+    image: neo4j:5.24-enterprise
     ports:
       - 7687:7687
       - 7474:7474

--- a/tests/e2e/test_hybrid_e2e.py
+++ b/tests/e2e/test_hybrid_e2e.py
@@ -12,6 +12,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import logging
 
 import pytest
 from neo4j import Driver
@@ -38,6 +39,26 @@ def test_hybrid_retriever_search_text(
     assert len(results.items) == 5
     for result in results.items:
         assert isinstance(result, RetrieverResultItem)
+
+
+@pytest.mark.usefixtures("setup_neo4j_for_retrieval")
+def test_hybrid_retriever_no_neo4j_deprecation_warning(
+    driver: Driver, random_embedder: Embedder, caplog
+) -> None:
+    retriever = HybridRetriever(
+        driver, "vector-index-name", "fulltext-index-name", random_embedder
+    )
+
+    top_k = 5
+    with caplog.at_level(logging.WARNING):
+        retriever.search(query_text="Find me a book about Fremen", top_k=top_k)
+
+    for record in caplog.records:
+        if (
+            "Neo.ClientNotification.Statement.FeatureDeprecationWarning"
+            in record.message
+        ):
+            assert False, f"Deprecation warning found in logs: {record.message}"
 
 
 @pytest.mark.usefixtures("setup_neo4j_for_retrieval")

--- a/tests/e2e/test_hybrid_e2e.py
+++ b/tests/e2e/test_hybrid_e2e.py
@@ -43,7 +43,7 @@ def test_hybrid_retriever_search_text(
 
 @pytest.mark.usefixtures("setup_neo4j_for_retrieval")
 def test_hybrid_retriever_no_neo4j_deprecation_warning(
-    driver: Driver, random_embedder: Embedder, caplog
+    driver: Driver, random_embedder: Embedder, caplog: pytest.LogCaptureFixture
 ) -> None:
     retriever = HybridRetriever(
         driver, "vector-index-name", "fulltext-index-name", random_embedder

--- a/tests/e2e/test_kg_writer_component_e2e.py
+++ b/tests/e2e/test_kg_writer_component_e2e.py
@@ -106,7 +106,7 @@ async def test_kg_writer(driver: neo4j.Driver) -> None:
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("setup_neo4j_for_kg_construction")
 async def test_kg_writer_no_neo4j_deprecation_warning(
-    driver: neo4j.Driver, caplog
+    driver: neo4j.Driver, caplog: pytest.LogCaptureFixture
 ) -> None:
     start_node = Neo4jNode(
         id="1",

--- a/tests/e2e/test_kg_writer_component_e2e.py
+++ b/tests/e2e/test_kg_writer_component_e2e.py
@@ -12,6 +12,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import logging
 
 import neo4j
 import pytest
@@ -100,3 +101,42 @@ async def test_kg_writer(driver: neo4j.Driver) -> None:
         for key, val in node_with_two_embeddings.embedding_properties.items():
             assert key in node_c.keys()
             assert val == node_c.get(key)
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("setup_neo4j_for_kg_construction")
+async def test_kg_writer_no_neo4j_deprecation_warning(
+    driver: neo4j.Driver, caplog
+) -> None:
+    start_node = Neo4jNode(
+        id="1",
+        label="MyLabel",
+        properties={"chunk": 1},
+        embedding_properties={"vectorProperty": [1.0, 2.0, 3.0]},
+    )
+    end_node = Neo4jNode(
+        id="2",
+        label="MyLabel",
+        properties={},
+        embedding_properties=None,
+    )
+    relationship = Neo4jRelationship(
+        start_node_id="1", end_node_id="2", type="MY_RELATIONSHIP"
+    )
+    graph = Neo4jGraph(
+        nodes=[start_node, end_node],
+        relationships=[relationship],
+    )
+
+    neo4j_writer = Neo4jWriter(driver=driver)
+    with caplog.at_level(logging.WARNING):
+        res = await neo4j_writer.run(graph=graph)
+
+    for record in caplog.records:
+        if (
+            "Neo.ClientNotification.Statement.FeatureDeprecationWarning"
+            in record.message
+        ):
+            assert False, f"Deprecation warning found in logs: {record.message}"
+
+    assert res.status == "SUCCESS"

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import hashlib
 import json
 import os.path
-from contextlib import contextmanager
 from typing import Any, Literal
 
 import neo4j
@@ -557,25 +556,3 @@ def build_data_objects(
             )
 
     return neo4j_objs, question_objs
-
-
-@contextmanager
-def capture_notifications(driver: neo4j.Driver):
-    original_execute_query = driver.execute_query
-
-    notifications = []
-
-    def execute_query_wrapper(*args, **kwargs):
-        result = original_execute_query(*args, **kwargs)
-        # result is (records, summary, keys)
-        _, summary, _ = result
-        print("summary", summary)
-        if summary and summary.notifications:
-            notifications.extend(summary.notifications)
-        return result
-
-    driver.execute_query = execute_query_wrapper
-    try:
-        yield notifications
-    finally:
-        driver.execute_query = original_execute_query

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os.path
+from contextlib import contextmanager
 from typing import Any, Literal
 
 import neo4j
@@ -556,3 +557,25 @@ def build_data_objects(
             )
 
     return neo4j_objs, question_objs
+
+
+@contextmanager
+def capture_notifications(driver: neo4j.Driver):
+    original_execute_query = driver.execute_query
+
+    notifications = []
+
+    def execute_query_wrapper(*args, **kwargs):
+        result = original_execute_query(*args, **kwargs)
+        # result is (records, summary, keys)
+        _, summary, _ = result
+        print("summary", summary)
+        if summary and summary.notifications:
+            notifications.extend(summary.notifications)
+        return result
+
+    driver.execute_query = execute_query_wrapper
+    try:
+        yield notifications
+    finally:
+        driver.execute_query = original_execute_query

--- a/tests/unit/experimental/pipeline/test_kg_builder.py
+++ b/tests/unit/experimental/pipeline/test_kg_builder.py
@@ -12,7 +12,8 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from unittest.mock import MagicMock, patch
+from unittest import mock
+from unittest.mock import MagicMock, Mock, patch
 
 import neo4j
 import pytest
@@ -25,8 +26,12 @@ from neo4j_graphrag.experimental.pipeline.pipeline import PipelineResult
 from neo4j_graphrag.llm.base import LLMInterface
 
 
+@mock.patch(
+    "neo4j_graphrag.experimental.components.kg_writer.Neo4jWriter._get_version",
+    return_value=(5, 23, 0),
+)
 @pytest.mark.asyncio
-async def test_knowledge_graph_builder_init_with_text() -> None:
+async def test_knowledge_graph_builder_init_with_text(_: Mock) -> None:
     llm = MagicMock(spec=LLMInterface)
     driver = MagicMock(spec=neo4j.Driver)
     embedder = MagicMock(spec=Embedder)
@@ -60,8 +65,12 @@ async def test_knowledge_graph_builder_init_with_text() -> None:
         assert pipe_inputs["splitter"]["text"] == text_input
 
 
+@mock.patch(
+    "neo4j_graphrag.experimental.components.kg_writer.Neo4jWriter._get_version",
+    return_value=(5, 23, 0),
+)
 @pytest.mark.asyncio
-async def test_knowledge_graph_builder_init_with_file_path() -> None:
+async def test_knowledge_graph_builder_init_with_file_path(_: Mock) -> None:
     llm = MagicMock(spec=LLMInterface)
     driver = MagicMock(spec=neo4j.Driver)
     embedder = MagicMock(spec=Embedder)
@@ -94,8 +103,12 @@ async def test_knowledge_graph_builder_init_with_file_path() -> None:
         assert pipe_inputs["pdf_loader"]["filepath"] == file_path
 
 
+@mock.patch(
+    "neo4j_graphrag.experimental.components.kg_writer.Neo4jWriter._get_version",
+    return_value=(5, 23, 0),
+)
 @pytest.mark.asyncio
-async def test_knowledge_graph_builder_run_with_both_inputs() -> None:
+async def test_knowledge_graph_builder_run_with_both_inputs(_: Mock) -> None:
     llm = MagicMock(spec=LLMInterface)
     driver = MagicMock(spec=neo4j.Driver)
     embedder = MagicMock(spec=Embedder)
@@ -118,8 +131,12 @@ async def test_knowledge_graph_builder_run_with_both_inputs() -> None:
     ) or "Expected 'text' argument when 'from_pdf' is False." in str(exc_info.value)
 
 
+@mock.patch(
+    "neo4j_graphrag.experimental.components.kg_writer.Neo4jWriter._get_version",
+    return_value=(5, 23, 0),
+)
 @pytest.mark.asyncio
-async def test_knowledge_graph_builder_run_with_no_inputs() -> None:
+async def test_knowledge_graph_builder_run_with_no_inputs(_: Mock) -> None:
     llm = MagicMock(spec=LLMInterface)
     driver = MagicMock(spec=neo4j.Driver)
     embedder = MagicMock(spec=Embedder)
@@ -139,8 +156,12 @@ async def test_knowledge_graph_builder_run_with_no_inputs() -> None:
     ) or "Expected 'text' argument when 'from_pdf' is False." in str(exc_info.value)
 
 
+@mock.patch(
+    "neo4j_graphrag.experimental.components.kg_writer.Neo4jWriter._get_version",
+    return_value=(5, 23, 0),
+)
 @pytest.mark.asyncio
-async def test_knowledge_graph_builder_document_info_with_file() -> None:
+async def test_knowledge_graph_builder_document_info_with_file(_: Mock) -> None:
     llm = MagicMock(spec=LLMInterface)
     driver = MagicMock(spec=neo4j.Driver)
     embedder = MagicMock(spec=Embedder)
@@ -167,8 +188,12 @@ async def test_knowledge_graph_builder_document_info_with_file() -> None:
         assert "extractor" not in pipe_inputs
 
 
+@mock.patch(
+    "neo4j_graphrag.experimental.components.kg_writer.Neo4jWriter._get_version",
+    return_value=(5, 23, 0),
+)
 @pytest.mark.asyncio
-async def test_knowledge_graph_builder_document_info_with_text() -> None:
+async def test_knowledge_graph_builder_document_info_with_text(_: Mock) -> None:
     llm = MagicMock(spec=LLMInterface)
     driver = MagicMock(spec=neo4j.Driver)
     embedder = MagicMock(spec=Embedder)
@@ -194,8 +219,12 @@ async def test_knowledge_graph_builder_document_info_with_text() -> None:
         assert pipe_inputs["splitter"] == {"text": text_input}
 
 
+@mock.patch(
+    "neo4j_graphrag.experimental.components.kg_writer.Neo4jWriter._get_version",
+    return_value=(5, 23, 0),
+)
 @pytest.mark.asyncio
-async def test_knowledge_graph_builder_with_entities_and_file() -> None:
+async def test_knowledge_graph_builder_with_entities_and_file(_: Mock) -> None:
     llm = MagicMock(spec=LLMInterface)
     driver = MagicMock(spec=neo4j.Driver)
     embedder = MagicMock(spec=Embedder)
@@ -234,7 +263,11 @@ async def test_knowledge_graph_builder_with_entities_and_file() -> None:
         assert pipe_inputs["schema"]["potential_schema"] == potential_schema
 
 
-def test_simple_kg_pipeline_on_error_conversion() -> None:
+@mock.patch(
+    "neo4j_graphrag.experimental.components.kg_writer.Neo4jWriter._get_version",
+    return_value=(5, 23, 0),
+)
+def test_simple_kg_pipeline_on_error_conversion(_: Mock) -> None:
     llm = MagicMock(spec=LLMInterface)
     driver = MagicMock(spec=neo4j.Driver)
     embedder = MagicMock(spec=Embedder)
@@ -265,7 +298,11 @@ def test_simple_kg_pipeline_on_error_invalid_value() -> None:
     assert "Expected one of ['RAISE', 'IGNORE']" in str(exc_info.value)
 
 
-def test_simple_kg_pipeline_no_entity_resolution() -> None:
+@mock.patch(
+    "neo4j_graphrag.experimental.components.kg_writer.Neo4jWriter._get_version",
+    return_value=(5, 23, 0),
+)
+def test_simple_kg_pipeline_no_entity_resolution(_: Mock) -> None:
     llm = MagicMock(spec=LLMInterface)
     driver = MagicMock(spec=neo4j.Driver)
     embedder = MagicMock(spec=Embedder)

--- a/tests/unit/retrievers/test_hybrid.py
+++ b/tests/unit/retrievers/test_hybrid.py
@@ -87,6 +87,7 @@ def test_hybrid_retriever_with_result_format_function(
         embedder,
         result_formatter=result_formatter,
     )
+    retriever.neo4j_version_is_5_23_or_above = True
     retriever.driver.execute_query.return_value = [  # type: ignore
         [neo4j_record],
         None,
@@ -174,12 +175,16 @@ def test_hybrid_search_text_happy_path(
     retriever = HybridRetriever(
         driver, vector_index_name, fulltext_index_name, embedder
     )
+    retriever.neo4j_version_is_5_23_or_above = True
     retriever.driver.execute_query.return_value = [  # type: ignore
         [neo4j_record],
         None,
         None,
     ]
-    search_query, _ = get_search_query(SearchType.HYBRID)
+    search_query, _ = get_search_query(
+        SearchType.HYBRID,
+        neo4j_version_is_5_23_or_above=retriever.neo4j_version_is_5_23_or_above,
+    )
 
     records = retriever.search(query_text=query_text, top_k=top_k)
 
@@ -226,12 +231,16 @@ def test_hybrid_search_favors_query_vector_over_embedding_vector(
         embedder,
         neo4j_database=database,
     )
+    retriever.neo4j_version_is_5_23_or_above = True
     retriever.driver.execute_query.return_value = [  # type: ignore
         [neo4j_record],
         None,
         None,
     ]
-    search_query, _ = get_search_query(SearchType.HYBRID)
+    search_query, _ = get_search_query(
+        SearchType.HYBRID,
+        neo4j_version_is_5_23_or_above=retriever.neo4j_version_is_5_23_or_above,
+    )
 
     retriever.search(query_text=query_text, query_vector=query_vector, top_k=top_k)
 
@@ -300,12 +309,17 @@ def test_hybrid_retriever_return_properties(
         embedder,
         return_properties,
     )
+    retriever.neo4j_version_is_5_23_or_above = True
     driver.execute_query.return_value = [
         [neo4j_record],
         None,
         None,
     ]
-    search_query, _ = get_search_query(SearchType.HYBRID, return_properties)
+    search_query, _ = get_search_query(
+        SearchType.HYBRID,
+        return_properties,
+        neo4j_version_is_5_23_or_above=retriever.neo4j_version_is_5_23_or_above,
+    )
 
     records = retriever.search(query_text=query_text, top_k=top_k)
 
@@ -355,13 +369,16 @@ def test_hybrid_cypher_retrieval_query_with_params(
         retrieval_query,
         embedder,
     )
+    retriever.neo4j_version_is_5_23_or_above = True
     driver.execute_query.return_value = [
         [neo4j_record],
         None,
         None,
     ]
     search_query, _ = get_search_query(
-        SearchType.HYBRID, retrieval_query=retrieval_query
+        SearchType.HYBRID,
+        retrieval_query=retrieval_query,
+        neo4j_version_is_5_23_or_above=retriever.neo4j_version_is_5_23_or_above,
     )
 
     records = retriever.search(
@@ -419,6 +436,7 @@ def test_hybrid_cypher_retriever_with_result_format_function(
         embedder,
         result_formatter=result_formatter,
     )
+    retriever.neo4j_version_is_5_23_or_above = True
     retriever.driver.execute_query.return_value = [  # type: ignore
         [neo4j_record],
         None,


### PR DESCRIPTION
# Description
- Add check to not use deprecated Cypher syntax when Neo4j version is >= 5.23.0
- Removes warning supression


## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity


Complexity: Low

## How Has This Been Tested?
- [x] Unit tests
- [x] E2E tests
- [x] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [x] CHANGELOG.md updated if appropriate
