### PR TITLE
Adds a warning about the default value of return_context for GraphRAG.search changing

### DIFF
--- a/docs/source/user_guide_kg_builder.rst
+++ b/docs/source/user_guide_kg_builder.rst
@@ -446,6 +446,7 @@ with the same label and identical "name" property.
 It can be used like this:
 
 .. code:: python
+
     from neo4j_graphrag.experimental.components.resolver import (
         SinglePropertyExactMatchResolver,
     )

--- a/src/neo4j_graphrag/generation/graphrag.py
+++ b/src/neo4j_graphrag/generation/graphrag.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from typing import Any, Optional
 
 from pydantic import ValidationError
@@ -84,12 +85,18 @@ class GraphRAG:
         query_text: str = "",
         examples: str = "",
         retriever_config: Optional[dict[str, Any]] = None,
-        return_context: bool = False,
+        return_context: bool | None = None,
     ) -> RagResultModel:
-        """This method performs a full RAG search:
-        1. Retrieval: context retrieval
-        2. Augmentation: prompt formatting
-        3. Generation: answer generation with LLM
+        """
+        .. warning::
+            The default value of 'return_context' will change from 'False' to 'True' in a future version.
+
+
+        This method performs a full RAG search:
+            1. Retrieval: context retrieval
+            2. Augmentation: prompt formatting
+            3. Generation: answer generation with LLM
+
 
         Args:
             query_text (str): The user question
@@ -102,6 +109,12 @@ class GraphRAG:
             RagResultModel: The LLM-generated answer
 
         """
+        if return_context is None:
+            warnings.warn(
+                "The default value of 'return_context' will change from 'False' to 'True' in a future version.",
+                DeprecationWarning,
+            )
+            return_context = False
         try:
             validated_data = RagSearchModel(
                 query_text=query_text,


### PR DESCRIPTION
# Description

Adds a warning to the `neo4j_graphrag.generation.graphrag.GraphRAG.search` method which lets the user know that the default value of the `return_context` argument will change from 'False' to 'True' in a future version.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Low

## How Has This Been Tested?
- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
