### PR TITLE
Fix: AzureOpenAIEmbeddings inheritance issue

### DIFF
--- a/src/neo4j_graphrag/embeddings/openai.py
+++ b/src/neo4j_graphrag/embeddings/openai.py
@@ -34,6 +34,19 @@ class BaseOpenAIEmbeddings(Embedder, abc.ABC):
                 "Please install it with `pip install openai`."
             )
         self.model = model
+    
+    def embed_query(self, text: str, **kwargs: Any) -> list[float]:
+        """
+        Generate embeddings for a given query using a OpenAI text embedding model.
+
+        Args:
+            text (str): The text to generate an embedding for.
+            **kwargs (Any): Additional arguments to pass to the OpenAI embedding generation function.
+        """
+        response = self.openai_client.embeddings.create(
+            input=text, model=self.model, **kwargs
+        )
+        return response.data[0].embedding
 
 
 class OpenAIEmbeddings(BaseOpenAIEmbeddings):
@@ -50,34 +63,8 @@ class OpenAIEmbeddings(BaseOpenAIEmbeddings):
         super().__init__(model, **kwargs)
         self.openai_client = openai.OpenAI(**kwargs)
 
-    def embed_query(self, text: str, **kwargs: Any) -> list[float]:
-        """
-        Generate embeddings for a given query using a OpenAI text embedding model.
-
-        Args:
-            text (str): The text to generate an embedding for.
-            **kwargs (Any): Additional arguments to pass to the OpenAI embedding generation function.
-        """
-        response = self.openai_client.embeddings.create(
-            input=text, model=self.model, **kwargs
-        )
-        return response.data[0].embedding
-
 
 class AzureOpenAIEmbeddings(BaseOpenAIEmbeddings):
     def __init__(self, model: str = "text-embedding-ada-002", **kwargs: Any) -> None:
         super().__init__(model, **kwargs)
         self.openai_client = openai.AzureOpenAI(**kwargs)
-
-    def embed_query(self, text: str, **kwargs: Any) -> list[float]:
-        """
-        Generate embeddings for a given query using a OpenAI text embedding model.
-
-        Args:
-            text (str): The text to generate an embedding for.
-            **kwargs (Any): Additional arguments to pass to the OpenAI embedding generation function.
-        """
-        response = self.openai_client.embeddings.create(
-            input=text, model=self.model, **kwargs
-        )
-        return response.data[0].embedding

--- a/src/neo4j_graphrag/embeddings/openai.py
+++ b/src/neo4j_graphrag/embeddings/openai.py
@@ -64,7 +64,20 @@ class OpenAIEmbeddings(BaseOpenAIEmbeddings):
         return response.data[0].embedding
 
 
-class AzureOpenAIEmbeddings(OpenAIEmbeddings):
+class AzureOpenAIEmbeddings(BaseOpenAIEmbeddings):
     def __init__(self, model: str = "text-embedding-ada-002", **kwargs: Any) -> None:
         super().__init__(model, **kwargs)
         self.openai_client = openai.AzureOpenAI(**kwargs)
+
+    def embed_query(self, text: str, **kwargs: Any) -> list[float]:
+        """
+        Generate embeddings for a given query using a OpenAI text embedding model.
+
+        Args:
+            text (str): The text to generate an embedding for.
+            **kwargs (Any): Additional arguments to pass to the OpenAI embedding generation function.
+        """
+        response = self.openai_client.embeddings.create(
+            input=text, model=self.model, **kwargs
+        )
+        return response.data[0].embedding


### PR DESCRIPTION
# Description

This pull request addresses issue #190. AzureOpenAIEmbeddings object is inheriting from OpenAIEmbeddings class vs. the base class (BaseOpenAIEmbeddings). As such when instantiating the AzureOpenAIEmbeddings object, you an unexpected keyword argument error.

**Example:** got an unexpected keyword argument 'azure_endpoint'

## Type of Change
- [ ] New feature
- [X ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Low

## How Has This Been Tested?
- [ ] Unit tests
- [ ] E2E tests
- [X] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
