### PR TITLE
Fix ollama embedder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+### Fixed
+
+- Fix a bug where the `OllamaEmbedder` would return a `list[list[float]]` instead of the expected `list[float]`.
+
 ## 1.4.1
 
 ### Fixed

--- a/src/neo4j_graphrag/embeddings/ollama.py
+++ b/src/neo4j_graphrag/embeddings/ollama.py
@@ -55,10 +55,12 @@ class OllamaEmbeddings(Embedder):
             **kwargs,
         )
 
-        if embeddings_response is None or embeddings_response.embeddings is None:
+        if embeddings_response is None or not embeddings_response.embeddings:
             raise EmbeddingsGenerationError("Failed to retrieve embeddings.")
 
-        embedding = embeddings_response.embeddings
+        embeddings = embeddings_response.embeddings
+        # client always returns a sequence of sequences
+        embedding = embeddings[0]
         if not isinstance(embedding, list):
             raise EmbeddingsGenerationError("Embedding is not a list of floats.")
 


### PR DESCRIPTION
# Description

Ollama embed method always returns a sequence of sequences, even if passed only one item. This PR addresses this.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High
>
>

Complexity: Low

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [x] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [x] CHANGELOG.md updated if appropriate
