### PR TITLE
Fix Weaviate Retriever e2e tests

### DIFF
--- a/.github/workflows/pr-e2e-tests.yaml
+++ b/.github/workflows/pr-e2e-tests.yaml
@@ -20,7 +20,7 @@ jobs:
           - 'latest'
     services:
       t2v-transformers:
-        image: cr.weaviate.io/semitechnologies/transformers-inference:sentence-transformers-all-MiniLM-L6-v2-onnx
+        image: cr.weaviate.io/semitechnologies/transformers-inference:sentence-transformers-all-MiniLM-L6-v2
         env:
           ENABLE_CUDA: '0'
       weaviate:

--- a/.github/workflows/scheduled-e2e-tests.yaml
+++ b/.github/workflows/scheduled-e2e-tests.yaml
@@ -19,7 +19,7 @@ jobs:
           - 'latest'
     services:
       t2v-transformers:
-        image: cr.weaviate.io/semitechnologies/transformers-inference:sentence-transformers-all-MiniLM-L6-v2-onnx
+        image: cr.weaviate.io/semitechnologies/transformers-inference:sentence-transformers-all-MiniLM-L6-v2
         env:
           ENABLE_CUDA: '0'
         credentials:

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -10,8 +10,8 @@ services:
       - http
     image: cr.weaviate.io/semitechnologies/weaviate:1.25.1
     ports:
-      - 8080:8080
-      - 50051:50051
+      - "8080:8080"
+      - "50051:50051"
     restart: on-failure:0
     environment:
       TRANSFORMERS_INFERENCE_API: "http://t2v-transformers:8080"
@@ -22,7 +22,7 @@ services:
       ENABLE_MODULES: "text2vec-transformers"
       CLUSTER_HOSTNAME: "node1"
   t2v-transformers:
-    image: cr.weaviate.io/semitechnologies/transformers-inference:sentence-transformers-all-MiniLM-L6-v2-onnx
+    image: cr.weaviate.io/semitechnologies/transformers-inference:sentence-transformers-all-MiniLM-L6-v2
     environment:
       ENABLE_CUDA: "0"
   neo4j:

--- a/tests/e2e/weaviate_e2e/populate_dbs.py
+++ b/tests/e2e/weaviate_e2e/populate_dbs.py
@@ -31,7 +31,7 @@ def populate_dbs(
         collection_name,
         vectorizer_config=wvc.config.Configure.Vectorizer.text2vec_transformers(),
         vector_index_config=wvc.config.Configure.VectorIndex.hnsw(
-            distance_metric=wvc.config.VectorDistances.COSINE  # select prefered distance metric
+            distance_metric=wvc.config.VectorDistances.COSINE  # select preferred distance metric
         ),
         properties=[
             wvc.config.Property(name="neo4j_id", data_type=wvc.config.DataType.TEXT),

--- a/tests/e2e/weaviate_e2e/test_weaviate_e2e.py
+++ b/tests/e2e/weaviate_e2e/test_weaviate_e2e.py
@@ -135,6 +135,6 @@ def test_weaviate_neo4j_text_input_remote_embedder(
         r"labels=frozenset\({'Question'}\) properties={'question': 'In 1953 Watson \& "
         "Crick built a model of the molecular structure of this, the gene-carrying "
         "substance', 'id': 'question_c458c6f64d8d47429636bc5a94c97f51'}> "
-        r"score=0.5[0-9]+>"
+        r"score=0.6[0-9]+>"
     )
     assert re.match(pattern, results.items[0].content)


### PR DESCRIPTION
# Description

The scores produced by the former container are:
```
[['question_c458c6f64d8d47429636bc5a94c97f51', 0.589142918586731], ['question_3d53154d16068c1e86e024923bc220d8', 0.5859494209289551]]
```

notably different from the ones that are obtained by a direct use of `sentence-transformer` or the `EMBEDDING_BIOLOGY` vector (in the other tests):
```
[['question_c458c6f64d8d47429636bc5a94c97f51', 0.6165122985839844], ['question_3d53154d16068c1e86e024923bc220d8', 0.5926026105880737]]
```

Changing to this other Docker container fixes this issue. 

And now the two scores are different enough to prevent unstable floating point errors, for all the tests.


Container sizes are roughly equivalent:
- 6.23G for the [new one](https://hub.docker.com/layers/semitechnologies/transformers-inference/sentence-transformers-all-MiniLM-L6-v2/images/sha256-48840c0c06b6bae621d9d725a38d4bcb3224cc22618132b14111053efd82628f)
- VS 6.13G for [old one](https://hub.docker.com/layers/semitechnologies/transformers-inference/sentence-transformers-all-MiniLM-L6-v2-onnx/images/sha256-799fec44c000217059951effd32bab6bcdc04af57e3fc147389159371ebb2f17)

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Low

## How Has This Been Tested?
- [ ] Unit tests
- [x] E2E tests
- [x] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
