### PR TITLE
Add py.typed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Ability to add event listener to get notifications about Pipeline progress.
+- Added py.typed so that mypy knows to use type annotations from the neo4j-graphrag package.
 
 ### Changed
 - Changed the default behaviour of `FixedSizeSplitter` to avoid words cut-off in the chunks whenever it is possible.


### PR DESCRIPTION
# Description

Running mypy after installing the neo4j-graphrag package results in a mypy error:

```
Skipping analyzing "neo4j_graphrag.llm": module is installed, but missing library stubs or py.typed marker  [import-untyped]
```

[PEP-561](https://peps.python.org/pep-0561/) needs to be implemented. [It seems like we don't need to add anything else](https://blog.whtsky.me/tech/2021/dont-forget-py.typed-for-your-typed-python-package/).

This will be verified after the next release


## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [x] Project configuration change

## Complexity
 
Low 
Complexity:

## How Has This Been Tested?
- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
