### PR TITLE
Fix datetime warning

### DIFF
--- a/src/neo4j_graphrag/experimental/pipeline/notification.py
+++ b/src/neo4j_graphrag/experimental/pipeline/notification.py
@@ -14,7 +14,6 @@
 #  limitations under the License.
 from __future__ import annotations
 
-import datetime
 from typing import Any, Optional
 
 from neo4j_graphrag.experimental.pipeline.types import (
@@ -41,7 +40,6 @@ class EventNotifier:
         event = PipelineEvent(
             event_type=EventType.PIPELINE_STARTED,
             run_id=run_id,
-            timestamp=datetime.datetime.utcnow(),
             message=None,
             payload=input_data,
         )
@@ -53,7 +51,6 @@ class EventNotifier:
         event = PipelineEvent(
             event_type=EventType.PIPELINE_FINISHED,
             run_id=run_id,
-            timestamp=datetime.datetime.utcnow(),
             message=None,
             payload=output_data,
         )
@@ -69,7 +66,6 @@ class EventNotifier:
             event_type=EventType.TASK_STARTED,
             run_id=run_id,
             task_name=task_name,
-            timestamp=datetime.datetime.utcnow(),
             message=None,
             payload=input_data,
         )
@@ -85,7 +81,6 @@ class EventNotifier:
             event_type=EventType.TASK_FINISHED,
             run_id=run_id,
             task_name=task_name,
-            timestamp=datetime.datetime.utcnow(),
             message=None,
             payload=output_data.result.model_dump()
             if output_data and output_data.result

--- a/src/neo4j_graphrag/experimental/pipeline/types.py
+++ b/src/neo4j_graphrag/experimental/pipeline/types.py
@@ -82,7 +82,9 @@ class Event(BaseModel):
     event_type: EventType
     run_id: str
     """Pipeline unique run_id, same as the one returned in PipelineResult after pipeline.run"""
-    timestamp: datetime.datetime
+    timestamp: datetime.datetime = Field(
+        default_factory=lambda: datetime.datetime.now(datetime.timezone.utc)
+    )
     message: Optional[str] = None
     """Optional information about the status"""
     payload: Optional[dict[str, Any]] = None

--- a/tests/unit/experimental/pipeline/test_pipeline.py
+++ b/tests/unit/experimental/pipeline/test_pipeline.py
@@ -30,6 +30,7 @@ from neo4j_graphrag.experimental.pipeline.types import (
     PipelineEvent,
     RunResult,
     TaskEvent,
+    Event,
 )
 
 from .components import (
@@ -479,3 +480,14 @@ async def test_pipeline_event_notification() -> None:
         if previous_ts:
             assert actual_event.timestamp > previous_ts
         previous_ts = actual_event.timestamp
+
+
+def test_event_model_no_warning(recwarn: Sized) -> None:
+    event = Event(
+        event_type=EventType.PIPELINE_STARTED,
+        run_id="run_id",
+        message=None,
+        payload=None,
+    )
+    assert event.timestamp is not None
+    assert len(recwarn) == 0


### PR DESCRIPTION
# Description

Fix for this warning:

```
DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
timestamp=datetime.datetime.utcnow(),
```


## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High
>
>

Complexity:

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
