### PR TITLE
Refactors upsert vector function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@
 
 - Utility functions to retrieve metadata for vector and full-text indexes.
 - Support for effective_search_ratio parameter in vector and hybrid searches.
+- Introduced upsert_vectors utility function for batch upserting embeddings to vector indexes.
 
 ### Changed
 
 - Refactored index-related functions for improved compatibility and functionality.
+- Added deprecation warnings to upsert_vector, upsert_vector_on_relationship functions in favor of upsert_vectors.
+- Added deprecation warnings to async_upsert_vector, async_upsert_vector_on_relationship functions notifying developers that they will be removed in a future release.
 
 ## 1.4.3
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Ensure that your vector index is created prior to executing this example.
 ```python
 from neo4j import GraphDatabase
 from neo4j_graphrag.embeddings import OpenAIEmbeddings
-from neo4j_graphrag.indexes import upsert_vector
+from neo4j_graphrag.indexes import upsert_embeddings
 
 NEO4J_URI = "neo4j://localhost:7687"
 NEO4J_USERNAME = "neo4j"
@@ -211,14 +211,15 @@ text = (
     "The son of Duke Leto Atreides and the Lady Jessica, Paul is the heir of House "
     "Atreides, an aristocratic family that rules the planet Caladan."
 )
-vector = embedder.embed_query(text)
+embedding = embedder.embed_query(text)
 
 # Upsert the vector
-upsert_vector(
+upsert_embeddings(
     driver,
-    node_id=0,
-    embedding_property="embedding",
-    vector=vector,
+    ids=["1234"],
+    embedding_property="embeddingProperty",
+    embeddings=[embedding],
+    entity_type="NODE"
 )
 driver.close()
 ```

--- a/README.md
+++ b/README.md
@@ -211,14 +211,14 @@ text = (
     "The son of Duke Leto Atreides and the Lady Jessica, Paul is the heir of House "
     "Atreides, an aristocratic family that rules the planet Caladan."
 )
-embedding = embedder.embed_query(text)
+vector = embedder.embed_query(text)
 
 # Upsert the vector
 upsert_vectors(
     driver,
     ids=["1234"],
     embedding_property="vectorProperty",
-    embeddings=[embedding],
+    embeddings=[vector],
     entity_type="NODE"
 )
 driver.close()

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Ensure that your vector index is created prior to executing this example.
 from neo4j import GraphDatabase
 from neo4j_graphrag.embeddings import OpenAIEmbeddings
 from neo4j_graphrag.indexes import upsert_vectors
+from neo4j_graphrag.types import EntityType
 
 NEO4J_URI = "neo4j://localhost:7687"
 NEO4J_USERNAME = "neo4j"
@@ -219,7 +220,7 @@ upsert_vectors(
     ids=["1234"],
     embedding_property="vectorProperty",
     embeddings=[vector],
-    entity_type="NODE"
+    entity_type=EntityType.NODE,
 )
 driver.close()
 ```

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Ensure that your vector index is created prior to executing this example.
 ```python
 from neo4j import GraphDatabase
 from neo4j_graphrag.embeddings import OpenAIEmbeddings
-from neo4j_graphrag.indexes import upsert_embeddings
+from neo4j_graphrag.indexes import upsert_vectors
 
 NEO4J_URI = "neo4j://localhost:7687"
 NEO4J_USERNAME = "neo4j"
@@ -214,10 +214,10 @@ text = (
 embedding = embedder.embed_query(text)
 
 # Upsert the vector
-upsert_embeddings(
+upsert_vectors(
     driver,
     ids=["1234"],
-    embedding_property="embeddingProperty",
+    embedding_property="vectorProperty",
     embeddings=[embedding],
     entity_type="NODE"
 )

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -382,6 +382,8 @@ Database Interaction
 
 .. autofunction:: neo4j_graphrag.indexes.drop_index_if_exists
 
+.. autofunction:: neo4j_graphrag.indexes.upsert_embeddings
+
 .. autofunction:: neo4j_graphrag.indexes.upsert_vector
 
 .. autofunction:: neo4j_graphrag.indexes.upsert_vector_on_relationship

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -382,7 +382,7 @@ Database Interaction
 
 .. autofunction:: neo4j_graphrag.indexes.drop_index_if_exists
 
-.. autofunction:: neo4j_graphrag.indexes.upsert_embeddings
+.. autofunction:: neo4j_graphrag.indexes.upsert_vectors
 
 .. autofunction:: neo4j_graphrag.indexes.upsert_vector
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -159,12 +159,12 @@ Note that the below example is not the only way you can upsert data into your Ne
     driver = GraphDatabase.driver(URI, auth=AUTH)
 
     # Upsert the vector
-    embedding = ...
+    vector = ...
     upsert_vectors(
         driver,
         ids=["1234"],
         embedding_property="vectorProperty",
-        embeddings=[embedding],
+        embeddings=[vector],
         entity_type="NODE"
     )
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -150,7 +150,7 @@ Note that the below example is not the only way you can upsert data into your Ne
 .. code:: python
 
     from neo4j import GraphDatabase
-    from neo4j_graphrag.indexes import upsert_vector
+    from neo4j_graphrag.indexes import upsert_embeddings
 
     URI = "neo4j://localhost:7687"
     AUTH = ("neo4j", "password")
@@ -159,12 +159,13 @@ Note that the below example is not the only way you can upsert data into your Ne
     driver = GraphDatabase.driver(URI, auth=AUTH)
 
     # Upsert the vector
-    vector = ...
-    upsert_vector(
+    embedding = ...
+    upsert_embeddings(
         driver,
-        node_id=1,
-        embedding_property="vectorProperty",
-        vector=vector,
+        ids=["1234"],
+        embedding_property="embeddingProperty",
+        embeddings=[embedding],
+        entity_type="NODE"
     )
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -148,9 +148,9 @@ Note that the below example is not the only way you can upsert data into your Ne
 
 
 .. code:: python
-
     from neo4j import GraphDatabase
     from neo4j_graphrag.indexes import upsert_vectors
+    from neo4j_graphrag.types import EntityType
 
     URI = "neo4j://localhost:7687"
     AUTH = ("neo4j", "password")
@@ -165,7 +165,7 @@ Note that the below example is not the only way you can upsert data into your Ne
         ids=["1234"],
         embedding_property="vectorProperty",
         embeddings=[vector],
-        entity_type="NODE"
+        entity_type=EntityType.NODE,
     )
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -150,7 +150,7 @@ Note that the below example is not the only way you can upsert data into your Ne
 .. code:: python
 
     from neo4j import GraphDatabase
-    from neo4j_graphrag.indexes import upsert_embeddings
+    from neo4j_graphrag.indexes import upsert_vectors
 
     URI = "neo4j://localhost:7687"
     AUTH = ("neo4j", "password")
@@ -160,10 +160,10 @@ Note that the below example is not the only way you can upsert data into your Ne
 
     # Upsert the vector
     embedding = ...
-    upsert_embeddings(
+    upsert_vectors(
         driver,
         ids=["1234"],
-        embedding_property="embeddingProperty",
+        embedding_property="vectorProperty",
         embeddings=[embedding],
         entity_type="NODE"
     )

--- a/docs/source/user_guide_rag.rst
+++ b/docs/source/user_guide_rag.rst
@@ -920,6 +920,7 @@ Populate a Vector Index
 
     from neo4j import GraphDatabase
     from random import random
+    from neo4j_graphrag.indexes import upsert_embeddings
 
     URI = "neo4j://localhost:7687"
     AUTH = ("neo4j", "password")
@@ -928,10 +929,17 @@ Populate a Vector Index
     driver = GraphDatabase.driver(URI, auth=AUTH)
 
     # Upsert the vector
-    vector = [random() for _ in range(DIMENSION)]
-    upsert_vector(driver, node_id="1234", embedding_property="embedding", vector=vector)
+    embedding = [random() for _ in range(DIMENSION)]
+        upsert_embeddings(
+        driver,
+        ids=["1234"],
+        embedding_property="embeddingProperty",
+        embeddings=[embedding],
+        entity_type="NODE"
+    )
+    upsert_embeddings(driver, node_id="1234", embedding_property="embedding", vector=vector)
 
-This will update the node with `id(node)=1234` to add (or update) a `node.embedding` property.
+This will update the node with `id(node)=1234` to add (or update) a `node.embeddingProperty` property.
 This property will also be added to the vector index.
 
 

--- a/docs/source/user_guide_rag.rst
+++ b/docs/source/user_guide_rag.rst
@@ -929,12 +929,12 @@ Populate a Vector Index
     driver = GraphDatabase.driver(URI, auth=AUTH)
 
     # Upsert the vector
-    embedding = [random() for _ in range(DIMENSION)]
+    vector = [random() for _ in range(DIMENSION)]
         upsert_vectors(
         driver,
         ids=["1234"],
         embedding_property="vectorProperty",
-        embeddings=[embedding],
+        embeddings=[vector],
         entity_type="NODE"
     )
     upsert_vectors(driver, node_id="1234", embedding_property="embedding", vector=vector)

--- a/docs/source/user_guide_rag.rst
+++ b/docs/source/user_guide_rag.rst
@@ -920,7 +920,7 @@ Populate a Vector Index
 
     from neo4j import GraphDatabase
     from random import random
-    from neo4j_graphrag.indexes import upsert_embeddings
+    from neo4j_graphrag.indexes import upsert_vectors
 
     URI = "neo4j://localhost:7687"
     AUTH = ("neo4j", "password")
@@ -930,16 +930,16 @@ Populate a Vector Index
 
     # Upsert the vector
     embedding = [random() for _ in range(DIMENSION)]
-        upsert_embeddings(
+        upsert_vectors(
         driver,
         ids=["1234"],
-        embedding_property="embeddingProperty",
+        embedding_property="vectorProperty",
         embeddings=[embedding],
         entity_type="NODE"
     )
-    upsert_embeddings(driver, node_id="1234", embedding_property="embedding", vector=vector)
+    upsert_vectors(driver, node_id="1234", embedding_property="embedding", vector=vector)
 
-This will update the node with `id(node)=1234` to add (or update) a `node.embeddingProperty` property.
+This will update the node with `id(node)=1234` to add (or update) a `node.vectorProperty` property.
 This property will also be added to the vector index.
 
 

--- a/docs/source/user_guide_rag.rst
+++ b/docs/source/user_guide_rag.rst
@@ -917,10 +917,11 @@ Populate a Vector Index
 ==========================
 
 .. code:: python
+    from random import random
 
     from neo4j import GraphDatabase
-    from random import random
     from neo4j_graphrag.indexes import upsert_vectors
+    from neo4j_graphrag.types import EntityType
 
     URI = "neo4j://localhost:7687"
     AUTH = ("neo4j", "password")
@@ -929,15 +930,15 @@ Populate a Vector Index
     driver = GraphDatabase.driver(URI, auth=AUTH)
 
     # Upsert the vector
+    DIMENSION = 1536
     vector = [random() for _ in range(DIMENSION)]
-        upsert_vectors(
+    upsert_vectors(
         driver,
         ids=["1234"],
         embedding_property="vectorProperty",
         embeddings=[vector],
-        entity_type="NODE"
+        entity_type=EntityType.NODE,
     )
-    upsert_vectors(driver, node_id="1234", embedding_property="embedding", vector=vector)
 
 This will update the node with `id(node)=1234` to add (or update) a `node.vectorProperty` property.
 This property will also be added to the vector index.

--- a/src/neo4j_graphrag/indexes.py
+++ b/src/neo4j_graphrag/indexes.py
@@ -294,7 +294,8 @@ def upsert_vectors(
         embeddings (List[List[float]]): The list of vectors to store, one per ID.
         neo4j_database (Optional[str]): The name of the Neo4j database.
             If not provided, defaults to the server's default database. 'neo4j' by default.
-        entity_type (EntityType): Specifies whether to upsert to nodes or relationships.
+        entity_type (EntityType): Specifies whether to upsert to nodes ('NODE') or relationships ('RELATIONSHIP').
+            Defaults to 'NODE'.
 
     Raises:
         ValueError: If the lengths of IDs and embeddings do not match, or if embeddings are not of uniform dimension.

--- a/src/neo4j_graphrag/indexes.py
+++ b/src/neo4j_graphrag/indexes.py
@@ -318,7 +318,9 @@ def upsert_embeddings(
             ],
             "embedding_property": embedding_property,
         }
-        driver.execute_query(query, parameters, database_=neo4j_database)
+        driver.execute_query(
+            query_=query, parameters_=parameters, database_=neo4j_database
+        )
     except neo4j.exceptions.ClientError as e:
         raise Neo4jInsertionError(
             f"Upserting vectors to Neo4j failed: {e.message}"

--- a/src/neo4j_graphrag/indexes.py
+++ b/src/neo4j_graphrag/indexes.py
@@ -277,7 +277,7 @@ def upsert_embeddings(
         upsert_embeddings(
             driver,
             ids=['123', '456', '789'],
-            embedding_property="vectorProperty",
+            embedding_property="embeddingProperty",
             embeddings=[
                 [0.12, 0.34, 0.56],
                 [0.78, 0.90, 0.12],
@@ -335,6 +335,9 @@ def upsert_vector(
     neo4j_database: Optional[str] = None,
 ) -> None:
     """
+    .. warning::
+        'upsert_vector' is deprecated and will be removed in a future version, please use 'upsert_embeddings' instead.
+
     This method constructs a Cypher query and executes it to upsert (insert or update) a vector property on a specific node.
 
     Example:
@@ -396,6 +399,9 @@ def upsert_vector_on_relationship(
     neo4j_database: Optional[str] = None,
 ) -> None:
     """
+    .. warning::
+        'upsert_vector_on_relationship' is deprecated and will be removed in a future version, please use 'upsert_embeddings' instead.
+
     This method constructs a Cypher query and executes it to upsert (insert or update) a vector property on a specific relationship.
 
     Example:
@@ -457,6 +463,9 @@ async def async_upsert_vector(
     neo4j_database: Optional[str] = None,
 ) -> None:
     """
+    .. warning::
+        'async_upsert_vector' is deprecated and will be removed in a future version.
+
     This method constructs a Cypher query and asynchronously executes it
     to upsert (insert or update) a vector property on a specific node.
 
@@ -519,6 +528,9 @@ async def async_upsert_vector_on_relationship(
     neo4j_database: Optional[str] = None,
 ) -> None:
     """
+    .. warning::
+        'async_upsert_vector_on_relationship' is deprecated and will be removed in a future version.
+
     This method constructs a Cypher query and asynchronously executes it
     to upsert (insert or update) a vector property on a specific relationship.
 

--- a/src/neo4j_graphrag/indexes.py
+++ b/src/neo4j_graphrag/indexes.py
@@ -248,7 +248,7 @@ def drop_index_if_exists(
         raise Neo4jIndexError(f"Dropping Neo4j index failed: {e.message}") from e
 
 
-def upsert_embeddings(
+def upsert_vectors(
     driver: neo4j.Driver,
     ids: List[str],
     embedding_property: str,
@@ -265,7 +265,7 @@ def upsert_embeddings(
     .. code-block:: python
 
         from neo4j import GraphDatabase
-        from neo4j_graphrag.indexes import upsert_embeddings
+        from neo4j_graphrag.indexes import upsert_vectors
 
         URI = "neo4j://localhost:7687"
         AUTH = ("neo4j", "password")
@@ -274,10 +274,10 @@ def upsert_embeddings(
         driver = GraphDatabase.driver(URI, auth=AUTH)
 
         # Upsert embeddings data for several nodes
-        upsert_embeddings(
+        upsert_vectors(
             driver,
             ids=['123', '456', '789'],
-            embedding_property="embeddingProperty",
+            embedding_property="vectorProperty",
             embeddings=[
                 [0.12, 0.34, 0.56],
                 [0.78, 0.90, 0.12],
@@ -336,7 +336,7 @@ def upsert_vector(
 ) -> None:
     """
     .. warning::
-        'upsert_vector' is deprecated and will be removed in a future version, please use 'upsert_embeddings' instead.
+        'upsert_vector' is deprecated and will be removed in a future version, please use 'upsert_vectors' instead.
 
     This method constructs a Cypher query and executes it to upsert (insert or update) a vector property on a specific node.
 
@@ -372,7 +372,7 @@ def upsert_vector(
         Neo4jInsertionError: If upserting of the vector fails.
     """
     warnings.warn(
-        "'upsert_vector' is deprecated and will be removed in a future version, please use 'upsert_embeddings' instead.",
+        "'upsert_vector' is deprecated and will be removed in a future version, please use 'upsert_vectors' instead.",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -400,7 +400,7 @@ def upsert_vector_on_relationship(
 ) -> None:
     """
     .. warning::
-        'upsert_vector_on_relationship' is deprecated and will be removed in a future version, please use 'upsert_embeddings' instead.
+        'upsert_vector_on_relationship' is deprecated and will be removed in a future version, please use 'upsert_vectors' instead.
 
     This method constructs a Cypher query and executes it to upsert (insert or update) a vector property on a specific relationship.
 
@@ -436,7 +436,7 @@ def upsert_vector_on_relationship(
         Neo4jInsertionError: If upserting of the vector fails.
     """
     warnings.warn(
-        "'upsert_vector_on_relationship' is deprecated and will be removed in a future version, please use 'upsert_embeddings' instead.",
+        "'upsert_vector_on_relationship' is deprecated and will be removed in a future version, please use 'upsert_vectors' instead.",
         DeprecationWarning,
         stacklevel=2,
     )

--- a/src/neo4j_graphrag/indexes.py
+++ b/src/neo4j_graphrag/indexes.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from typing import List, Literal, Optional
 
 import neo4j
@@ -23,10 +24,12 @@ from pydantic import ValidationError
 from neo4j_graphrag.neo4j_queries import (
     UPSERT_VECTOR_ON_NODE_QUERY,
     UPSERT_VECTOR_ON_RELATIONSHIP_QUERY,
+    UPSERT_VECTORS_ON_NODE_QUERY,
+    UPSERT_VECTORS_ON_RELATIONSHIP_QUERY,
 )
 
 from .exceptions import Neo4jIndexError, Neo4jInsertionError
-from .types import FulltextIndexModel, VectorIndexModel
+from .types import EntityType, FulltextIndexModel, VectorIndexModel
 
 logger = logging.getLogger(__name__)
 
@@ -245,6 +248,83 @@ def drop_index_if_exists(
         raise Neo4jIndexError(f"Dropping Neo4j index failed: {e.message}") from e
 
 
+def upsert_embeddings(
+    driver: neo4j.Driver,
+    ids: List[str],
+    embedding_property: str,
+    embeddings: List[List[float]],
+    neo4j_database: Optional[str] = None,
+    entity_type: EntityType = EntityType.NODE,
+) -> None:
+    """
+    This method constructs a Cypher query and executes it to upsert
+    (insert or update) embeddings on a set of nodes or relationships.
+
+    Example:
+
+    .. code-block:: python
+
+        from neo4j import GraphDatabase
+        from neo4j_graphrag.indexes import upsert_embeddings
+
+        URI = "neo4j://localhost:7687"
+        AUTH = ("neo4j", "password")
+
+        # Connect to Neo4j database
+        driver = GraphDatabase.driver(URI, auth=AUTH)
+
+        # Upsert embeddings data for several nodes
+        upsert_embeddings(
+            driver,
+            ids=['123', '456', '789'],
+            embedding_property="vectorProperty",
+            embeddings=[
+                [0.12, 0.34, 0.56],
+                [0.78, 0.90, 0.12],
+                [0.34, 0.56, 0.78],
+            ],
+            neo4j_database="neo4j",
+            entity_type='NODE',
+        )
+
+    Args:
+        driver (neo4j.Driver): Neo4j Python driver instance.
+        ids (List[int]): The element IDs of the nodes or relationships.
+        embedding_property (str): The name of the property to store the vectors in.
+        embeddings (List[List[float]]): The list of vectors to store, one per ID.
+        neo4j_database (Optional[str]): The name of the Neo4j database.
+            If not provided, defaults to the server's default database. 'neo4j' by default.
+        entity_type (EntityType): Specifies whether to upsert to nodes or relationships.
+
+    Raises:
+        ValueError: If the lengths of IDs and embeddings do not match, or if embeddings are not of uniform dimension.
+        Neo4jInsertionError: If an error occurs while attempting to upsert the vectors in Neo4j.
+    """
+    if entity_type == EntityType.NODE:
+        query = UPSERT_VECTORS_ON_NODE_QUERY
+    elif entity_type == EntityType.RELATIONSHIP:
+        query = UPSERT_VECTORS_ON_RELATIONSHIP_QUERY
+    else:
+        raise ValueError("entity_type must be either 'NODE' or 'RELATIONSHIP'")
+    if len(ids) != len(embeddings):
+        raise ValueError("ids and embeddings must be the same length")
+    if not all(len(embedding) == len(embeddings[0]) for embedding in embeddings):
+        raise ValueError("All embeddings must be of the same size")
+    try:
+        parameters = {
+            "rows": [
+                {"id": id, "embedding": embedding}
+                for id, embedding in zip(ids, embeddings)
+            ],
+            "embedding_property": embedding_property,
+        }
+        driver.execute_query(query, parameters, database_=neo4j_database)
+    except neo4j.exceptions.ClientError as e:
+        raise Neo4jInsertionError(
+            f"Upserting vectors to Neo4j failed: {e.message}"
+        ) from e
+
+
 def upsert_vector(
     driver: neo4j.Driver,
     node_id: int,
@@ -286,6 +366,11 @@ def upsert_vector(
     Raises:
         Neo4jInsertionError: If upserting of the vector fails.
     """
+    warnings.warn(
+        "'upsert_vector' is deprecated and will be removed in a future version, please use 'upsert_embeddings' instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     try:
         parameters = {
             "node_element_id": node_id,
@@ -342,6 +427,11 @@ def upsert_vector_on_relationship(
     Raises:
         Neo4jInsertionError: If upserting of the vector fails.
     """
+    warnings.warn(
+        "'upsert_vector_on_relationship' is deprecated and will be removed in a future version, please use 'upsert_embeddings' instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     try:
         parameters = {
             "rel_element_id": rel_id,
@@ -399,6 +489,11 @@ async def async_upsert_vector(
     Raises:
         Neo4jInsertionError: If upserting of the vector fails.
     """
+    warnings.warn(
+        "'async_upsert_vector' is deprecated and will be removed in a future version.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     try:
         parameters = {
             "node_id": node_id,
@@ -456,6 +551,11 @@ async def async_upsert_vector_on_relationship(
     Raises:
         Neo4jInsertionError: If upserting of the vector fails.
     """
+    warnings.warn(
+        "'async_upsert_vector_on_relationship' is deprecated and will be removed in a future version.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     try:
         parameters = {
             "rel_id": rel_id,

--- a/src/neo4j_graphrag/neo4j_queries.py
+++ b/src/neo4j_graphrag/neo4j_queries.py
@@ -119,7 +119,7 @@ UPSERT_VECTORS_ON_NODE_QUERY = (
     "UNWIND $rows AS row "
     "MATCH (n) "
     "WHERE elementId(n) = row.id "
-    "WITH n "
+    "WITH n, row "
     "CALL db.create.setNodeVectorProperty(n, $embedding_property, row.embedding) "
     "RETURN n"
 )
@@ -136,7 +136,7 @@ UPSERT_VECTORS_ON_RELATIONSHIP_QUERY = (
     "UNWIND $rows AS row "
     "MATCH ()-[r]->() "
     "WHERE elementId(r) = row.id "
-    "WITH r "
+    "WITH r, row "
     "CALL db.create.setRelationshipVectorProperty(r, $embedding_property, row.embedding) "
     "RETURN r"
 )

--- a/src/neo4j_graphrag/neo4j_queries.py
+++ b/src/neo4j_graphrag/neo4j_queries.py
@@ -115,11 +115,29 @@ UPSERT_VECTOR_ON_NODE_QUERY = (
     "RETURN n"
 )
 
+UPSERT_VECTORS_ON_NODE_QUERY = (
+    "UNWIND $rows AS row "
+    "MATCH (n) "
+    "WHERE elementId(n) = row.id "
+    "WITH n "
+    "CALL db.create.setNodeVectorProperty(n, $embedding_property, row.embedding) "
+    "RETURN n"
+)
+
 UPSERT_VECTOR_ON_RELATIONSHIP_QUERY = (
     "MATCH ()-[r]->() "
     "WHERE elementId(r) = $rel_element_id "
     "WITH r "
     "CALL db.create.setRelationshipVectorProperty(r, $embedding_property, $vector) "
+    "RETURN r"
+)
+
+UPSERT_VECTORS_ON_RELATIONSHIP_QUERY = (
+    "UNWIND $rows AS row "
+    "MATCH ()-[r]->() "
+    "WHERE elementId(r) = row.id "
+    "WITH r "
+    "CALL db.create.setRelationshipVectorProperty(r, $embedding_property, row.embedding) "
     "RETURN r"
 )
 

--- a/src/neo4j_graphrag/neo4j_queries.py
+++ b/src/neo4j_graphrag/neo4j_queries.py
@@ -107,6 +107,7 @@ UPSERT_RELATIONSHIP_QUERY_VARIABLE_SCOPE_CLAUSE = (
     "RETURN elementId(rel)"
 )
 
+# Deprecated, remove along with upsert_vector
 UPSERT_VECTOR_ON_NODE_QUERY = (
     "MATCH (n) "
     "WHERE elementId(n) = $node_element_id "
@@ -124,6 +125,7 @@ UPSERT_VECTORS_ON_NODE_QUERY = (
     "RETURN n"
 )
 
+# Deprecated, remove along with upsert_vector_on_relationship
 UPSERT_VECTOR_ON_RELATIONSHIP_QUERY = (
     "MATCH ()-[r]->() "
     "WHERE elementId(r) = $rel_element_id "

--- a/tests/e2e/test_indexes_e2e.py
+++ b/tests/e2e/test_indexes_e2e.py
@@ -17,7 +17,7 @@ import pytest
 from neo4j_graphrag.indexes import (
     retrieve_fulltext_index_info,
     retrieve_vector_index_info,
-    upsert_embeddings,
+    upsert_vectors,
 )
 from neo4j_graphrag.types import EntityType
 
@@ -193,7 +193,7 @@ def test_retrieve_fulltext_index_info_wrong_info(driver: neo4j.Driver) -> None:
     assert index_info is None
 
 
-def test_upsert_embeddings_on_nodes(driver: neo4j.Driver) -> None:
+def test_upsert_vectors_on_nodes(driver: neo4j.Driver) -> None:
     driver.execute_query("MATCH (n) DETACH DELETE n;")
     result = driver.execute_query(
         "CREATE (p:Character {name: 'Paul Atreides'}), "
@@ -202,7 +202,7 @@ def test_upsert_embeddings_on_nodes(driver: neo4j.Driver) -> None:
     )
     ids = result.records[0]["ids"]
     assert len(ids) == 2
-    upsert_embeddings(
+    upsert_vectors(
         driver=driver,
         ids=ids,
         embedding_property="embedding",
@@ -223,7 +223,7 @@ def test_upsert_embeddings_on_nodes(driver: neo4j.Driver) -> None:
     assert records_sorted == expected_records_sorted
 
 
-def test_upsert_embeddings_on_relationships(driver: neo4j.Driver) -> None:
+def test_upsert_vectors_on_relationships(driver: neo4j.Driver) -> None:
     driver.execute_query("MATCH (n) DETACH DELETE n;")
     result = driver.execute_query(
         "CREATE (:Character {name: 'Paul Atreides'})-[a:IS_MEMBER_OF]->(:House {name: 'Atreides'}), "
@@ -232,7 +232,7 @@ def test_upsert_embeddings_on_relationships(driver: neo4j.Driver) -> None:
     )
     ids = result.records[0]["ids"]
     assert len(ids) == 2
-    upsert_embeddings(
+    upsert_vectors(
         driver=driver,
         ids=ids,
         embedding_property="embedding",

--- a/tests/e2e/test_indexes_e2e.py
+++ b/tests/e2e/test_indexes_e2e.py
@@ -17,7 +17,9 @@ import pytest
 from neo4j_graphrag.indexes import (
     retrieve_fulltext_index_info,
     retrieve_vector_index_info,
+    upsert_embeddings,
 )
+from neo4j_graphrag.types import EntityType
 
 
 @pytest.mark.usefixtures("setup_neo4j_for_retrieval")
@@ -189,3 +191,76 @@ def test_retrieve_fulltext_index_info_wrong_info(driver: neo4j.Driver) -> None:
         text_properties=[""],
     )
     assert index_info is None
+
+
+def test_upsert_embeddings_on_nodes(driver: neo4j.Driver) -> None:
+    driver.execute_query("MATCH (n) DETACH DELETE n;")
+    result = driver.execute_query(
+        "CREATE (p:Character {name: 'Paul Atreides'}), "
+        "(v:Character {name: 'Vladimir Harkonnen'}) "
+        "RETURN [elementId(p), elementId(v)] AS ids"
+    )
+    ids = result.records[0]["ids"]
+    assert len(ids) == 2
+    upsert_embeddings(
+        driver=driver,
+        ids=ids,
+        embedding_property="embedding",
+        embeddings=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+        entity_type=EntityType.NODE,
+    )
+    result = driver.execute_query(
+        "MATCH (c:Character) RETURN "
+        "elementId(c) as id, c.name as name, c.embedding as embedding"
+    )
+    records = [r.data() for r in result.records]
+    records_sorted = sorted(records, key=lambda x: x["id"])
+    expected_records = [
+        {"id": ids[0], "name": "Paul Atreides", "embedding": [1.0, 2.0, 3.0]},
+        {"id": ids[1], "name": "Vladimir Harkonnen", "embedding": [4.0, 5.0, 6.0]},
+    ]
+    expected_records_sorted = sorted(expected_records, key=lambda x: x["id"])
+    assert records_sorted == expected_records_sorted
+
+
+def test_upsert_embeddings_on_relationships(driver: neo4j.Driver) -> None:
+    driver.execute_query("MATCH (n) DETACH DELETE n;")
+    result = driver.execute_query(
+        "CREATE (:Character {name: 'Paul Atreides'})-[a:IS_MEMBER_OF]->(:House {name: 'Atreides'}), "
+        "(:Character {name: 'Vladimir Harkonnen'})-[h:IS_MEMBER_OF]->(:House {name: 'Harkonnen'}) "
+        "RETURN [elementId(a), elementId(h)] AS ids"
+    )
+    ids = result.records[0]["ids"]
+    assert len(ids) == 2
+    upsert_embeddings(
+        driver=driver,
+        ids=ids,
+        embedding_property="embedding",
+        embeddings=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+        entity_type=EntityType.RELATIONSHIP,
+    )
+    result = driver.execute_query(
+        "MATCH (c:Character)-[r:IS_MEMBER_OF]->(h:House) RETURN "
+        "type(r) AS type, elementId(r) AS id, r.embedding AS embedding, "
+        "c.name as character, h.name AS house"
+    )
+    records = [r.data() for r in result.records]
+    records_sorted = sorted(records, key=lambda x: x["id"])
+    expected_records = [
+        {
+            "type": "IS_MEMBER_OF",
+            "id": ids[0],
+            "embedding": [1.0, 2.0, 3.0],
+            "character": "Paul Atreides",
+            "house": "Atreides",
+        },
+        {
+            "type": "IS_MEMBER_OF",
+            "id": ids[1],
+            "embedding": [4.0, 5.0, 6.0],
+            "character": "Vladimir Harkonnen",
+            "house": "Harkonnen",
+        },
+    ]
+    expected_records_sorted = sorted(expected_records, key=lambda x: x["id"])
+    assert records_sorted == expected_records_sorted

--- a/tests/unit/test_indexes.py
+++ b/tests/unit/test_indexes.py
@@ -23,9 +23,9 @@ from neo4j_graphrag.indexes import (
     create_fulltext_index,
     create_vector_index,
     drop_index_if_exists,
-    upsert_vectors,
     upsert_vector,
     upsert_vector_on_relationship,
+    upsert_vectors,
 )
 
 
@@ -325,4 +325,3 @@ def test_upsert_vectors_inconsistent_embedding_sizes(driver: MagicMock) -> None:
             neo4j_database="neo4j",
         )
     assert str(exc_info.value) == "All embeddings must be of the same size"
-

--- a/tests/unit/test_indexes.py
+++ b/tests/unit/test_indexes.py
@@ -23,7 +23,7 @@ from neo4j_graphrag.indexes import (
     create_fulltext_index,
     create_vector_index,
     drop_index_if_exists,
-    upsert_embeddings,
+    upsert_vectors,
     upsert_vector,
     upsert_vector_on_relationship,
 )
@@ -290,9 +290,9 @@ def test_upsert_vector_raises_neo4j_insertion_error(
     assert "Upserting vector to Neo4j failed" in str(excinfo)
 
 
-def test_upsert_embeddings_wrong_entity_type(driver: MagicMock) -> None:
+def test_upsert_vectors_wrong_entity_type(driver: MagicMock) -> None:
     with pytest.raises(ValueError) as exc_info:
-        upsert_embeddings(
+        upsert_vectors(
             driver=driver,
             ids=["1"],
             embedding_property="embedding",
@@ -303,9 +303,9 @@ def test_upsert_embeddings_wrong_entity_type(driver: MagicMock) -> None:
     assert str(exc_info.value) == "entity_type must be either 'NODE' or 'RELATIONSHIP'"
 
 
-def test_upsert_embeddings_mismatched_ids_and_embeddings(driver: MagicMock) -> None:
+def test_upsert_vectors_mismatched_ids_and_embeddings(driver: MagicMock) -> None:
     with pytest.raises(ValueError) as exc_info:
-        upsert_embeddings(
+        upsert_vectors(
             driver=driver,
             ids=["1"],
             embedding_property="embedding",
@@ -315,9 +315,9 @@ def test_upsert_embeddings_mismatched_ids_and_embeddings(driver: MagicMock) -> N
     assert str(exc_info.value) == "ids and embeddings must be the same length"
 
 
-def test_upsert_embeddings_inconsistent_embedding_sizes(driver: MagicMock) -> None:
+def test_upsert_vectors_inconsistent_embedding_sizes(driver: MagicMock) -> None:
     with pytest.raises(ValueError) as exc_info:
-        upsert_embeddings(
+        upsert_vectors(
             driver=driver,
             ids=["1", "2"],
             embedding_property="embedding",

--- a/tests/unit/test_indexes.py
+++ b/tests/unit/test_indexes.py
@@ -23,6 +23,7 @@ from neo4j_graphrag.indexes import (
     create_fulltext_index,
     create_vector_index,
     drop_index_if_exists,
+    upsert_embeddings,
     upsert_vector,
     upsert_vector_on_relationship,
 )
@@ -287,3 +288,41 @@ def test_upsert_vector_raises_neo4j_insertion_error(
         upsert_vector(driver, id, embedding_property, vector)
 
     assert "Upserting vector to Neo4j failed" in str(excinfo)
+
+
+def test_upsert_embeddings_wrong_entity_type(driver: MagicMock) -> None:
+    with pytest.raises(ValueError) as exc_info:
+        upsert_embeddings(
+            driver=driver,
+            ids=["1"],
+            embedding_property="embedding",
+            embeddings=[[1.0, 2.0, 3.0]],
+            neo4j_database="neo4j",
+            entity_type="WRONG_ENTITY_TYPE",  # type: ignore[arg-type]
+        )
+    assert str(exc_info.value) == "entity_type must be either 'NODE' or 'RELATIONSHIP'"
+
+
+def test_upsert_embeddings_mismatched_ids_and_embeddings(driver: MagicMock) -> None:
+    with pytest.raises(ValueError) as exc_info:
+        upsert_embeddings(
+            driver=driver,
+            ids=["1"],
+            embedding_property="embedding",
+            embeddings=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+            neo4j_database="neo4j",
+        )
+    assert str(exc_info.value) == "ids and embeddings must be the same length"
+
+
+def test_upsert_embeddings_inconsistent_embedding_sizes(driver: MagicMock) -> None:
+    with pytest.raises(ValueError) as exc_info:
+        upsert_embeddings(
+            driver=driver,
+            ids=["1", "2"],
+            embedding_property="embedding",
+            embeddings=[[1.0, 2.0, 3.0], [4.0, 5.0]],
+            neo4j_database="neo4j",
+        )
+    assert str(exc_info.value) == "All embeddings must be of the same size"
+


### PR DESCRIPTION
# Description

This PR refactors the utility functions used to upsert embeddings to vector indexes. The main changes are:

- Adds an `upsert_vectors` utility function allowing for multiple vectors to be upserted at once to node or relationship vector indexes.
- Adds deprecation warnings to the `upsert_vector` and `upsert_vector_on_relationship` functions informing the user that these functions are deprecated and will be removed in the future, and advising them to move to the `upsert_vectors` function.
- Adds deprecation warnings to the `async_upsert_vector` and `async_upsert_vector_on_relationship` functions informing the user that these functions are deprecated and will be removed in the future. Given these functions are the last ones in the package to support the `AsyncDriver`, it make sense to remove them so the package only needs to support the `GraphDriver`.

## Type of Change
- [X] New feature
- [ ] Bug fix
- [ ] Breaking change
- [X] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Low

## How Has This Been Tested?
- [X] Unit tests
- [X] E2E tests
- [X] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [X] Documentation has been updated
- [X] Unit tests have been updated
- [X] E2E tests have been updated
- [ ] Examples have been updated
- [X] New files have copyright header
- [X] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
