### PR TITLE
Raise SearchQueryParseError when HybridRetriever and HybridCypherRetriever encounters invalid Lucene string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+### Added
+- Introduced SearchQueryParseError for handling invalid Lucene query strings in HybridRetriever and HybridCypherRetriever.
+
 ## 1.5.0
 
 ### Added

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-VERSION       = SNAPSHOT
+VERSION       = 1.4.0
 PRODUCT       = neo4j-graphrag-python
 SPHINXOPTS    =
 SPHINXBUILD   = poetry run sphinx-build

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-VERSION       = 1.4.0
+VERSION       = SNAPSHOT
 PRODUCT       = neo4j-graphrag-python
 SPHINXOPTS    =
 SPHINXBUILD   = poetry run sphinx-build

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -445,6 +445,16 @@ Errors
 
   * :class:`neo4j_graphrag.exceptions.LLMGenerationError`
 
+  * :class:`neo4j_graphrag.exceptions.SchemaValidationError`
+
+  * :class:`neo4j_graphrag.exceptions.PdfLoaderError`
+
+  * :class:`neo4j_graphrag.exceptions.PromptMissingPlaceholderError`
+
+  * :class:`neo4j_graphrag.exceptions.InvalidHybridSearchRankerError`
+
+  * :class:`neo4j_graphrag.exceptions.SearchQueryParseError`
+
   * :class:`neo4j_graphrag.experimental.pipeline.exceptions.PipelineDefinitionError`
 
   * :class:`neo4j_graphrag.experimental.pipeline.exceptions.PipelineMissingDependencyError`
@@ -556,6 +566,41 @@ LLMGenerationError
 ==================
 
 .. autoclass:: neo4j_graphrag.exceptions.LLMGenerationError
+   :show-inheritance:
+
+
+SchemaValidationError
+=====================
+
+.. autoclass:: neo4j_graphrag.exceptions.SchemaValidationError
+   :show-inheritance:
+
+
+PdfLoaderError
+==============
+
+.. autoclass:: neo4j_graphrag.exceptions.PdfLoaderError
+   :show-inheritance:
+
+
+PromptMissingPlaceholderError
+=============================
+
+.. autoclass:: neo4j_graphrag.exceptions.PromptMissingPlaceholderError
+   :show-inheritance:
+
+
+InvalidHybridSearchRankerError
+==============================
+
+.. autoclass:: neo4j_graphrag.exceptions.InvalidHybridSearchRankerError
+   :show-inheritance:
+
+
+SearchQueryParseError
+=====================
+
+.. autoclass:: neo4j_graphrag.exceptions.SearchQueryParseError
    :show-inheritance:
 
 

--- a/src/neo4j_graphrag/exceptions.py
+++ b/src/neo4j_graphrag/exceptions.py
@@ -128,3 +128,7 @@ class PromptMissingPlaceholderError(Neo4jGraphRagError):
 
 class InvalidHybridSearchRankerError(Neo4jGraphRagError):
     """Exception raised when an invalid ranker type for Hybrid Search is provided."""
+
+
+class SearchQueryParseError(Neo4jGraphRagError):
+    """Exception raised when there is a query parse error in the text search string."""


### PR DESCRIPTION

# Description
This PR introduces `SearchQueryParseError` that gets raised when HybridRetriever and HybridCypherRetriever encounters invalid Lucene string.

For example, `~alien` should raise an error as this is as the reserved character `~` is used incorrectly.

However, "alien~" is valid and should neither raise an error nor get processed ([see Apache Lucene documentation](https://lucene.apache.org/core/2_9_4/queryparsersyntax.html)).

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity


Complexity: Low

## How Has This Been Tested?
- [x] Unit tests
- [x] E2E tests
- [x] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [x] CHANGELOG.md updated if appropriate
