### PR TITLE
fix: config loading after module reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,3 +309,4 @@
 
 -   Updated documentation to include new custom exceptions.
 -   Improved the use of Pydantic for input data validation for retriever objects.
+-   Fixed config loading after module reload (usage in jupyter notebooks)

--- a/src/neo4j_graphrag/experimental/pipeline/component.py
+++ b/src/neo4j_graphrag/experimental/pipeline/component.py
@@ -21,6 +21,7 @@ from typing import Any, get_type_hints
 from pydantic import BaseModel
 
 from neo4j_graphrag.experimental.pipeline.exceptions import PipelineDefinitionError
+from neo4j_graphrag.utils.validation import issubclass_safe
 
 
 class DataModel(BaseModel):
@@ -52,7 +53,7 @@ class ComponentMeta(abc.ABCMeta):
                     f"The run method return type must be annotated in {name}"
                 )
             # the type hint must be a subclass of DataModel
-            if not issubclass(return_model, DataModel):
+            if not issubclass_safe(return_model, DataModel):
                 raise PipelineDefinitionError(
                     f"The run method must return a subclass of DataModel in {name}"
                 )

--- a/src/neo4j_graphrag/experimental/pipeline/config/object_config.py
+++ b/src/neo4j_graphrag/experimental/pipeline/config/object_config.py
@@ -56,6 +56,8 @@ from neo4j_graphrag.experimental.pipeline.config.param_resolver import (
     ParamConfig,
 )
 from neo4j_graphrag.llm import LLMInterface
+from neo4j_graphrag.utils.validation import issubclass_safe
+
 
 logger = logging.getLogger(__name__)
 
@@ -131,9 +133,9 @@ class ObjectConfig(AbstractConfig, Generic[T]):
         self._global_data = resolved_data or {}
         logger.debug(f"OBJECT_CONFIG: parsing {self} using {resolved_data}")
         if self.class_ is None:
-            raise ValueError(f"`class_` is not required to parse object {self}")
+            raise ValueError(f"`class_` is required to parse object {self}")
         klass = self._get_class(self.class_, self.get_module())
-        if not issubclass(klass, self.get_interface()):
+        if not issubclass_safe(klass, self.get_interface()):
             raise ValueError(
                 f"Invalid class '{klass}'. Expected a subclass of '{self.get_interface()}'"
             )


### PR DESCRIPTION
# Description

When running jupyter notebook it's common to use auto reload:
```
%reload_ext autoreload
%autoreload 2
```

With auto reload activated the builtin `issubclass` no longer works as expected and config loading fails (see unit test)


## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity


Complexity: low

## How Has This Been Tested?
- [x ] Unit tests

# Checklist


- [x] Documentation has been updated
- [x] Unit tests have been updated
- [x] E2E tests have been updated
- [x] Examples have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [x] CHANGELOG.md updated if appropriate
