### PR TITLE
Add optional schema enforcement for KG builder as a validation layer after entity and relation extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Next
 
 ### Added
+
+- Added optional schema enforcement as a validation layer after entity and relation extraction.
 - Introduced SearchQueryParseError for handling invalid Lucene query strings in HybridRetriever and HybridCypherRetriever.
 
 ## 1.5.0

--- a/docs/source/user_guide_kg_builder.rst
+++ b/docs/source/user_guide_kg_builder.rst
@@ -125,8 +125,8 @@ This schema information can be provided to the `SimpleKGBuilder` as demonstrated
         # ...
     )
 
-Prompt Template, Lexical Graph Config, Schema Enforcement, and Error Behavior
---------------------------------------------------------
+Extra configurations
+--------------------
 
 These parameters are part of the `EntityAndRelationExtractor` component.
 For detailed information, refer to the section on :ref:`Entity and Relation Extractor`.
@@ -138,7 +138,7 @@ They are also accessible via the `SimpleKGPipeline` interface.
         # ...
         prompt_template="",
         lexical_graph_config=my_config,
-        enforce_schema=SchemaEnforcementMode.Strict
+        enforce_schema="STRICT"
         on_error="RAISE",
         # ...
     )

--- a/docs/source/user_guide_kg_builder.rst
+++ b/docs/source/user_guide_kg_builder.rst
@@ -125,7 +125,7 @@ This schema information can be provided to the `SimpleKGBuilder` as demonstrated
         # ...
     )
 
-Prompt Template, Lexical Graph Config and Error Behavior
+Prompt Template, Lexical Graph Config, Schema Enforcement, and Error Behavior
 --------------------------------------------------------
 
 These parameters are part of the `EntityAndRelationExtractor` component.
@@ -138,6 +138,7 @@ They are also accessible via the `SimpleKGPipeline` interface.
         # ...
         prompt_template="",
         lexical_graph_config=my_config,
+        enforce_schema=SchemaEnforcementMode.Strict
         on_error="RAISE",
         # ...
     )
@@ -828,6 +829,38 @@ It can be used in this way:
     The `LLMEntityRelationExtractor` works better if `"response_format": {"type": "json_object"}` is in the model parameters.
 
 The LLM to use can be customized, the only constraint is that it obeys the :ref:`LLMInterface <llminterface>`.
+
+Schema Enforcement Behaviour
+---------------
+By default, even if a schema is provided to guide the LLM in the entity and relation extraction, the LLM response is not validated against that schema.
+This behaviour can be changed by using the `enforce_schema` flag in the `LLMEntityRelationExtractor` constructor:
+
+.. code:: python
+
+    from neo4j_graphrag.experimental.components.entity_relation_extractor import LLMEntityRelationExtractor
+    from neo4j_graphrag.experimental.components.types import SchemaEnforcementMode
+
+    extractor = LLMEntityRelationExtractor(
+        # ...
+        enforce_schema=SchemaEnforcementMode.STRICT,
+    )
+    schema = SchemaConfig(
+        entities={"Label": {"name": str}},
+        relations={"REL_TYPE": {}},
+        potential_schema=[("Label", "REL_TYPE", "Label")]
+    )
+
+   #....
+    result = await extractor.run(
+        #...
+        schema=schema
+    )
+
+In this scenario, any extracted node/relation/property that is not part of the provided schema will be pruned.
+Any relation whose start node or end node does not conform to the provided tuple in `potential_schema` will be pruned.
+If a node is left with no properties, it will be also pruned.
+
+Note that if the schema enforcement mode is on but the schema is not provided, no schema enforcement will be applied.
 
 Error Behaviour
 ---------------

--- a/docs/source/user_guide_kg_builder.rst
+++ b/docs/source/user_guide_kg_builder.rst
@@ -831,7 +831,7 @@ It can be used in this way:
 The LLM to use can be customized, the only constraint is that it obeys the :ref:`LLMInterface <llminterface>`.
 
 Schema Enforcement Behaviour
----------------
+----------------------------
 By default, even if a schema is provided to guide the LLM in the entity and relation extraction, the LLM response is not validated against that schema.
 This behaviour can be changed by using the `enforce_schema` flag in the `LLMEntityRelationExtractor` constructor:
 
@@ -844,23 +844,14 @@ This behaviour can be changed by using the `enforce_schema` flag in the `LLMEnti
         # ...
         enforce_schema=SchemaEnforcementMode.STRICT,
     )
-    schema = SchemaConfig(
-        entities={"Label": {"name": str}},
-        relations={"REL_TYPE": {}},
-        potential_schema=[("Label", "REL_TYPE", "Label")]
-    )
-
-   #....
-    result = await extractor.run(
-        #...
-        schema=schema
-    )
 
 In this scenario, any extracted node/relation/property that is not part of the provided schema will be pruned.
 Any relation whose start node or end node does not conform to the provided tuple in `potential_schema` will be pruned.
 If a node is left with no properties, it will be also pruned.
 
-Note that if the schema enforcement mode is on but the schema is not provided, no schema enforcement will be applied.
+.. warning::
+
+    Note that if the schema enforcement mode is on but the schema is not provided, no schema enforcement will be applied.
 
 Error Behaviour
 ---------------

--- a/docs/source/user_guide_kg_builder.rst
+++ b/docs/source/user_guide_kg_builder.rst
@@ -847,6 +847,7 @@ This behaviour can be changed by using the `enforce_schema` flag in the `LLMEnti
 
 In this scenario, any extracted node/relation/property that is not part of the provided schema will be pruned.
 Any relation whose start node or end node does not conform to the provided tuple in `potential_schema` will be pruned.
+If a relation start/end nodes are valid but the direction is incorrect, the latter will be inverted.
 If a node is left with no properties, it will be also pruned.
 
 .. warning::

--- a/src/neo4j_graphrag/experimental/components/entity_relation_extractor.py
+++ b/src/neo4j_graphrag/experimental/components/entity_relation_extractor.py
@@ -409,7 +409,7 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
             schema_entity = schema.entities.get(node.label)
             if not schema_entity:
                 continue
-            allowed_props = schema_entity.get("properties", {})
+            allowed_props = schema_entity.get("properties", [])
             filtered_props = self._enforce_properties(node.properties, allowed_props)
             if filtered_props:
                 valid_nodes.append(
@@ -461,7 +461,7 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
                     (start_label, rel.type, end_label) not in potential_schema):
                 continue
 
-            allowed_props = schema_relation.get("properties", {})
+            allowed_props = schema_relation.get("properties", [])
             filtered_props = self._enforce_properties(rel.properties, allowed_props)
 
             valid_rels.append(

--- a/src/neo4j_graphrag/experimental/components/entity_relation_extractor.py
+++ b/src/neo4j_graphrag/experimental/components/entity_relation_extractor.py
@@ -354,12 +354,15 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
          Perform validation after entity and relation extraction:
          - Enforce schema if schema enforcement mode is on and schema is provided
         """
-        # if enforcing_schema is on and schema is provided, clean the graph
-        return (
-            self._clean_graph(chunk_graph, schema)
-            if self.enforce_schema != SchemaEnforcementMode.NONE and schema.entities
-            else chunk_graph
-        )
+        if self.enforce_schema != SchemaEnforcementMode.NONE:
+            if not schema or not schema.entities:  # schema is not provided
+                logger.warning(
+                    "Schema enforcement is ON but the guiding schema is not provided."
+                )
+            else:
+                # if enforcing_schema is on and schema is provided, clean the graph
+                return self._clean_graph(chunk_graph, schema)
+        return chunk_graph
 
     def _clean_graph(
             self,

--- a/src/neo4j_graphrag/experimental/components/types.py
+++ b/src/neo4j_graphrag/experimental/components/types.py
@@ -176,5 +176,3 @@ class GraphResult(DataModel):
 class SchemaEnforcementMode(str, Enum):
     NONE = "none"
     STRICT = "strict"
-    # future possibility: OPEN = "open" -> ensure conformance of nodes/props/rels that
-    # were listed in the schema but leave room for extras

--- a/src/neo4j_graphrag/experimental/components/types.py
+++ b/src/neo4j_graphrag/experimental/components/types.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import uuid
+from enum import Enum
 from typing import Any, Dict, Optional
 
 from pydantic import BaseModel, Field, field_validator
@@ -170,3 +171,10 @@ class LexicalGraphConfig(BaseModel):
 class GraphResult(DataModel):
     graph: Neo4jGraph
     config: LexicalGraphConfig
+
+
+class SchemaEnforcementMode(str, Enum):
+    NONE = "none"
+    STRICT = "strict"
+    # future possibility: OPEN = "open" -> ensure conformance of nodes/props/rels that
+    # were listed in the schema but leave room for extras

--- a/src/neo4j_graphrag/experimental/components/types.py
+++ b/src/neo4j_graphrag/experimental/components/types.py
@@ -174,5 +174,5 @@ class GraphResult(DataModel):
 
 
 class SchemaEnforcementMode(str, Enum):
-    NONE = "none"
-    STRICT = "strict"
+    NONE = "NONE"
+    STRICT = "STRICT"

--- a/src/neo4j_graphrag/experimental/pipeline/config/template_pipeline/simple_kg_builder.py
+++ b/src/neo4j_graphrag/experimental/pipeline/config/template_pipeline/simple_kg_builder.py
@@ -37,7 +37,10 @@ from neo4j_graphrag.experimental.components.text_splitters.base import TextSplit
 from neo4j_graphrag.experimental.components.text_splitters.fixed_size_splitter import (
     FixedSizeSplitter,
 )
-from neo4j_graphrag.experimental.components.types import LexicalGraphConfig
+from neo4j_graphrag.experimental.components.types import (
+    LexicalGraphConfig,
+    SchemaEnforcementMode
+)
 from neo4j_graphrag.experimental.pipeline.config.object_config import ComponentType
 from neo4j_graphrag.experimental.pipeline.config.template_pipeline.base import (
     TemplatePipelineConfig,
@@ -71,6 +74,7 @@ class SimpleKGPipelineConfig(TemplatePipelineConfig):
     entities: Sequence[EntityInputType] = []
     relations: Sequence[RelationInputType] = []
     potential_schema: Optional[list[tuple[str, str, str]]] = None
+    enforce_schema: SchemaEnforcementMode = SchemaEnforcementMode.NONE
     on_error: OnError = OnError.IGNORE
     prompt_template: Union[ERExtractionTemplate, str] = ERExtractionTemplate()
     perform_entity_resolution: bool = True
@@ -124,6 +128,7 @@ class SimpleKGPipelineConfig(TemplatePipelineConfig):
         return LLMEntityRelationExtractor(
             llm=self.get_default_llm(),
             prompt_template=self.prompt_template,
+            enforce_schema=self.enforce_schema,
             on_error=self.on_error,
         )
 

--- a/tests/unit/experimental/components/test_entity_relation_extractor.py
+++ b/tests/unit/experimental/components/test_entity_relation_extractor.py
@@ -349,7 +349,7 @@ async def test_extractor_schema_enforcement_valid_nodes_with_empty_props():
                                            create_lexical_graph=False,
                                            enforce_schema=SchemaEnforcementMode.STRICT)
 
-    schema = SchemaConfig(entities={"Person": {"label": "Person", "properties": []}},
+    schema = SchemaConfig(entities={"Person": {"label": "Person"}},
                           relations={},
                           potential_schema=[])
 
@@ -378,7 +378,7 @@ async def test_extractor_schema_enforcement_invalid_relations_wrong_types():
     schema = SchemaConfig(
         entities={"Person": {"label": "Person",
                              "properties": [{"name": "name", "type": "STRING"}]}},
-        relations={"LIKES": {"label": "LIKES", "properties": []}},
+        relations={"LIKES": {"label": "LIKES"}},
         potential_schema=[])
 
     chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
@@ -409,7 +409,7 @@ async def test_extractor_schema_enforcement_invalid_relations_wrong_start_node()
                              "properties": [{"name": "name", "type": "STRING"}]},
                   "City": {"label": "City",
                            "properties": [{"name": "name", "type": "STRING"}]}},
-        relations={"LIVES_IN": {"label": "LIVES_IN", "properties": []}},
+        relations={"LIVES_IN": {"label": "LIVES_IN"}},
         potential_schema=[("Person", "LIVES_IN", "City")])
 
     chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
@@ -470,7 +470,7 @@ async def test_extractor_schema_enforcement_removed_relation_start_end_nodes():
     schema = SchemaConfig(
         entities={"Person": {"label": "Person",
                              "properties": [{"name": "name", "type": "STRING"}]}},
-        relations={"LIKES": {"label": "LIKES", "properties": []}},
+        relations={"LIKES": {"label": "LIKES"}},
         potential_schema=[("Person", "LIKES", "Person")])
 
     chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])

--- a/tests/unit/experimental/components/test_entity_relation_extractor.py
+++ b/tests/unit/experimental/components/test_entity_relation_extractor.py
@@ -243,9 +243,11 @@ async def test_extractor_no_schema_enforcement() -> None:
                                            create_lexical_graph=False,
                                            enforce_schema=SchemaEnforcementMode.NONE)
 
-    schema = SchemaConfig(entities={"Person": {"name": "STRING"}},
-                          relations={},
-                          potential_schema=[])
+    schema = SchemaConfig(
+        entities={"Person": {"label": "Person",
+                             "properties": [{"name": "name", "type": "STRING"}]}},
+        relations={},
+        potential_schema=[])
 
     chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
 
@@ -290,9 +292,11 @@ async def test_extractor_schema_enforcement_invalid_nodes():
                                            create_lexical_graph=False,
                                            enforce_schema=SchemaEnforcementMode.STRICT)
 
-    schema = SchemaConfig(entities={"Person": {"name": "STRING"}},
-                          relations={},
-                          potential_schema=[])
+    schema = SchemaConfig(
+        entities={"Person": {"label": "Person",
+                             "properties": [{"name": "name", "type": "STRING"}]}},
+        relations={},
+        potential_schema=[])
 
     chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
 
@@ -316,9 +320,12 @@ async def test_extraction_schema_enforcement_invalid_node_properties():
                                            create_lexical_graph=False,
                                            enforce_schema=SchemaEnforcementMode.STRICT)
 
-    schema = SchemaConfig(entities={"Person": {"name": str, "age": int}},
-                          relations={},
-                          potential_schema=[])
+    schema = SchemaConfig(
+        entities={"Person": {"label": "Person",
+                             "properties": [{"name": "name", "type": "STRING"},
+                                            {"name": "age", "type": "INTEGER"}]}},
+        relations={},
+        potential_schema=[])
 
     chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
 
@@ -342,7 +349,7 @@ async def test_extractor_schema_enforcement_valid_nodes_with_empty_props():
                                            create_lexical_graph=False,
                                            enforce_schema=SchemaEnforcementMode.STRICT)
 
-    schema = SchemaConfig(entities={"Person": {}},
+    schema = SchemaConfig(entities={"Person": {"label": "Person", "properties": []}},
                           relations={},
                           potential_schema=[])
 
@@ -368,9 +375,11 @@ async def test_extractor_schema_enforcement_invalid_relations_wrong_types():
                                            create_lexical_graph=False,
                                            enforce_schema=SchemaEnforcementMode.STRICT)
 
-    schema = SchemaConfig(entities={"Person": {"name": str}},
-                          relations={"LIKES": {}},
-                          potential_schema=[])
+    schema = SchemaConfig(
+        entities={"Person": {"label": "Person",
+                             "properties": [{"name": "name", "type": "STRING"}]}},
+        relations={"LIKES": {"label": "LIKES", "properties": []}},
+        potential_schema=[])
 
     chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
 
@@ -395,9 +404,13 @@ async def test_extractor_schema_enforcement_invalid_relations_wrong_start_node()
                                            create_lexical_graph=False,
                                            enforce_schema=SchemaEnforcementMode.STRICT)
 
-    schema = SchemaConfig(entities={"Person": {"name": str}, "City": {"name": str}},
-                          relations={"LIVES_IN": {}},
-                          potential_schema=[("Person", "LIVES_IN", "City")])
+    schema = SchemaConfig(
+        entities={"Person": {"label": "Person",
+                             "properties": [{"name": "name", "type": "STRING"}]},
+                  "City": {"label": "City",
+                           "properties": [{"name": "name", "type": "STRING"}]}},
+        relations={"LIVES_IN": {"label": "LIVES_IN", "properties": []}},
+        potential_schema=[("Person", "LIVES_IN", "City")])
 
     chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
 
@@ -422,8 +435,10 @@ async def test_extractor_schema_enforcement_invalid_relation_properties():
                                            enforce_schema=SchemaEnforcementMode.STRICT)
 
     schema = SchemaConfig(
-        entities={"Person": {"name": str}},
-        relations={"LIKES": {"strength": str}},
+        entities={"Person": {"label": "Person",
+                             "properties": [{"name": "name", "type": "STRING"}]}},
+        relations={"LIKES": {"label": "LIKES",
+                             "properties": [{"name": "strength", "type": "STRING"}]}},
         potential_schema=[]
     )
 
@@ -452,9 +467,11 @@ async def test_extractor_schema_enforcement_removed_relation_start_end_nodes():
                                            create_lexical_graph=False,
                                            enforce_schema=SchemaEnforcementMode.STRICT)
 
-    schema = SchemaConfig(entities={"Person": {"name": str}},
-                          relations={"LIKES": {}},
-                          potential_schema=[("Person", "LIKES", "Person")])
+    schema = SchemaConfig(
+        entities={"Person": {"label": "Person",
+                             "properties": [{"name": "name", "type": "STRING"}]}},
+        relations={"LIKES": {"label": "LIKES", "properties": []}},
+        potential_schema=[("Person", "LIKES", "Person")])
 
     chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
 

--- a/tests/unit/experimental/components/test_entity_relation_extractor.py
+++ b/tests/unit/experimental/components/test_entity_relation_extractor.py
@@ -25,11 +25,13 @@ from neo4j_graphrag.experimental.components.entity_relation_extractor import (
     balance_curly_braces,
     fix_invalid_json,
 )
+from neo4j_graphrag.experimental.components.schema import SchemaConfig
 from neo4j_graphrag.experimental.components.types import (
     DocumentInfo,
     Neo4jGraph,
     TextChunk,
     TextChunks,
+    SchemaEnforcementMode,
 )
 from neo4j_graphrag.experimental.pipeline.exceptions import InvalidJSONError
 from neo4j_graphrag.llm import LLMInterface, LLMResponse
@@ -227,6 +229,239 @@ async def test_extractor_custom_prompt() -> None:
     chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
     await extractor.run(chunks=chunks)
     llm.ainvoke.assert_called_once_with("this is my prompt")
+
+
+@pytest.mark.asyncio
+async def test_extractor_no_schema_enforcement() -> None:
+    llm = MagicMock(spec=LLMInterface)
+    llm.ainvoke.return_value = LLMResponse(
+        content='{"nodes":[{"id":"0","label":"Alien","properties":{"foo":"bar"}}],'
+                '"relationships":[]}'
+    )
+
+    extractor = LLMEntityRelationExtractor(llm=llm,
+                                           create_lexical_graph=False,
+                                           enforce_schema=SchemaEnforcementMode.NONE)
+
+    schema = SchemaConfig(entities={"Person": {"name": "STRING"}},
+                          relations={},
+                          potential_schema=[])
+
+    chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
+
+    result: Neo4jGraph = await extractor.run(chunks=chunks, schema=schema)
+
+    assert len(result.nodes) == 1
+    assert result.nodes[0].label == "Alien"
+    assert result.nodes[0].properties == {"chunk_index": 0, "foo": "bar"}
+
+
+@pytest.mark.asyncio
+async def test_extractor_schema_enforcement_when_no_schema_provided():
+    llm = MagicMock(spec=LLMInterface)
+    llm.ainvoke.return_value = LLMResponse(
+        content='{"nodes":[{"id":"0","label":"Alien","properties":{"foo":"bar"}}],'
+                '"relationships":[]}'
+    )
+
+    extractor = LLMEntityRelationExtractor(llm=llm,
+                                           create_lexical_graph=False,
+                                           enforce_schema=SchemaEnforcementMode.STRICT)
+
+    chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
+
+    result: Neo4jGraph = await extractor.run(chunks=chunks)
+
+    assert len(result.nodes) == 1
+    assert result.nodes[0].label == "Alien"
+    assert result.nodes[0].properties == {"chunk_index": 0, "foo": "bar"}
+
+
+@pytest.mark.asyncio
+async def test_extractor_schema_enforcement_invalid_nodes():
+    llm = MagicMock(spec=LLMInterface)
+    llm.ainvoke.return_value = LLMResponse(
+        content='{"nodes":[{"id":"0","label":"Alien","properties":{"foo":"bar"}},'
+                '{"id":"1","label":"Person","properties":{"name":"Alice"}}],'
+                '"relationships":[]}'
+    )
+
+    extractor = LLMEntityRelationExtractor(llm=llm,
+                                           create_lexical_graph=False,
+                                           enforce_schema=SchemaEnforcementMode.STRICT)
+
+    schema = SchemaConfig(entities={"Person": {"name": "STRING"}},
+                          relations={},
+                          potential_schema=[])
+
+    chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
+
+    result: Neo4jGraph = await extractor.run(chunks=chunks, schema=schema)
+
+    assert len(result.nodes) == 1
+    assert result.nodes[0].label == "Person"
+    assert result.nodes[0].properties == {"chunk_index": 0, "name": "Alice"}
+
+
+@pytest.mark.asyncio
+async def test_extraction_schema_enforcement_invalid_node_properties():
+    llm = MagicMock(spec=LLMInterface)
+    llm.ainvoke.return_value = LLMResponse(
+        content='{"nodes":[{"id":"1","label":"Person","properties":'
+                '{"name":"Alice","age":30,"foo":"bar"}}],'
+                '"relationships":[]}'
+    )
+
+    extractor = LLMEntityRelationExtractor(llm=llm,
+                                           create_lexical_graph=False,
+                                           enforce_schema=SchemaEnforcementMode.STRICT)
+
+    schema = SchemaConfig(entities={"Person": {"name": str, "age": int}},
+                          relations={},
+                          potential_schema=[])
+
+    chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
+
+    result: Neo4jGraph = await extractor.run(chunks, schema=schema)
+
+    # "foo" is removed
+    assert len(result.nodes) == 1
+    assert len(result.nodes[0].properties) == 3
+    assert "foo" not in result.nodes[0].properties
+
+
+@pytest.mark.asyncio
+async def test_extractor_schema_enforcement_valid_nodes_with_empty_props():
+    llm = MagicMock(spec=LLMInterface)
+    llm.ainvoke.return_value = LLMResponse(
+        content='{"nodes":[{"id":"1","label":"Person","properties":{"foo":"bar"}}],'
+                '"relationships":[]}'
+    )
+
+    extractor = LLMEntityRelationExtractor(llm=llm,
+                                           create_lexical_graph=False,
+                                           enforce_schema=SchemaEnforcementMode.STRICT)
+
+    schema = SchemaConfig(entities={"Person": {}},
+                          relations={},
+                          potential_schema=[])
+
+    chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
+
+    result: Neo4jGraph = await extractor.run(chunks, schema=schema)
+
+    assert len(result.nodes) == 0
+
+
+@pytest.mark.asyncio
+async def test_extractor_schema_enforcement_invalid_relations_wrong_types():
+    llm = MagicMock(spec=LLMInterface)
+    llm.ainvoke.return_value = LLMResponse(
+        content='{"nodes":[{"id":"1","label":"Person","properties":'
+                '{"name":"Alice"}},{"id":"2","label":"Person","properties":'
+                '{"name":"Bob"}}],'
+                '"relationships":[{"start_node_id":"1","end_node_id":"2",'
+                '"type":"FRIENDS_WITH","properties":{}}]}'
+    )
+
+    extractor = LLMEntityRelationExtractor(llm=llm,
+                                           create_lexical_graph=False,
+                                           enforce_schema=SchemaEnforcementMode.STRICT)
+
+    schema = SchemaConfig(entities={"Person": {"name": str}},
+                          relations={"LIKES": {}},
+                          potential_schema=[])
+
+    chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
+
+    result: Neo4jGraph = await extractor.run(chunks, schema=schema)
+
+    assert len(result.nodes) == 2
+    assert len(result.relationships) == 0
+
+
+@pytest.mark.asyncio
+async def test_extractor_schema_enforcement_invalid_relations_wrong_start_node():
+    llm = MagicMock(spec=LLMInterface)
+    llm.ainvoke.return_value = LLMResponse(
+        content='{"nodes":[{"id":"1","label":"Person","properties":{"name":"Alice"}},'
+                '{"id":"2","label":"Person","properties":{"name":"Bob"}}, '
+                '{"id":"3","label":"City","properties":{"name":"London"}}],'
+                '"relationships":[{"start_node_id":"1","end_node_id":"2",'
+                '"type":"LIVES_IN","properties":{}}]}'
+    )
+
+    extractor = LLMEntityRelationExtractor(llm=llm,
+                                           create_lexical_graph=False,
+                                           enforce_schema=SchemaEnforcementMode.STRICT)
+
+    schema = SchemaConfig(entities={"Person": {"name": str}, "City": {"name": str}},
+                          relations={"LIVES_IN": {}},
+                          potential_schema=[("Person", "LIVES_IN", "City")])
+
+    chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
+
+    result: Neo4jGraph = await extractor.run(chunks, schema=schema)
+
+    assert len(result.nodes) == 3
+    assert len(result.relationships) == 0
+
+
+@pytest.mark.asyncio
+async def test_extractor_schema_enforcement_invalid_relation_properties():
+    llm = MagicMock(spec=LLMInterface)
+    llm.ainvoke.return_value = LLMResponse(
+        content='{"nodes":[{"id":"1","label":"Person","properties":{"name":"Alice"}},'
+                '{"id":"2","label":"Person","properties":{"name":"Bob"}}],'
+                '"relationships":[{"start_node_id":"1","end_node_id":"2",'
+                '"type":"LIKES","properties":{"strength":"high","foo":"bar"}}]}'
+    )
+
+    extractor = LLMEntityRelationExtractor(llm=llm,
+                                           create_lexical_graph=False,
+                                           enforce_schema=SchemaEnforcementMode.STRICT)
+
+    schema = SchemaConfig(
+        entities={"Person": {"name": str}},
+        relations={"LIKES": {"strength": str}},
+        potential_schema=[]
+    )
+
+    chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
+
+    result: Neo4jGraph = await extractor.run(chunks, schema=schema)
+
+    assert len(result.nodes) == 2
+    assert len(result.relationships) == 1
+    rel = result.relationships[0]
+    assert "foo" not in rel.properties
+    assert rel.properties["strength"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_extractor_schema_enforcement_removed_relation_start_end_nodes():
+    llm = MagicMock(spec=LLMInterface)
+    llm.ainvoke.return_value = LLMResponse(
+        content='{"nodes":[{"id":"1","label":"Alien","properties":{}},'
+                '{"id":"2","label":"Robot","properties":{}}],'
+                '"relationships":[{"start_node_id":"1","end_node_id":"2",'
+                '"type":"LIKES","properties":{}}]}'
+    )
+
+    extractor = LLMEntityRelationExtractor(llm=llm,
+                                           create_lexical_graph=False,
+                                           enforce_schema=SchemaEnforcementMode.STRICT)
+
+    schema = SchemaConfig(entities={"Person": {"name": str}},
+                          relations={"LIKES": {}},
+                          potential_schema=[("Person", "LIKES", "Person")])
+
+    chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
+
+    result: Neo4jGraph = await extractor.run(chunks, schema=schema)
+
+    assert len(result.nodes) == 0
+    assert len(result.relationships) == 0
 
 
 def test_fix_invalid_json_empty_result() -> None:


### PR DESCRIPTION
# Description

This PR adds an optional schema enforcement layer to validate the extracted entities, relations, and properties against the schema that is passed to the LLM as guidance for the extraction. This change introduces:
- A new `_clean_graph` function in the `LLMEntityRelationExtractor` class that filters out invalid nodes, relationships, and properties based on a provided `SchemaConfig` object:
- Support for different enforcement modes (e.g., NONE vs. STRICT). So far implemented using Enum.
- Unit tests covering various enforcement scenarios (no schema, invalid nodes, invalid relations, etc.).

The cleanup is performed at the chunk graphs level after the extraction and before post-processing, i.e.,before relationships to the chunks are created.

Cleanup logic:
- Remove invalid nodes (not conformant to the schema)
- Remove invalid node properties (not conformant to the schema)
- Remove nodes that are left with no properties
- Remove invalid relations (whose types or start/end nodes are not conformant to the schema)
- Remove relations whose start/end node was removed
- Remove invalid relations properties (not conformant to the schema).

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High
>
>

Complexity:

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
- [x] CHANGELOG.md updated if appropriate
