### PR TITLE
chore: Fallback to Qdrant point id

### DIFF
--- a/src/neo4j_graphrag/retrievers/external/qdrant/qdrant.py
+++ b/src/neo4j_graphrag/retrievers/external/qdrant/qdrant.py
@@ -211,7 +211,7 @@ class QdrantNeo4jRetriever(ExternalRetriever):
         for point in points:
             assert point.payload is not None
             result_tuples.append(
-                [f"{point.payload[self.id_property_external]}", point.score]
+                [point.payload.get(self.id_property_external, point.id), point.score]
             )
 
         search_query = get_match_query(


### PR DESCRIPTION
# Description

Resolves #294.

This PR updates `QdrantNeo4jRetriever` to use the point's ID as a fallback if the dedicated ID field is not found in the payload.