### PR TITLE
Expose all components in SimpleKGPipeline init and config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added the `run_with_context` method to `Component`. This method includes a `context_` parameter, which provides information about the pipeline from which the component is executed (e.g., the `run_id`). It also enables the component to send events to the pipeline's callback function.
+- Exposed `schema_builder`, `chunk_embedder`, `extractor` and `resolver` in the `SimpleKGPipeline` constructor so that they can be customized.
 
 
 ## 1.6.0

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -102,6 +102,14 @@ Neo4jWriter
 .. autoclass:: neo4j_graphrag.experimental.components.kg_writer.Neo4jWriter
     :members: run
 
+
+EntityResolver
+==============
+
+.. autoclass:: neo4j_graphrag.experimental.components.resolver.EntityResolver
+    :members: run
+
+
 SinglePropertyExactMatchResolver
 ================================
 

--- a/docs/source/user_guide_kg_builder.rst
+++ b/docs/source/user_guide_kg_builder.rst
@@ -178,9 +178,13 @@ For advanced customization or when using a custom implementation, you can pass
 instances of specific components to the `SimpleKGPipeline`. The components that can
 customized at the moment are:
 
-- `text_splitter`: must be an instance of :ref:`TextSplitter`
 - `pdf_loader`: must be an instance of :ref:`PdfLoader`
+- `schema_builder`: must be an instance of :ref:`SchemaBuilder`
+- `text_splitter`: must be an instance of :ref:`TextSplitter`
+- `chunk_embedder`: must be an instance of :ref:`TextChunkEmbedder`
+- `extractor`: must be an instance of :ref:`EntityRelationExtractor`
 - `kg_writer`: must be an instance of :ref:`KGWriter`
+- `resolver`: must be an instance of :ref:`EntityResolver`
 
 For instance, the following code can be used to customize the chunk size and
 chunk overlap in the text splitter component:
@@ -198,6 +202,24 @@ chunk overlap in the text splitter component:
         text_splitter=text_splitter,
         # ...
     )
+
+
+.. warning::
+
+    When providing a custom component, all other related parameters in the SimpleKGPipeline constructor are ignored. For instance, in the following example:
+
+    .. code:: python
+
+        kg_builder = SimpleKGPipeline(
+            # ...
+            writer=Neo4jKGWriter(neo4j_database="db_1"),
+            neo4j_database="db_2",
+            # ...
+        )
+
+
+    The graph will be saved to the **db_1** database.
+
 
 
 Using a Config file

--- a/src/neo4j_graphrag/experimental/pipeline/config/object_config.py
+++ b/src/neo4j_graphrag/experimental/pipeline/config/object_config.py
@@ -244,7 +244,10 @@ class EmbedderType(RootModel):  # type: ignore[type-arg]
         return self.root.parse(resolved_data)
 
 
-class ComponentConfig(ObjectConfig[Component]):
+ComponentT = TypeVar("ComponentT", bound=Component)
+
+
+class ComponentConfig(ObjectConfig[ComponentT]):
     """A config model for all components.
 
     In addition to the object config, components can have pre-defined parameters
@@ -261,14 +264,17 @@ class ComponentConfig(ObjectConfig[Component]):
         return self.resolve_params(self.run_params_)
 
 
-class ComponentType(RootModel):  # type: ignore[type-arg]
-    root: Union[Component, ComponentConfig]
+class ComponentType(
+    RootModel[Generic[ComponentT]],
+    # Generic[ComponentT]
+):
+    root: Union[ComponentT, ComponentConfig[ComponentT]]
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    def parse(self, resolved_data: dict[str, Any] | None = None) -> Component:
+    def parse(self, resolved_data: dict[str, Any] | None = None) -> ComponentT:
         if isinstance(self.root, Component):
-            return self.root
+            return self.root  # type: ignore
         return self.root.parse(resolved_data)
 
     def get_run_params(self, resolved_data: dict[str, Any]) -> dict[str, Any]:

--- a/src/neo4j_graphrag/experimental/pipeline/config/pipeline_config.py
+++ b/src/neo4j_graphrag/experimental/pipeline/config/pipeline_config.py
@@ -20,6 +20,7 @@ import neo4j
 from pydantic import field_validator
 
 from neo4j_graphrag.embeddings import Embedder
+from neo4j_graphrag.experimental.pipeline import Component
 from neo4j_graphrag.experimental.pipeline.config.base import AbstractConfig
 from neo4j_graphrag.experimental.pipeline.config.object_config import (
     ComponentType,
@@ -83,7 +84,7 @@ class AbstractPipelineConfig(AbstractConfig):
         return embedders
 
     def _resolve_component_definition(
-        self, name: str, config: ComponentType
+        self, name: str, config: ComponentType[Component]
     ) -> ComponentDefinition:
         component = config.parse(self._global_data)
         if hasattr(config.root, "run_params_"):
@@ -188,7 +189,7 @@ class PipelineConfig(AbstractPipelineConfig):
     """Configuration class for raw pipelines.
     Config must contain all components and connections."""
 
-    component_config: dict[str, ComponentType]
+    component_config: dict[str, ComponentType[Component]]
     connection_config: list[ConnectionDefinition]
     template_: Literal[PipelineType.NONE] = PipelineType.NONE
 

--- a/src/neo4j_graphrag/experimental/pipeline/config/template_pipeline/simple_kg_builder.py
+++ b/src/neo4j_graphrag/experimental/pipeline/config/template_pipeline/simple_kg_builder.py
@@ -87,7 +87,7 @@ class SimpleKGPipelineConfig(TemplatePipelineConfig):
     chunk_embedder: Optional[ComponentType[TextChunkEmbedder]] = None
     extractor: Optional[ComponentType[EntityRelationExtractor]] = None
     kg_writer: Optional[ComponentType[KGWriter]] = None
-    resolver: Optional[list[ComponentType[EntityResolver]]] = None
+    resolver: Optional[ComponentType[EntityResolver]] = None
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -158,6 +158,8 @@ class SimpleKGPipelineConfig(TemplatePipelineConfig):
     def _get_resolver(self) -> Optional[EntityResolver]:
         if not self.perform_entity_resolution:
             return None
+        if self.resolver:
+            return self.resolver.parse(self._global_data)
         return SinglePropertyExactMatchResolver(
             driver=self.get_default_neo4j_driver(),
             neo4j_database=self.neo4j_database,

--- a/src/neo4j_graphrag/experimental/pipeline/kg_builder.py
+++ b/src/neo4j_graphrag/experimental/pipeline/kg_builder.py
@@ -21,9 +21,15 @@ import neo4j
 from pydantic import ValidationError
 
 from neo4j_graphrag.embeddings import Embedder
-from neo4j_graphrag.experimental.components.entity_relation_extractor import OnError
+from neo4j_graphrag.experimental.components.embedder import TextChunkEmbedder
+from neo4j_graphrag.experimental.components.entity_relation_extractor import (
+    OnError,
+    EntityRelationExtractor,
+)
 from neo4j_graphrag.experimental.components.kg_writer import KGWriter
 from neo4j_graphrag.experimental.components.pdf_loader import DataLoader
+from neo4j_graphrag.experimental.components.resolver import EntityResolver
+from neo4j_graphrag.experimental.components.schema import SchemaBuilder
 from neo4j_graphrag.experimental.components.text_splitters.base import TextSplitter
 from neo4j_graphrag.experimental.components.types import LexicalGraphConfig
 from neo4j_graphrag.experimental.pipeline.config.object_config import ComponentType
@@ -82,9 +88,13 @@ class SimpleKGPipeline:
         relations: Optional[Sequence[RelationInputType]] = None,
         potential_schema: Optional[List[tuple[str, str, str]]] = None,
         from_pdf: bool = True,
-        text_splitter: Optional[TextSplitter] = None,
         pdf_loader: Optional[DataLoader] = None,
+        schema_builder: Optional[SchemaBuilder] = None,
+        text_splitter: Optional[TextSplitter] = None,
+        chunk_embedder: Optional[TextChunkEmbedder] = None,
+        extractor: Optional[EntityRelationExtractor] = None,
         kg_writer: Optional[KGWriter] = None,
+        resolver: Optional[list[EntityResolver]] = None,
         on_error: str = "IGNORE",
         prompt_template: Union[ERExtractionTemplate, str] = ERExtractionTemplate(),
         perform_entity_resolution: bool = True,
@@ -102,8 +112,12 @@ class SimpleKGPipeline:
                 potential_schema=potential_schema,
                 from_pdf=from_pdf,
                 pdf_loader=ComponentType(pdf_loader) if pdf_loader else None,
-                kg_writer=ComponentType(kg_writer) if kg_writer else None,
+                schema_builder=ComponentType(schema_builder) if schema_builder else None,
                 text_splitter=ComponentType(text_splitter) if text_splitter else None,
+                chunk_embedder=ComponentType(chunk_embedder) if chunk_embedder else None,
+                extractor=ComponentType(extractor) if extractor else None,
+                kg_writer=ComponentType(kg_writer) if kg_writer else None,
+                resolver=[ComponentType(r) for r in resolver] if resolver else None,
                 on_error=OnError(on_error),
                 prompt_template=prompt_template,
                 perform_entity_resolution=perform_entity_resolution,

--- a/src/neo4j_graphrag/experimental/pipeline/kg_builder.py
+++ b/src/neo4j_graphrag/experimental/pipeline/kg_builder.py
@@ -94,7 +94,7 @@ class SimpleKGPipeline:
         chunk_embedder: Optional[TextChunkEmbedder] = None,
         extractor: Optional[EntityRelationExtractor] = None,
         kg_writer: Optional[KGWriter] = None,
-        resolver: Optional[list[EntityResolver]] = None,
+        resolver: Optional[EntityResolver] = None,
         on_error: str = "IGNORE",
         prompt_template: Union[ERExtractionTemplate, str] = ERExtractionTemplate(),
         perform_entity_resolution: bool = True,
@@ -112,12 +112,16 @@ class SimpleKGPipeline:
                 potential_schema=potential_schema,
                 from_pdf=from_pdf,
                 pdf_loader=ComponentType(pdf_loader) if pdf_loader else None,
-                schema_builder=ComponentType(schema_builder) if schema_builder else None,
+                schema_builder=ComponentType(schema_builder)
+                if schema_builder
+                else None,
                 text_splitter=ComponentType(text_splitter) if text_splitter else None,
-                chunk_embedder=ComponentType(chunk_embedder) if chunk_embedder else None,
+                chunk_embedder=ComponentType(chunk_embedder)
+                if chunk_embedder
+                else None,
                 extractor=ComponentType(extractor) if extractor else None,
                 kg_writer=ComponentType(kg_writer) if kg_writer else None,
-                resolver=[ComponentType(r) for r in resolver] if resolver else None,
+                resolver=ComponentType(resolver) if resolver else None,
                 on_error=OnError(on_error),
                 prompt_template=prompt_template,
                 perform_entity_resolution=perform_entity_resolution,

--- a/tests/unit/experimental/pipeline/config/template_pipeline/test_simple_kg_builder.py
+++ b/tests/unit/experimental/pipeline/config/template_pipeline/test_simple_kg_builder.py
@@ -71,7 +71,7 @@ def test_simple_kg_pipeline_config_pdf_loader_class_overwrite_but_from_pdf_is_fa
 def test_simple_kg_pipeline_config_pdf_loader_from_pdf_is_true_class_overwrite_from_config(
     mock_component_parse: Mock,
 ) -> None:
-    my_pdf_loader_config = ComponentConfig(
+    my_pdf_loader_config: ComponentConfig[PdfLoader] = ComponentConfig(
         class_="",
     )
     my_pdf_loader = PdfLoader()
@@ -92,7 +92,7 @@ def test_simple_kg_pipeline_config_text_splitter() -> None:
 def test_simple_kg_pipeline_config_text_splitter_overwrite(
     mock_component_parse: Mock,
 ) -> None:
-    my_text_splitter_config = ComponentConfig(
+    my_text_splitter_config: ComponentConfig[FixedSizeSplitter] = ComponentConfig(
         class_="",
     )
     my_text_splitter = FixedSizeSplitter()
@@ -184,7 +184,7 @@ def test_simple_kg_pipeline_config_writer_overwrite(
     _: Mock,
     driver: neo4j.Driver,
 ) -> None:
-    my_writer_config = ComponentConfig(
+    my_writer_config: ComponentConfig[Neo4jWriter] = ComponentConfig(
         class_="",
     )
     my_writer = Neo4jWriter(driver, neo4j_database="my_db")

--- a/tests/unit/experimental/pipeline/config/test_pipeline_config.py
+++ b/tests/unit/experimental/pipeline/config/test_pipeline_config.py
@@ -345,7 +345,7 @@ def test_abstract_pipeline_config_resolve_component_definition_no_run_params(
 ) -> None:
     mock_component_parse.return_value = component
     config = AbstractPipelineConfig()
-    component_type = ComponentType(component)
+    component_type: ComponentType[Component] = ComponentType(component)
     component_definition = config._resolve_component_definition("name", component_type)
     assert isinstance(component_definition, ComponentDefinition)
     mock_component_parse.assert_called_once_with({})

--- a/tests/unit/experimental/pipeline/config/test_pipeline_config.py
+++ b/tests/unit/experimental/pipeline/config/test_pipeline_config.py
@@ -366,7 +366,7 @@ def test_abstract_pipeline_config_resolve_component_definition_with_run_params(
     mock_component_parse.return_value = component
     mock_resolve_params.return_value = {"param": "resolver param result"}
     config = AbstractPipelineConfig()
-    component_type = ComponentType(
+    component_type: ComponentType[Component] = ComponentType(
         ComponentConfig(class_="", params_={}, run_params_={"param1": "value1"})
     )
     component_definition = config._resolve_component_definition("name", component_type)

--- a/tests/unit/experimental/pipeline/test_simple_kg_pipeline.py
+++ b/tests/unit/experimental/pipeline/test_simple_kg_pipeline.py
@@ -34,7 +34,7 @@ from neo4j_graphrag.llm.base import LLMInterface
     return_value=((5, 23, 0), False, False),
 )
 @pytest.mark.asyncio
-async def test_knowledge_graph_builder_document_info_with_file(_: Mock) -> None:
+async def test_simple_kg_pipeline_document_info_with_file(_: Mock) -> None:
     llm = MagicMock(spec=LLMInterface)
     driver = MagicMock(spec=neo4j.Driver)
     embedder = MagicMock(spec=Embedder)
@@ -66,7 +66,7 @@ async def test_knowledge_graph_builder_document_info_with_file(_: Mock) -> None:
     return_value=((5, 23, 0), False, False),
 )
 @pytest.mark.asyncio
-async def test_knowledge_graph_builder_document_info_with_text(_: Mock) -> None:
+async def test_simple_kg_pipeline_document_info_with_text(_: Mock) -> None:
     llm = MagicMock(spec=LLMInterface)
     driver = MagicMock(spec=neo4j.Driver)
     embedder = MagicMock(spec=Embedder)
@@ -97,7 +97,7 @@ async def test_knowledge_graph_builder_document_info_with_text(_: Mock) -> None:
     return_value=((5, 23, 0), False, False),
 )
 @pytest.mark.asyncio
-async def test_knowledge_graph_builder_with_entities_and_file(_: Mock) -> None:
+async def test_simple_kg_pipeline_with_entities_and_file(_: Mock) -> None:
     llm = MagicMock(spec=LLMInterface)
     driver = MagicMock(spec=neo4j.Driver)
     embedder = MagicMock(spec=Embedder)
@@ -156,7 +156,7 @@ def test_simple_kg_pipeline_on_error_invalid_value() -> None:
     return_value=((5, 23, 0), False, False),
 )
 @pytest.mark.asyncio
-async def test_knowledge_graph_builder_with_lexical_graph_config(_: Mock) -> None:
+async def test_simple_kg_pipeline_with_lexical_graph_config(_: Mock) -> None:
     llm = MagicMock(spec=LLMInterface)
     driver = MagicMock(spec=neo4j.Driver)
     embedder = MagicMock(spec=Embedder)


### PR DESCRIPTION
# Description

This PR exposes all components in the SimpleKGPipeline constructor, ie make it possible to customize all the components in the pipeline, including the entity extractor and resolver.

I also took the opportunity to revisit some type definition to remove `type: ignore` comments by leveraging generics.


## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Medium

## How Has This Been Tested?
- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [x] CHANGELOG.md updated if appropriate
