### PR TITLE
Cleanup cypher deprecated function

### DIFF
--- a/src/neo4j_graphrag/experimental/components/resolver.py
+++ b/src/neo4j_graphrag/experimental/components/resolver.py
@@ -221,7 +221,7 @@ class BasePropertySimilarityResolver(EntityResolver, abc.ABC, metaclass=Combined
             UNWIND labels(entity) AS lab
             WITH lab, entity
             WHERE NOT lab IN ['__Entity__', '__KGBuilder__']
-            WITH lab, collect({{ id: id(entity), {props_map} }}) AS labelCluster
+            WITH lab, collect({{ id: elementId(entity), {props_map} }}) AS labelCluster
             RETURN lab, labelCluster
         """
 
@@ -260,10 +260,10 @@ class BasePropertySimilarityResolver(EntityResolver, abc.ABC, metaclass=Combined
             for node_id_set in merged_sets:
                 if len(node_id_set) > 1:
                     merge_query = (
-                        "MATCH (n) WHERE id(n) IN $ids "
+                        "MATCH (n) WHERE elementId(n) IN $ids "
                         "WITH collect(n) AS nodes "
                         "CALL apoc.refactor.mergeNodes(nodes, {properties: 'discard', mergeRels: true}) "
-                        "YIELD node RETURN id(node)"
+                        "YIELD node RETURN elementId(node)"
                     )
                     result, _, _ = self.driver.execute_query(
                         merge_query,


### PR DESCRIPTION
This is a small cleanup to replace `id()` with `elementId()` in the resolvers' Cypher queries.


## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High
>
>

Complexity:

## How Has This Been Tested?
- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
