### PR TITLE
Automatic schema extraction from text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+### Added
+
+- Added support for automatic schema extraction from text using LLMs.
+
 ## 1.7.0
 
 ### Added
@@ -11,7 +15,6 @@
 - Added a `Pipeline.stream` method to stream pipeline progress.
 - Added a new semantic match resolver to the KG Builder for entity resolution based on spaCy embeddings and cosine similarities so that nodes with similar textual properties get merged.
 - Added a new fuzzy match resolver to the KG Builder for entity resolution based on RapiFuzz string fuzzy matching.
-- Added support for automatic schema extraction from text using LLMs.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added a `Pipeline.stream` method to stream pipeline progress.
 - Added a new semantic match resolver to the KG Builder for entity resolution based on spaCy embeddings and cosine similarities so that nodes with similar textual properties get merged.
 - Added a new fuzzy match resolver to the KG Builder for entity resolution based on RapiFuzz string fuzzy matching.
+- Added support for automatic schema extraction from text using LLMs.
 
 ### Changed
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -77,6 +77,12 @@ SchemaBuilder
 .. autoclass:: neo4j_graphrag.experimental.components.schema.SchemaBuilder
     :members: run
 
+SchemaFromText
+=============
+
+.. autoclass:: neo4j_graphrag.experimental.components.schema.SchemaFromText
+    :members: run
+
 EntityRelationExtractor
 =======================
 
@@ -359,6 +365,13 @@ ERExtractionTemplate
 --------------------
 
 .. autoclass:: neo4j_graphrag.generation.prompts.ERExtractionTemplate
+    :members:
+    :exclude-members: format
+
+SchemaExtractionTemplate
+------------------------
+
+.. autoclass:: neo4j_graphrag.generation.prompts.SchemaExtractionTemplate
     :members:
     :exclude-members: format
 

--- a/src/neo4j_graphrag/experimental/pipeline/config/template_pipeline/simple_kg_builder.py
+++ b/src/neo4j_graphrag/experimental/pipeline/config/template_pipeline/simple_kg_builder.py
@@ -81,7 +81,7 @@ class SimpleKGPipelineConfig(TemplatePipelineConfig):
     entities: Sequence[EntityInputType] = []
     relations: Sequence[RelationInputType] = []
     potential_schema: Optional[list[tuple[str, str, str]]] = None
-    schema: Optional[Union[SchemaConfig, dict[str, list[Any]]]] = None
+    schema: Optional[Union[SchemaConfig, dict[str, list[Any]]]] = None  # type: ignore
     enforce_schema: SchemaEnforcementMode = SchemaEnforcementMode.NONE
     on_error: OnError = OnError.IGNORE
     prompt_template: Union[ERExtractionTemplate, str] = ERExtractionTemplate()
@@ -97,10 +97,10 @@ class SimpleKGPipelineConfig(TemplatePipelineConfig):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @model_validator(mode="after")
-    def handle_schema_precedence(self) -> T:
+    def handle_schema_precedence(self) -> T:  # type: ignore
         """Handle schema precedence and warnings"""
         self._process_schema_parameters()
-        return self
+        return self  # type: ignore
 
     def _process_schema_parameters(self) -> None:
         """
@@ -192,12 +192,12 @@ class SimpleKGPipelineConfig(TemplatePipelineConfig):
             if isinstance(self.schema, SchemaConfig):
                 # extract components from SchemaConfig
                 entities = list(self.schema.entities.values())
-                relations = list(self.schema.relations.values())
+                relations = list(self.schema.relations.values())  # type: ignore
                 potential_schema = self.schema.potential_schema
             else:
                 # extract from dictionary
                 entities = [
-                    SchemaEntity.from_text_or_dict(e)
+                    SchemaEntity.from_text_or_dict(e)  # type: ignore
                     for e in self.schema.get("entities", [])
                 ]
                 relations = [
@@ -208,7 +208,7 @@ class SimpleKGPipelineConfig(TemplatePipelineConfig):
         else:
             # use individual components
             entities = (
-                [SchemaEntity.from_text_or_dict(e) for e in self.entities]
+                [SchemaEntity.from_text_or_dict(e) for e in self.entities]  # type: ignore
                 if self.entities
                 else []
             )
@@ -219,7 +219,7 @@ class SimpleKGPipelineConfig(TemplatePipelineConfig):
             )
             potential_schema = self.potential_schema
 
-        return entities, relations, potential_schema
+        return entities, relations, potential_schema  # type: ignore
 
     def _get_run_params_for_schema(self) -> dict[str, Any]:
         if self.auto_schema_extraction and not self.has_user_provided_schema():

--- a/src/neo4j_graphrag/experimental/pipeline/config/template_pipeline/simple_kg_builder.py
+++ b/src/neo4j_graphrag/experimental/pipeline/config/template_pipeline/simple_kg_builder.py
@@ -81,7 +81,7 @@ class SimpleKGPipelineConfig(TemplatePipelineConfig):
     entities: Sequence[EntityInputType] = []
     relations: Sequence[RelationInputType] = []
     potential_schema: Optional[list[tuple[str, str, str]]] = None
-    schema: Optional[Union[SchemaConfig, dict[str, list]]] = None
+    schema: Optional[Union[SchemaConfig, dict[str, list[Any]]]] = None
     enforce_schema: SchemaEnforcementMode = SchemaEnforcementMode.NONE
     on_error: OnError = OnError.IGNORE
     prompt_template: Union[ERExtractionTemplate, str] = ERExtractionTemplate()

--- a/src/neo4j_graphrag/experimental/pipeline/kg_builder.py
+++ b/src/neo4j_graphrag/experimental/pipeline/kg_builder.py
@@ -15,7 +15,7 @@
 
 from __future__ import annotations
 
-from typing import List, Optional, Sequence, Union
+from typing import List, Optional, Sequence, Union, Any
 import logging
 
 import neo4j
@@ -92,7 +92,7 @@ class SimpleKGPipeline:
         entities: Optional[Sequence[EntityInputType]] = None,
         relations: Optional[Sequence[RelationInputType]] = None,
         potential_schema: Optional[List[tuple[str, str, str]]] = None,
-        schema: Optional[Union[SchemaConfig, dict[str, list]]] = None,
+        schema: Optional[Union[SchemaConfig, dict[str, list[Any]]]] = None,
         enforce_schema: str = "NONE",
         from_pdf: bool = True,
         text_splitter: Optional[TextSplitter] = None,

--- a/src/neo4j_graphrag/experimental/pipeline/kg_builder.py
+++ b/src/neo4j_graphrag/experimental/pipeline/kg_builder.py
@@ -47,6 +47,7 @@ from neo4j_graphrag.experimental.components.schema import SchemaConfig
 
 logger = logging.getLogger(__name__)
 
+
 class SimpleKGPipeline:
     """
     A class to simplify the process of building a knowledge graph from text documents.
@@ -123,7 +124,9 @@ class SimpleKGPipeline:
                 perform_entity_resolution=perform_entity_resolution,
                 lexical_graph_config=lexical_graph_config,
                 neo4j_database=neo4j_database,
-                auto_schema_extraction=not bool(schema or entities or relations or potential_schema),
+                auto_schema_extraction=not bool(
+                    schema or entities or relations or potential_schema
+                ),
             )
         except (ValidationError, ValueError) as e:
             raise PipelineDefinitionError() from e

--- a/src/neo4j_graphrag/generation/__init__.py
+++ b/src/neo4j_graphrag/generation/__init__.py
@@ -1,8 +1,9 @@
 from .graphrag import GraphRAG
-from .prompts import PromptTemplate, RagTemplate
+from .prompts import PromptTemplate, RagTemplate, SchemaExtractionTemplate
 
 __all__ = [
     "GraphRAG",
     "PromptTemplate",
     "RagTemplate",
+    "SchemaExtractionTemplate"
 ]

--- a/src/neo4j_graphrag/generation/__init__.py
+++ b/src/neo4j_graphrag/generation/__init__.py
@@ -1,9 +1,4 @@
 from .graphrag import GraphRAG
 from .prompts import PromptTemplate, RagTemplate, SchemaExtractionTemplate
 
-__all__ = [
-    "GraphRAG",
-    "PromptTemplate",
-    "RagTemplate",
-    "SchemaExtractionTemplate"
-]
+__all__ = ["GraphRAG", "PromptTemplate", "RagTemplate", "SchemaExtractionTemplate"]

--- a/src/neo4j_graphrag/generation/prompts.py
+++ b/src/neo4j_graphrag/generation/prompts.py
@@ -200,3 +200,41 @@ Input text:
         text: str = "",
     ) -> str:
         return super().format(text=text, schema=schema, examples=examples)
+
+
+class SchemaExtractionTemplate(PromptTemplate):
+    DEFAULT_TEMPLATE = """
+You are a top-tier algorithm designed for extracting a labeled property graph schema in 
+structured formats.
+
+Generate the generalized graph schema based on input text. Identify key entity types,
+their relationship types, and property types whenever it is possible. Return only 
+abstract schema information, no concrete instances. Use singular PascalCase labels for 
+entity types and UPPER_SNAKE_CASE for relationship types. Include property definitions 
+only when the type can be confidently inferred, otherwise omit the properties. 
+Accepted property types are: BOOLEAN, DATE, DURATION, FLOAT, INTEGER, LIST, 
+LOCAL DATETIME, LOCAL TIME, POINT, STRING, ZONED DATETIME, ZONED TIME.
+Do not add extra keys or explanatory text. Return a valid JSON object without 
+back‑ticks, markdown, or comments.
+ 
+For example, if the text says "Alice lives in London", the output JSON object should 
+adhere to the following format: 
+{"entities": [{"label": "Person", "properties": [{"name": "name", "type": "STRING"}]}, 
+{"label": "City", "properties":[{"name": "name", "type": "STRING"}]}],
+"relations": [{"label": "LIVES_IN"}],
+"potential_schema":[[ "Person", "LIVES_IN", "City"]]}
+
+More examples:
+{examples}
+
+Input text:
+{text}
+"""
+    EXPECTED_INPUTS = ["text"]
+
+    def format(
+            self,
+            examples: str,
+            text: str = "",
+    ) -> str:
+        return super().format(text=text, examples=examples)

--- a/src/neo4j_graphrag/generation/prompts.py
+++ b/src/neo4j_graphrag/generation/prompts.py
@@ -219,10 +219,10 @@ back‑ticks, markdown, or comments.
  
 For example, if the text says "Alice lives in London", the output JSON object should 
 adhere to the following format: 
-{"entities": [{"label": "Person", "properties": [{"name": "name", "type": "STRING"}]}, 
-{"label": "City", "properties":[{"name": "name", "type": "STRING"}]}],
-"relations": [{"label": "LIVES_IN"}],
-"potential_schema":[[ "Person", "LIVES_IN", "City"]]}
+{{"entities": [{{"label": "Person", "properties": [{{"name": "name", "type": "STRING"}}]}}, 
+{{"label": "City", "properties":[{{"name": "name", "type": "STRING"}}]}}],
+"relations": [{{"label": "LIVES_IN"}}],
+"potential_schema":[[ "Person", "LIVES_IN", "City"]]}}
 
 More examples:
 {examples}
@@ -233,8 +233,8 @@ Input text:
     EXPECTED_INPUTS = ["text"]
 
     def format(
-            self,
-            examples: str,
-            text: str = "",
+        self,
+        text: str = "",
+        examples: str = "",
     ) -> str:
         return super().format(text=text, examples=examples)

--- a/tests/unit/experimental/components/test_schema.py
+++ b/tests/unit/experimental/components/test_schema.py
@@ -110,7 +110,7 @@ def schema_config(
     valid_entities: list[SchemaEntity],
     valid_relations: list[SchemaRelation],
     potential_schema: list[tuple[str, str, str]],
-):
+) -> SchemaConfig:
     return schema_builder.create_schema_model(
         valid_entities, valid_relations, potential_schema
     )
@@ -445,14 +445,14 @@ def test_create_schema_model_missing_relations(
 
 
 @pytest.fixture
-def mock_llm():
+def mock_llm() -> AsyncMock:
     mock = AsyncMock()
     mock.invoke = AsyncMock()
     return mock
 
 
 @pytest.fixture
-def valid_schema_json():
+def valid_schema_json() -> str:
     return """
     {
         "entities": [
@@ -485,7 +485,7 @@ def valid_schema_json():
 
 
 @pytest.fixture
-def invalid_schema_json():
+def invalid_schema_json() -> str:
     return """
     {
         "entities": [
@@ -499,14 +499,14 @@ def invalid_schema_json():
 
 
 @pytest.fixture
-def schema_from_text(mock_llm):
+def schema_from_text(mock_llm: AsyncMock) -> SchemaFromText:
     return SchemaFromText(llm=mock_llm)
 
 
 @pytest.mark.asyncio
 async def test_schema_from_text_run_valid_response(
-    schema_from_text, mock_llm, valid_schema_json
-):
+    schema_from_text: SchemaFromText, mock_llm: AsyncMock, valid_schema_json: str
+) -> None:
     # configure the mock LLM to return a valid schema JSON
     mock_llm.invoke.return_value = valid_schema_json
 
@@ -534,8 +534,8 @@ async def test_schema_from_text_run_valid_response(
 
 @pytest.mark.asyncio
 async def test_schema_from_text_run_invalid_json(
-    schema_from_text, mock_llm, invalid_schema_json
-):
+    schema_from_text: SchemaFromText, mock_llm: AsyncMock, invalid_schema_json: str
+) -> None:
     # configure the mock LLM to return invalid JSON
     mock_llm.invoke.return_value = invalid_schema_json
 
@@ -547,7 +547,9 @@ async def test_schema_from_text_run_invalid_json(
 
 
 @pytest.mark.asyncio
-async def test_schema_from_text_custom_template(mock_llm, valid_schema_json):
+async def test_schema_from_text_custom_template(
+    mock_llm: AsyncMock, valid_schema_json: str
+) -> None:
     # create a  custom template
     custom_prompt = "This is a custom prompt with text: {text}"
     custom_template = PromptTemplate(template=custom_prompt, expected_inputs=["text"])
@@ -567,7 +569,9 @@ async def test_schema_from_text_custom_template(mock_llm, valid_schema_json):
 
 
 @pytest.mark.asyncio
-async def test_schema_from_text_llm_params(mock_llm, valid_schema_json):
+async def test_schema_from_text_llm_params(
+    mock_llm: AsyncMock, valid_schema_json: str
+) -> None:
     # configure custom LLM parameters
     llm_params = {"temperature": 0.1, "max_tokens": 500}
 
@@ -588,7 +592,7 @@ async def test_schema_from_text_llm_params(mock_llm, valid_schema_json):
 
 
 @pytest.mark.asyncio
-async def test_schema_config_store_as_json(schema_config):
+async def test_schema_config_store_as_json(schema_config: SchemaConfig) -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         # create file path
         json_path = os.path.join(temp_dir, "schema.json")
@@ -614,7 +618,7 @@ async def test_schema_config_store_as_json(schema_config):
 
 
 @pytest.mark.asyncio
-async def test_schema_config_store_as_yaml(schema_config):
+async def test_schema_config_store_as_yaml(schema_config: SchemaConfig) -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         # Create file path
         yaml_path = os.path.join(temp_dir, "schema.yaml")
@@ -640,7 +644,7 @@ async def test_schema_config_store_as_yaml(schema_config):
 
 
 @pytest.mark.asyncio
-async def test_schema_config_from_file(schema_config):
+async def test_schema_config_from_file(schema_config: SchemaConfig) -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         # create file paths with different extensions
         json_path = os.path.join(temp_dir, "schema.json")

--- a/tests/unit/experimental/components/test_schema.py
+++ b/tests/unit/experimental/components/test_schema.py
@@ -14,6 +14,9 @@
 #  limitations under the License.
 from __future__ import annotations
 
+import json
+from unittest.mock import AsyncMock
+
 import pytest
 from neo4j_graphrag.exceptions import SchemaValidationError
 from neo4j_graphrag.experimental.components.schema import (
@@ -21,8 +24,16 @@ from neo4j_graphrag.experimental.components.schema import (
     SchemaEntity,
     SchemaProperty,
     SchemaRelation,
+    SchemaFromText,
+    SchemaConfig,
 )
 from pydantic import ValidationError
+import os
+import tempfile
+import yaml
+from pathlib import Path
+
+from neo4j_graphrag.generation import PromptTemplate
 
 
 @pytest.fixture
@@ -91,6 +102,18 @@ def potential_schema_with_invalid_relation() -> list[tuple[str, str, str]]:
 @pytest.fixture
 def schema_builder() -> SchemaBuilder:
     return SchemaBuilder()
+
+
+@pytest.fixture
+def schema_config(
+    schema_builder: SchemaBuilder,
+    valid_entities: list[SchemaEntity],
+    valid_relations: list[SchemaRelation],
+    potential_schema: list[tuple[str, str, str]],
+):
+    return schema_builder.create_schema_model(
+        valid_entities, valid_relations, potential_schema
+    )
 
 
 def test_create_schema_model_valid_data(
@@ -419,3 +442,224 @@ def test_create_schema_model_missing_relations(
     assert "Relations must also be provided when using a potential schema." in str(
         exc_info.value
     ), "Should fail due to missing relations"
+
+
+@pytest.fixture
+def mock_llm():
+    mock = AsyncMock()
+    mock.invoke = AsyncMock()
+    return mock
+
+
+@pytest.fixture
+def valid_schema_json():
+    return '''
+    {
+        "entities": [
+            {
+                "label": "Person",
+                "properties": [
+                    {"name": "name", "type": "STRING"}
+                ]
+            },
+            {
+                "label": "Organization",
+                "properties": [
+                    {"name": "name", "type": "STRING"}
+                ]
+            }
+        ],
+        "relations": [
+            {
+                "label": "WORKS_FOR",
+                "properties": [
+                    {"name": "since", "type": "DATE"}
+                ]
+            }
+        ],
+        "potential_schema": [
+            ["Person", "WORKS_FOR", "Organization"]
+        ]
+    }
+    '''
+
+
+@pytest.fixture
+def invalid_schema_json():
+    return '''
+    {
+        "entities": [
+            {
+                "label": "Person",
+            },
+        ],
+        invalid json content
+    }
+    '''
+
+
+@pytest.fixture
+def schema_from_text(mock_llm):
+    return SchemaFromText(llm=mock_llm)
+
+
+@pytest.mark.asyncio
+async def test_schema_from_text_run_valid_response(schema_from_text, mock_llm, valid_schema_json):
+    # configure the mock LLM to return a valid schema JSON
+    mock_llm.invoke.return_value = valid_schema_json
+    
+    # run the schema extraction
+    schema_config = await schema_from_text.run(text="Sample text for extraction")
+    
+    # verify the LLM was called with a prompt
+    mock_llm.invoke.assert_called_once()
+    prompt_arg = mock_llm.invoke.call_args[0][0]
+    assert isinstance(prompt_arg, str)
+    assert "Sample text for extraction" in prompt_arg
+    
+    # verify the schema was correctly extracted
+    assert len(schema_config.entities) == 2
+    assert "Person" in schema_config.entities
+    assert "Organization" in schema_config.entities
+    
+    assert schema_config.relations is not None
+    assert "WORKS_FOR" in schema_config.relations
+    
+    assert schema_config.potential_schema is not None
+    assert len(schema_config.potential_schema) == 1
+    assert schema_config.potential_schema[0] == ("Person", "WORKS_FOR", "Organization")
+
+
+@pytest.mark.asyncio
+async def test_schema_from_text_run_invalid_json(schema_from_text, mock_llm, invalid_schema_json):
+    # configure the mock LLM to return invalid JSON
+    mock_llm.invoke.return_value = invalid_schema_json
+    
+    # verify that running with invalid JSON raises a ValueError
+    with pytest.raises(ValueError) as exc_info:
+        await schema_from_text.run(text="Sample text for extraction")
+    
+    assert "not valid JSON" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_schema_from_text_custom_template(mock_llm, valid_schema_json):
+    # create a  custom template 
+    custom_prompt = "This is a custom prompt with text: {text}"
+    custom_template = PromptTemplate(template=custom_prompt, expected_inputs=["text"])
+    
+    # create SchemaFromText with the custom template
+    schema_from_text = SchemaFromText(llm=mock_llm, prompt_template=custom_template)
+    
+    # configure mock LLM to return valid JSON and capture the prompt that was sent to it
+    mock_llm.invoke.return_value = valid_schema_json
+
+    # run the schema extraction
+    await schema_from_text.run(text="Sample text")
+
+    # verify the custom prompt was passed to the LLM
+    prompt_sent_to_llm = mock_llm.invoke.call_args[0][0]
+    assert "This is a custom prompt with text" in prompt_sent_to_llm
+
+
+@pytest.mark.asyncio
+async def test_schema_from_text_llm_params(mock_llm, valid_schema_json):
+    # configure custom LLM parameters
+    llm_params = {"temperature": 0.1, "max_tokens": 500}
+
+    # create SchemaFromText with custom LLM parameters
+    schema_from_text = SchemaFromText(llm=mock_llm, llm_params=llm_params)
+
+    # configure the mock LLM to return a valid schema JSON
+    mock_llm.invoke.return_value = valid_schema_json
+
+    # run the schema extraction
+    await schema_from_text.run(text="Sample text")
+    
+    # verify the LLM was called with the custom parameters
+    mock_llm.invoke.assert_called_once()
+    call_kwargs = mock_llm.invoke.call_args[1]
+    assert call_kwargs["temperature"] == 0.1
+    assert call_kwargs["max_tokens"] == 500
+
+
+@pytest.mark.asyncio
+async def test_schema_config_store_as_json(schema_config):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # create file path
+        json_path = os.path.join(temp_dir, "schema.json")
+        
+        # store the schema config
+        schema_config.store_as_json(json_path)
+        
+        # verify the file exists and has content
+        assert os.path.exists(json_path)
+        assert os.path.getsize(json_path) > 0
+        
+        # verify the content is valid JSON and contains expected data
+        with open(json_path, 'r') as f:
+            data = json.load(f)
+            assert "entities" in data
+            assert "PERSON" in data["entities"]
+            assert "properties" in data["entities"]["PERSON"]
+            assert "description" in data["entities"]["PERSON"]
+            assert data["entities"]["PERSON"]["description"] == "An individual human being."
+
+
+@pytest.mark.asyncio
+async def test_schema_config_store_as_yaml(schema_config):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Create file path
+        yaml_path = os.path.join(temp_dir, "schema.yaml")
+        
+        # Store the schema config
+        schema_config.store_as_yaml(yaml_path)
+        
+        # Verify the file exists and has content
+        assert os.path.exists(yaml_path)
+        assert os.path.getsize(yaml_path) > 0
+        
+        # Verify the content is valid YAML and contains expected data
+        with open(yaml_path, 'r') as f:
+            data = yaml.safe_load(f)
+            assert "entities" in data
+            assert "PERSON" in data["entities"]
+            assert "properties" in data["entities"]["PERSON"]
+            assert "description" in data["entities"]["PERSON"]
+            assert data["entities"]["PERSON"]["description"] == "An individual human being."
+
+
+@pytest.mark.asyncio
+async def test_schema_config_from_file(schema_config):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # create file paths with different extensions
+        json_path = os.path.join(temp_dir, "schema.json")
+        yaml_path = os.path.join(temp_dir, "schema.yaml")
+        yml_path = os.path.join(temp_dir, "schema.yml")
+        
+        # store the schema config in the different formats
+        schema_config.store_as_json(json_path)
+        schema_config.store_as_yaml(yaml_path)
+        schema_config.store_as_yaml(yml_path)
+        
+        # load using from_file which should detect the format based on extension
+        json_schema = SchemaConfig.from_file(json_path)
+        yaml_schema = SchemaConfig.from_file(yaml_path)
+        yml_schema = SchemaConfig.from_file(yml_path)
+        
+        # simple verification that the objects were loaded correctly
+        assert isinstance(json_schema, SchemaConfig)
+        assert isinstance(yaml_schema, SchemaConfig)
+        assert isinstance(yml_schema, SchemaConfig)
+        
+        # verify basic structure is intact
+        assert "entities" in json_schema.model_dump()
+        assert "entities" in yaml_schema.model_dump()
+        assert "entities" in yml_schema.model_dump()
+        
+        # verify an unsupported extension raises the correct error
+        txt_path = os.path.join(temp_dir, "schema.txt")
+        schema_config.store_as_json(txt_path)  # Store as JSON but with .txt extension
+        
+        with pytest.raises(ValueError, match="Unsupported file format"):
+            SchemaConfig.from_file(txt_path)


### PR DESCRIPTION
# Description

This PR adds support for automatic schema extraction using LLMs:
- New `SchemaFromText` component that uses LLM to analyse text and automatically extract a guiding schema, which can be used later in entity/relation extraction
- New `schema` parameter in SimpleKGPipeline that replaces deprecated individual schema parameters (i.e., `entities`, `relations`, `potential_schema`), which can be now provided manually or from the output of LLM (as `SchemaConfig` object)
- Automatic schema extraction in `SimpleKGPipeline` when no schema is provided
- Configurable behaviour with `auto_schema_extraction` flag (so far added to `SimpleKGPipelineConfig` only i.e., configurable from config files)
- Methods for saving and loading inferred schemas  (added to `SchemaConfig` Class)

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Medium

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
- [x] CHANGELOG.md updated if appropriate
