### PR TITLE
Refactor SchemaConfig -> GraphSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changed
 
+- `SchemaConfig` has been deprecated in favor of `GraphSchema` (used in the `SchemaBuilder` and `EntityRelationExtractor` classes).
 - Strict mode in `SimpleKGPipeline`: now properties and relationships are pruned only if they are defined in the input schema.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,16 @@
 
 ### Changed
 
-- `SchemaConfig` has been deprecated in favor of `GraphSchema` (used in the `SchemaBuilder` and `EntityRelationExtractor` classes).
+#### Strict mode
+
 - Strict mode in `SimpleKGPipeline`: now properties and relationships are pruned only if they are defined in the input schema.
+
+#### Schema definition
+
+- The `SchemaEntity` model has been renamed `NodeType`.
+- The `SchemaRelation` model has been renamed `RelationshipType`.
+- The `SchemaProperty` model has been renamed `PropertyType`.
+- `SchemaConfig` has been removed in favor of `GraphSchema` (used in the `SchemaBuilder` and `EntityRelationExtractor` classes). `entities`, `relations` and `potential_schema` fields have also been renamed `node_types`, `relationship_types` and `patterns` respectively.
 
 
 ## 1.7.0

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ kg_builder = SimpleKGPipeline(
     schema={
         "node_types": node_types,
         "relationship_types": relationship_types,
+        "patterns": patterns,
     },
     on_error="IGNORE",
     from_pdf=False,

--- a/README.md
+++ b/README.md
@@ -128,8 +128,10 @@ kg_builder = SimpleKGPipeline(
     llm=llm,
     driver=driver,
     embedder=embedder,
-    entities=entities,
-    relations=relations,
+    schema={
+        "entities": entities,
+        "relations": relations,
+    },
     on_error="IGNORE",
     from_pdf=False,
 )
@@ -365,7 +367,7 @@ When you're finished with your changes, create a pull request (PR) using the fol
 
 ## 🧪 Tests
 
-To be able to run all tests, all extra packages needs to be installed.  
+To be able to run all tests, all extra packages needs to be installed.
 This is achieved by:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ NEO4J_PASSWORD = "password"
 driver = GraphDatabase.driver(NEO4J_URI, auth=(NEO4J_USERNAME, NEO4J_PASSWORD))
 
 # List the entities and relations the LLM should look for in the text
-entities = ["Person", "House", "Planet"]
-relations = ["PARENT_OF", "HEIR_OF", "RULES"]
-potential_schema = [
+node_types = ["Person", "House", "Planet"]
+relationship_types = ["PARENT_OF", "HEIR_OF", "RULES"]
+patterns = [
     ("Person", "PARENT_OF", "Person"),
     ("Person", "HEIR_OF", "House"),
     ("House", "RULES", "Planet"),
@@ -129,8 +129,8 @@ kg_builder = SimpleKGPipeline(
     driver=driver,
     embedder=embedder,
     schema={
-        "entities": entities,
-        "relations": relations,
+        "node_types": node_types,
+        "relationship_types": relationship_types,
     },
     on_error="IGNORE",
     from_pdf=False,

--- a/docs/source/types.rst
+++ b/docs/source/types.rst
@@ -75,20 +75,20 @@ KGWriterModel
 
 .. autoclass:: neo4j_graphrag.experimental.components.kg_writer.KGWriterModel
 
-SchemaProperty
-==============
-
-.. autoclass:: neo4j_graphrag.experimental.components.schema.SchemaProperty
-
-SchemaEntity
+PropertyType
 ============
 
-.. autoclass:: neo4j_graphrag.experimental.components.schema.SchemaEntity
+.. autoclass:: neo4j_graphrag.experimental.components.schema.PropertyType
 
-SchemaRelation
-==============
+NodeType
+========
 
-.. autoclass:: neo4j_graphrag.experimental.components.schema.SchemaRelation
+.. autoclass:: neo4j_graphrag.experimental.components.schema.NodeType
+
+RelationshipType
+================
+
+.. autoclass:: neo4j_graphrag.experimental.components.schema.RelationshipType
 
 GraphSchema
 ===========

--- a/docs/source/types.rst
+++ b/docs/source/types.rst
@@ -90,10 +90,10 @@ SchemaRelation
 
 .. autoclass:: neo4j_graphrag.experimental.components.schema.SchemaRelation
 
-SchemaConfig
-============
+GraphSchema
+===========
 
-.. autoclass:: neo4j_graphrag.experimental.components.schema.SchemaConfig
+.. autoclass:: neo4j_graphrag.experimental.components.schema.GraphSchema
 
 LexicalGraphConfig
 ===================

--- a/docs/source/user_guide_kg_builder.rst
+++ b/docs/source/user_guide_kg_builder.rst
@@ -102,7 +102,7 @@ as shown below:
         {"label": "RULES", "properties": [{"name": "fromYear", "type": "INTEGER"}]},
     ]
 
-The `patterns` is defined by a list of triplet in the format:
+The `patterns` are defined by a list of triplet in the format:
 `(source_node_label, relationship_label, target_node_label)`. For instance:
 
 

--- a/docs/source/user_guide_kg_builder.rst
+++ b/docs/source/user_guide_kg_builder.rst
@@ -21,7 +21,7 @@ A Knowledge Graph (KG) construction pipeline requires a few components (some of 
 - **Data loader**: extract text from files (PDFs, ...).
 - **Text splitter**: split the text into smaller pieces of text (chunks), manageable by the LLM context window (token limit).
 - **Chunk embedder** (optional): compute the chunk embeddings.
-- **Schema builder**: provide a schema to ground the LLM extracted entities and relations and obtain an easily navigable KG. Schema can be provided manually or extracted automatically using LLMs.
+- **Schema builder**: provide a schema to ground the LLM extracted node and relationship types and obtain an easily navigable KG. Schema can be provided manually or extracted automatically using LLMs.
 - **Lexical graph builder**: build the lexical graph (Document, Chunk and their relationships) (optional).
 - **Entity and relation extractor**: extract relevant entities and relations from the text.
 - **Knowledge Graph writer**: save the identified entities and relations.
@@ -73,18 +73,18 @@ Customizing the SimpleKGPipeline
 Graph Schema
 ------------
 
-It is possible to guide the LLM by supplying a list of entities, relationships,
-and instructions on how to connect them. However, note that the extracted graph
+It is possible to guide the LLM by supplying a list of node and relationship types,
+and instructions on how to connect them (patterns). However, note that the extracted graph
 may not fully adhere to these guidelines unless schema enforcement is enabled
-(see :ref:`Schema Enforcement Behaviour`). Entities and relationships can be represented
+(see :ref:`Schema Enforcement Behaviour`). Node and relationship types can be represented
 as either simple strings (for their labels) or dictionaries. If using a dictionary,
 it must include a label key and can optionally include description and properties keys,
 as shown below:
 
 .. code:: python
 
-    ENTITIES = [
-        # entities can be defined with a simple label...
+    NODE_TYPES = [
+        # node types can be defined with a simple label...
         "Person",
         # ... or with a dict if more details are needed,
         # such as a description:
@@ -93,7 +93,7 @@ as shown below:
         {"label": "Planet", "properties": [{"name": "weather", "type": "STRING"}]},
     ]
     # same thing for relationships:
-    RELATIONS = [
+    RELATIONSHIP_TYPES = [
         "PARENT_OF",
         {
             "label": "HEIR_OF",
@@ -102,13 +102,13 @@ as shown below:
         {"label": "RULES", "properties": [{"name": "fromYear", "type": "INTEGER"}]},
     ]
 
-The `potential_schema` is defined by a list of triplet in the format:
+The `patterns` is defined by a list of triplet in the format:
 `(source_node_label, relationship_label, target_node_label)`. For instance:
 
 
 .. code:: python
 
-    POTENTIAL_SCHEMA = [
+    PATTERNS = [
         ("Person", "PARENT_OF", "Person"),
         ("Person", "HEIR_OF", "House"),
         ("House", "RULES", "Planet"),
@@ -122,15 +122,15 @@ This schema information can be provided to the `SimpleKGBuilder` as demonstrated
     kg_builder = SimpleKGPipeline(
         # ...
         schema={
-            "entities": ENTITIES,
-            "relations": RELATIONS,
-            "potential_schema": POTENTIAL_SCHEMA
+            "node_types": NODE_TYPES,
+            "relationship_types": RELATIONSHIP_TYPES,
+            "patterns": PATTERNS
         },
         # ...
     )
 
 .. note::
-   By default, if no schema is provided to the SimpleKGPipeline, automatic schema extraction will be performed using the LLM (See the :ref:`Automatic Schema Extraction with SchemaFromTextExtractor`).
+   By default, if no schema is provided to the SimpleKGPipeline, automatic schema extraction will be performed using the LLM (See the :ref:`Automatic Schema Extraction`).
 
 Extra configurations
 --------------------
@@ -419,9 +419,8 @@ within the configuration file.
         "neo4j_database": "myDb",
         "on_error": "IGNORE",
         "prompt_template": "...",
-
         "schema": {
-            "entities": [
+            "node_types": [
                 "Person",
                 {
                     "label": "House",
@@ -438,7 +437,7 @@ within the configuration file.
                     ]
                 }
             ],
-            "relations": [
+            "relationship_types": [
                 "PARENT_OF",
                 {
                     "label": "HEIR_OF",
@@ -451,7 +450,7 @@ within the configuration file.
                     ]
                 }
             ],
-            "potential_schema": [
+            "patterns": [
                 ["Person", "PARENT_OF", "Person"],
                 ["Person", "HEIR_OF", "House"],
                 ["House", "RULES", "Planet"]
@@ -473,7 +472,7 @@ or in YAML:
     on_error: IGNORE
     prompt_template: ...
     schema:
-      entities:
+      node_types:
         - Person
         - label: House
           description: Family the person belongs to
@@ -486,7 +485,7 @@ or in YAML:
               type: STRING
             - name: weather
               type: STRING
-      relations:
+      relationship_types:
         - PARENT_OF
         - label: HEIR_OF
           description: Used for inheritor relationship between father and sons
@@ -494,7 +493,7 @@ or in YAML:
           properties:
             - name: fromYear
               type: INTEGER
-      potential_schema:
+      patterns:
         - ["Person", "PARENT_OF", "Person"]
         - ["Person", "HEIR_OF", "House"]
         - ["House", "RULES", "Planet"]
@@ -747,12 +746,12 @@ Optionally, the document and chunk node labels can be configured using a `Lexica
 Schema Builder
 ==============
 
-The schema is used to try and ground the LLM to a list of possible entities and relations of interest.
+The schema is used to try and ground the LLM to a list of possible node and relationship types of interest.
 So far, schema must be manually created by specifying:
 
-- **Entities** the LLM should look for in the text, including their properties (name and type).
-- **Relations** of interest between these entities, including the relation properties (name and type).
-- **Triplets** to define the start (source) and end (target) entity types for each relation.
+- **Node types** the LLM should look for in the text, including their properties (name and type).
+- **Relationship types** of interest between these node types, including the relationship properties (name and type).
+- **Patterns** (triplets) to define the start (source) and end (target) entity types for each relationship.
 
 Here is a code block illustrating these concepts:
 
@@ -760,16 +759,16 @@ Here is a code block illustrating these concepts:
 
     from neo4j_graphrag.experimental.components.schema import (
         SchemaBuilder,
-        SchemaEntity,
-        SchemaProperty,
-        SchemaRelation,
+        NodeType,
+        PropertyType,
+        RelationshipType,
     )
 
     schema_builder = SchemaBuilder()
 
     await schema_builder.run(
-        entities=[
-            SchemaEntity(
+        node_types=[
+            NodeType(
                 label="Person",
                 properties=[
                     SchemaProperty(name="name", type="STRING"),
@@ -777,7 +776,7 @@ Here is a code block illustrating these concepts:
                     SchemaProperty(name="date_of_birth", type="DATE"),
                 ],
             ),
-            SchemaEntity(
+            NodeType(
                 label="Organization",
                 properties=[
                     SchemaProperty(name="name", type="STRING"),
@@ -785,15 +784,15 @@ Here is a code block illustrating these concepts:
                 ],
             ),
         ],
-        relations=[
-            SchemaRelation(
+        relationship_types=[
+            RelationshipType(
                 label="WORKED_ON",
             ),
-            SchemaRelation(
+            RelationshipType(
                 label="WORKED_FOR",
             ),
         ],
-        possible_schema=[
+        patterns=[
             ("Person", "WORKED_ON", "Field"),
             ("Person", "WORKED_FOR", "Organization"),
         ],

--- a/docs/source/user_guide_kg_builder.rst
+++ b/docs/source/user_guide_kg_builder.rst
@@ -75,7 +75,7 @@ Graph Schema
 
 It is possible to guide the LLM by supplying a list of entities, relationships,
 and instructions on how to connect them. However, note that the extracted graph
-may not fully adhere to these guidelines unless schema enforcement is enabled 
+may not fully adhere to these guidelines unless schema enforcement is enabled
 (see :ref:`Schema Enforcement Behaviour`). Entities and relationships can be represented
 as either simple strings (for their labels) or dictionaries. If using a dictionary,
 it must include a label key and can optionally include description and properties keys,
@@ -419,7 +419,7 @@ within the configuration file.
         "neo4j_database": "myDb",
         "on_error": "IGNORE",
         "prompt_template": "...",
-        
+
         "schema": {
             "entities": [
                 "Person",
@@ -799,10 +799,10 @@ Here is a code block illustrating these concepts:
         ],
     )
 
-After validation, this schema is saved in a `SchemaConfig` object, whose dict representation is passed
+After validation, this schema is saved in a `GraphSchema` object, whose dict representation is passed
 to the LLM.
 
-Automatic Schema Extraction 
+Automatic Schema Extraction
 ---------------------------
 
 Instead of manually defining the schema, you can use the `SchemaFromTextExtractor` component to automatically extract a schema from your text using an LLM:
@@ -826,19 +826,19 @@ Instead of manually defining the schema, you can use the `SchemaFromTextExtracto
     # Extract the schema from the text
     extracted_schema = await schema_extractor.run(text="Some text")
 
-The `SchemaFromTextExtractor` component analyzes the text and identifies entity types, relationship types, and their property types. It creates a complete `SchemaConfig` object that can be used in the same way as a manually defined schema.
+The `SchemaFromTextExtractor` component analyzes the text and identifies entity types, relationship types, and their property types. It creates a complete `GraphSchema` object that can be used in the same way as a manually defined schema.
 
 You can also save and reload the extracted schema:
 
 .. code:: python
 
     # Save the schema to JSON or YAML files
-    schema_config.store_as_json("my_schema.json")
-    schema_config.store_as_yaml("my_schema.yaml")
-    
+    extracted_schema.store_as_json("my_schema.json")
+    extracted_schema.store_as_yaml("my_schema.yaml")
+
     # Later, reload the schema from file
-    from neo4j_graphrag.experimental.components.schema import SchemaConfig
-    restored_schema = SchemaConfig.from_file("my_schema.json")  # or my_schema.yaml
+    from neo4j_graphrag.experimental.components.schema import GraphSchema
+    restored_schema = GraphSchema.from_file("my_schema.json")  # or my_schema.yaml
 
 
 Entity and Relation Extractor
@@ -993,7 +993,6 @@ If more customization is needed, it is possible to subclass the `EntityRelationE
 
     from pydantic import validate_call
     from neo4j_graphrag.experimental.components.entity_relation_extractor import EntityRelationExtractor
-    from neo4j_graphrag.experimental.components.schema import SchemaConfig
     from neo4j_graphrag.experimental.components.types import (
         Neo4jGraph,
         Neo4jNode,

--- a/examples/build_graph/simple_kg_builder_from_pdf.py
+++ b/examples/build_graph/simple_kg_builder_from_pdf.py
@@ -47,9 +47,11 @@ async def define_and_run_pipeline(
         llm=llm,
         driver=neo4j_driver,
         embedder=OpenAIEmbeddings(),
-        entities=ENTITIES,
-        relations=RELATIONS,
-        potential_schema=POTENTIAL_SCHEMA,
+        schema={
+            "entities": ENTITIES,
+            "relations": RELATIONS,
+            "potential_schema": POTENTIAL_SCHEMA,
+        },
         neo4j_database=DATABASE,
     )
     return await kg_builder.run_async(file_path=str(file_path))

--- a/examples/build_graph/simple_kg_builder_from_pdf.py
+++ b/examples/build_graph/simple_kg_builder_from_pdf.py
@@ -27,11 +27,11 @@ root_dir = Path(__file__).parents[1]
 file_path = root_dir / "data" / "Harry Potter and the Chamber of Secrets Summary.pdf"
 
 
-# Instantiate Entity and Relation objects. This defines the
+# Instantiate NodeType and RelationshipType objects. This defines the
 # entities and relations the LLM will be looking for in the text.
-ENTITIES = ["Person", "Organization", "Location"]
-RELATIONS = ["SITUATED_AT", "INTERACTS", "LED_BY"]
-POTENTIAL_SCHEMA = [
+NODE_TYPES = ["Person", "Organization", "Location"]
+RELATIONSHIP_TYPES = ["SITUATED_AT", "INTERACTS", "LED_BY"]
+PATTERNS = [
     ("Person", "SITUATED_AT", "Location"),
     ("Person", "INTERACTS", "Person"),
     ("Organization", "LED_BY", "Person"),
@@ -48,9 +48,9 @@ async def define_and_run_pipeline(
         driver=neo4j_driver,
         embedder=OpenAIEmbeddings(),
         schema={
-            "entities": ENTITIES,
-            "relations": RELATIONS,
-            "potential_schema": POTENTIAL_SCHEMA,
+            "node_types": NODE_TYPES,
+            "relationship_types": RELATIONSHIP_TYPES,
+            "patterns": PATTERNS,
         },
         neo4j_database=DATABASE,
     )

--- a/examples/build_graph/simple_kg_builder_from_text.py
+++ b/examples/build_graph/simple_kg_builder_from_text.py
@@ -71,9 +71,11 @@ async def define_and_run_pipeline(
         llm=llm,
         driver=neo4j_driver,
         embedder=OpenAIEmbeddings(),
-        entities=ENTITIES,
-        relations=RELATIONS,
-        potential_schema=POTENTIAL_SCHEMA,
+        schema={
+            "entities": ENTITIES,
+            "relations": RELATIONS,
+            "potential_schema": POTENTIAL_SCHEMA,
+        },
         from_pdf=False,
         neo4j_database=DATABASE,
     )

--- a/examples/build_graph/simple_kg_builder_from_text.py
+++ b/examples/build_graph/simple_kg_builder_from_text.py
@@ -37,7 +37,7 @@ an aristocratic family that rules the planet Caladan, the rainy planet, since 10
 
 # Instantiate Entity and Relation objects. This defines the
 # entities and relations the LLM will be looking for in the text.
-ENTITIES: list[EntityInputType] = [
+NODE_TYPES: list[EntityInputType] = [
     # entities can be defined with a simple label...
     "Person",
     # ... or with a dict if more details are needed,
@@ -47,7 +47,7 @@ ENTITIES: list[EntityInputType] = [
     {"label": "Planet", "properties": [{"name": "weather", "type": "STRING"}]},
 ]
 # same thing for relationships:
-RELATIONS: list[RelationInputType] = [
+RELATIONSHIP_TYPES: list[RelationInputType] = [
     "PARENT_OF",
     {
         "label": "HEIR_OF",
@@ -55,7 +55,7 @@ RELATIONS: list[RelationInputType] = [
     },
     {"label": "RULES", "properties": [{"name": "fromYear", "type": "INTEGER"}]},
 ]
-POTENTIAL_SCHEMA = [
+PATTERNS = [
     ("Person", "PARENT_OF", "Person"),
     ("Person", "HEIR_OF", "House"),
     ("House", "RULES", "Planet"),
@@ -72,9 +72,9 @@ async def define_and_run_pipeline(
         driver=neo4j_driver,
         embedder=OpenAIEmbeddings(),
         schema={
-            "entities": ENTITIES,
-            "relations": RELATIONS,
-            "potential_schema": POTENTIAL_SCHEMA,
+            "node_types": NODE_TYPES,
+            "relationship_types": RELATIONSHIP_TYPES,
+            "patterns": PATTERNS,
         },
         from_pdf=False,
         neo4j_database=DATABASE,

--- a/examples/customize/build_graph/components/schema_builders/schema.py
+++ b/examples/customize/build_graph/components/schema_builders/schema.py
@@ -14,43 +14,44 @@
 #  limitations under the License.
 from neo4j_graphrag.experimental.components.schema import (
     SchemaBuilder,
-    SchemaEntity,
-    SchemaProperty,
-    SchemaRelation,
+    NodeType,
+    PropertyType,
+    RelationshipType,
 )
 
 
 async def main() -> None:
     schema_builder = SchemaBuilder()
 
-    await schema_builder.run(
-        entities=[
-            SchemaEntity(
+    result = await schema_builder.run(
+        node_types=[
+            NodeType(
                 label="Person",
                 properties=[
-                    SchemaProperty(name="name", type="STRING"),
-                    SchemaProperty(name="place_of_birth", type="STRING"),
-                    SchemaProperty(name="date_of_birth", type="DATE"),
+                    PropertyType(name="name", type="STRING"),
+                    PropertyType(name="place_of_birth", type="STRING"),
+                    PropertyType(name="date_of_birth", type="DATE"),
                 ],
             ),
-            SchemaEntity(
+            NodeType(
                 label="Organization",
                 properties=[
-                    SchemaProperty(name="name", type="STRING"),
-                    SchemaProperty(name="country", type="STRING"),
+                    PropertyType(name="name", type="STRING"),
+                    PropertyType(name="country", type="STRING"),
                 ],
             ),
         ],
-        relations=[
-            SchemaRelation(
+        relationship_types=[
+            RelationshipType(
                 label="WORKED_ON",
             ),
-            SchemaRelation(
+            RelationshipType(
                 label="WORKED_FOR",
             ),
         ],
-        potential_schema=[
+        patterns=[
             ("Person", "WORKED_ON", "Field"),
             ("Person", "WORKED_FOR", "Organization"),
         ],
     )
+    print(result)

--- a/examples/customize/build_graph/components/schema_builders/schema_from_text.py
+++ b/examples/customize/build_graph/components/schema_builders/schema_from_text.py
@@ -92,14 +92,14 @@ async def extract_and_save_schema() -> None:
         inferred_schema.store_as_yaml(YAML_FILE_PATH)
 
         print("\nExtracted Schema Summary:")
-        print(f"Entities: {list(inferred_schema.entities)}")
+        print(f"Node types: {list(inferred_schema.node_types)}")
         print(
-            f"Relations: {list(inferred_schema.relations if inferred_schema.relations else [])}"
+            f"Relationship types: {list(inferred_schema.relationship_types if inferred_schema.relationship_types else [])}"
         )
 
-        if inferred_schema.potential_schema:
-            print("\nPotential Schema:")
-            for entity1, relation, entity2 in inferred_schema.potential_schema:
+        if inferred_schema.patterns:
+            print("\nPatterns:")
+            for entity1, relation, entity2 in inferred_schema.patterns:
                 print(f"  {entity1} --[{relation}]--> {entity2}")
 
     finally:
@@ -122,8 +122,8 @@ async def main() -> None:
     schema_from_json = GraphSchema.from_file(JSON_FILE_PATH)
     schema_from_yaml = GraphSchema.from_file(YAML_FILE_PATH)
 
-    print(f"Entities in JSON schema: {list(schema_from_json.entities)}")
-    print(f"Entities in YAML schema: {list(schema_from_yaml.entities)}")
+    print(f"Node types in JSON schema: {list(schema_from_json.node_types)}")
+    print(f"Node types in YAML schema: {list(schema_from_yaml.node_types)}")
 
 
 if __name__ == "__main__":

--- a/examples/customize/build_graph/components/schema_builders/schema_from_text.py
+++ b/examples/customize/build_graph/components/schema_builders/schema_from_text.py
@@ -14,7 +14,7 @@ from dotenv import load_dotenv
 
 from neo4j_graphrag.experimental.components.schema import (
     SchemaFromTextExtractor,
-    SchemaConfig,
+    GraphSchema,
 )
 from neo4j_graphrag.llm import OpenAILLM
 
@@ -27,25 +27,25 @@ logging.getLogger("neo4j_graphrag").setLevel(logging.INFO)
 
 # Sample text to extract schema from - it's about a company and its employees
 TEXT = """
-Acme Corporation was founded in 1985 by John Smith in New York City. 
-The company specializes in manufacturing high-quality widgets and gadgets 
+Acme Corporation was founded in 1985 by John Smith in New York City.
+The company specializes in manufacturing high-quality widgets and gadgets
 for the consumer electronics industry.
 
-Sarah Johnson joined Acme in 2010 as a Senior Engineer and was promoted to 
-Engineering Director in 2015. She oversees a team of 12 engineers working on 
-next-generation products. Sarah holds a PhD in Electrical Engineering from MIT 
+Sarah Johnson joined Acme in 2010 as a Senior Engineer and was promoted to
+Engineering Director in 2015. She oversees a team of 12 engineers working on
+next-generation products. Sarah holds a PhD in Electrical Engineering from MIT
 and has filed 5 patents during her time at Acme.
 
-The company expanded to international markets in 2012, opening offices in London, 
-Tokyo, and Berlin. Each office is managed by a regional director who reports 
+The company expanded to international markets in 2012, opening offices in London,
+Tokyo, and Berlin. Each office is managed by a regional director who reports
 directly to the CEO, Michael Brown, who took over leadership in 2008.
 
-Acme's most successful product, the SuperWidget X1, was launched in 2018 and 
-has sold over 2 million units worldwide. The product was developed by a team led 
+Acme's most successful product, the SuperWidget X1, was launched in 2018 and
+has sold over 2 million units worldwide. The product was developed by a team led
 by Robert Chen, who joined the company in 2016 after working at TechGiant for 8 years.
 
-The company currently employs 250 people across its 4 locations and had a revenue 
-of $75 million in the last fiscal year. Acme is planning to go public in 2024 
+The company currently employs 250 people across its 4 locations and had a revenue
+of $75 million in the last fiscal year. Acme is planning to go public in 2024
 with an estimated valuation of $500 million.
 """
 
@@ -92,9 +92,9 @@ async def extract_and_save_schema() -> None:
         inferred_schema.store_as_yaml(YAML_FILE_PATH)
 
         print("\nExtracted Schema Summary:")
-        print(f"Entities: {list(inferred_schema.entities.keys())}")
+        print(f"Entities: {list(inferred_schema.entities)}")
         print(
-            f"Relations: {list(inferred_schema.relations.keys() if inferred_schema.relations else [])}"
+            f"Relations: {list(inferred_schema.relations if inferred_schema.relations else [])}"
         )
 
         if inferred_schema.potential_schema:
@@ -119,11 +119,11 @@ async def main() -> None:
 
     # load schema from files
     print("\nLoading schemas from saved files:")
-    schema_from_json = SchemaConfig.from_file(JSON_FILE_PATH)
-    schema_from_yaml = SchemaConfig.from_file(YAML_FILE_PATH)
+    schema_from_json = GraphSchema.from_file(JSON_FILE_PATH)
+    schema_from_yaml = GraphSchema.from_file(YAML_FILE_PATH)
 
-    print(f"Entities in JSON schema: {list(schema_from_json.entities.keys())}")
-    print(f"Entities in YAML schema: {list(schema_from_yaml.entities.keys())}")
+    print(f"Entities in JSON schema: {list(schema_from_json.entities)}")
+    print(f"Entities in YAML schema: {list(schema_from_yaml.entities)}")
 
 
 if __name__ == "__main__":

--- a/examples/customize/build_graph/pipeline/kg_builder_from_pdf.py
+++ b/examples/customize/build_graph/pipeline/kg_builder_from_pdf.py
@@ -25,8 +25,8 @@ from neo4j_graphrag.experimental.components.kg_writer import Neo4jWriter
 from neo4j_graphrag.experimental.components.pdf_loader import PdfLoader
 from neo4j_graphrag.experimental.components.schema import (
     SchemaBuilder,
-    SchemaEntity,
-    SchemaRelation,
+    NodeType,
+    RelationshipType,
 )
 from neo4j_graphrag.experimental.components.text_splitters.fixed_size_splitter import (
     FixedSizeSplitter,
@@ -45,35 +45,35 @@ async def define_and_run_pipeline(
     from neo4j_graphrag.experimental.pipeline import Pipeline
 
     # Instantiate Entity and Relation objects
-    entities = [
-        SchemaEntity(label="PERSON", description="An individual human being."),
-        SchemaEntity(
+    node_types = [
+        NodeType(label="PERSON", description="An individual human being."),
+        NodeType(
             label="ORGANIZATION",
             description="A structured group of people with a common purpose.",
         ),
-        SchemaEntity(label="LOCATION", description="A location or place."),
-        SchemaEntity(
+        NodeType(label="LOCATION", description="A location or place."),
+        NodeType(
             label="HORCRUX",
             description="A magical item in the Harry Potter universe.",
         ),
     ]
-    relations = [
-        SchemaRelation(
+    relationship_types = [
+        RelationshipType(
             label="SITUATED_AT", description="Indicates the location of a person."
         ),
-        SchemaRelation(
+        RelationshipType(
             label="LED_BY",
             description="Indicates the leader of an organization.",
         ),
-        SchemaRelation(
+        RelationshipType(
             label="OWNS",
             description="Indicates the ownership of an item such as a Horcrux.",
         ),
-        SchemaRelation(
+        RelationshipType(
             label="INTERACTS", description="The interaction between two people."
         ),
     ]
-    potential_schema = [
+    patterns = [
         ("PERSON", "SITUATED_AT", "LOCATION"),
         ("PERSON", "INTERACTS", "PERSON"),
         ("PERSON", "OWNS", "HORCRUX"),
@@ -114,12 +114,12 @@ async def define_and_run_pipeline(
 
     pipe_inputs = {
         "pdf_loader": {
-            "filepath": "examples/pipeline/Harry Potter and the Death Hallows Summary.pdf"
+            "filepath": "examples/data/Harry Potter and the Death Hallows Summary.pdf"
         },
         "schema": {
-            "entities": entities,
-            "relations": relations,
-            "potential_schema": potential_schema,
+            "node_types": node_types,
+            "relationship_types": relationship_types,
+            "patterns": patterns,
         },
     }
     return await pipe.run(pipe_inputs)

--- a/examples/customize/build_graph/pipeline/kg_builder_from_text.py
+++ b/examples/customize/build_graph/pipeline/kg_builder_from_text.py
@@ -25,9 +25,9 @@ from neo4j_graphrag.experimental.components.entity_relation_extractor import (
 from neo4j_graphrag.experimental.components.kg_writer import Neo4jWriter
 from neo4j_graphrag.experimental.components.schema import (
     SchemaBuilder,
-    SchemaEntity,
-    SchemaProperty,
-    SchemaRelation,
+    NodeType,
+    PropertyType,
+    RelationshipType,
 )
 from neo4j_graphrag.experimental.components.text_splitters.fixed_size_splitter import (
     FixedSizeSplitter,
@@ -95,38 +95,38 @@ async def define_and_run_pipeline(
             the University of Bern in Switzerland and the University of Oxford."""
         },
         "schema": {
-            "entities": [
-                SchemaEntity(
+            "node_types": [
+                NodeType(
                     label="Person",
                     properties=[
-                        SchemaProperty(name="name", type="STRING"),
-                        SchemaProperty(name="place_of_birth", type="STRING"),
-                        SchemaProperty(name="date_of_birth", type="DATE"),
+                        PropertyType(name="name", type="STRING"),
+                        PropertyType(name="place_of_birth", type="STRING"),
+                        PropertyType(name="date_of_birth", type="DATE"),
                     ],
                 ),
-                SchemaEntity(
+                NodeType(
                     label="Organization",
                     properties=[
-                        SchemaProperty(name="name", type="STRING"),
-                        SchemaProperty(name="country", type="STRING"),
+                        PropertyType(name="name", type="STRING"),
+                        PropertyType(name="country", type="STRING"),
                     ],
                 ),
-                SchemaEntity(
+                NodeType(
                     label="Field",
                     properties=[
-                        SchemaProperty(name="name", type="STRING"),
+                        PropertyType(name="name", type="STRING"),
                     ],
                 ),
             ],
-            "relations": [
-                SchemaRelation(
+            "relationship_types": [
+                RelationshipType(
                     label="WORKED_ON",
                 ),
-                SchemaRelation(
+                RelationshipType(
                     label="WORKED_FOR",
                 ),
             ],
-            "potential_schema": [
+            "patterns": [
                 ("Person", "WORKED_ON", "Field"),
                 ("Person", "WORKED_FOR", "Organization"),
             ],

--- a/examples/customize/build_graph/pipeline/kg_builder_two_documents_entity_resolution.py
+++ b/examples/customize/build_graph/pipeline/kg_builder_two_documents_entity_resolution.py
@@ -28,9 +28,9 @@ from neo4j_graphrag.experimental.components.resolver import (
 )
 from neo4j_graphrag.experimental.components.schema import (
     SchemaBuilder,
-    SchemaEntity,
-    SchemaProperty,
-    SchemaRelation,
+    NodeType,
+    PropertyType,
+    RelationshipType,
 )
 from neo4j_graphrag.experimental.components.text_splitters.fixed_size_splitter import (
     FixedSizeSplitter,
@@ -92,35 +92,35 @@ async def define_and_run_pipeline(
     pipe_inputs = {
         "loader": {},
         "schema": {
-            "entities": [
-                SchemaEntity(
+            "node_types": [
+                NodeType(
                     label="Person",
                     properties=[
-                        SchemaProperty(name="name", type="STRING"),
-                        SchemaProperty(name="place_of_birth", type="STRING"),
-                        SchemaProperty(name="date_of_birth", type="DATE"),
+                        PropertyType(name="name", type="STRING"),
+                        PropertyType(name="place_of_birth", type="STRING"),
+                        PropertyType(name="date_of_birth", type="DATE"),
                     ],
                 ),
-                SchemaEntity(
+                NodeType(
                     label="Organization",
                     properties=[
-                        SchemaProperty(name="name", type="STRING"),
-                        SchemaProperty(name="country", type="STRING"),
+                        PropertyType(name="name", type="STRING"),
+                        PropertyType(name="country", type="STRING"),
                     ],
                 ),
             ],
-            "relations": [
-                SchemaRelation(
+            "relationship_types": [
+                RelationshipType(
                     label="WORKED_FOR",
                 ),
-                SchemaRelation(
+                RelationshipType(
                     label="FRIEND",
                 ),
-                SchemaRelation(
+                RelationshipType(
                     label="ENEMY",
                 ),
             ],
-            "potential_schema": [
+            "patterns": [
                 ("Person", "WORKED_FOR", "Organization"),
                 ("Person", "FRIEND", "Person"),
                 ("Person", "ENEMY", "Person"),
@@ -129,8 +129,8 @@ async def define_and_run_pipeline(
     }
     # run the pipeline for each documents
     for document in [
-        "examples/pipeline/Harry Potter and the Chamber of Secrets Summary.pdf",
-        "examples/pipeline/Harry Potter and the Death Hallows Summary.pdf",
+        "examples/data/Harry Potter and the Chamber of Secrets Summary.pdf",
+        "examples/data/Harry Potter and the Death Hallows Summary.pdf",
     ]:
         pipe_inputs["loader"]["filepath"] = document
         await pipe.run(pipe_inputs)

--- a/examples/customize/build_graph/pipeline/text_to_lexical_graph_to_entity_graph_single_pipeline.py
+++ b/examples/customize/build_graph/pipeline/text_to_lexical_graph_to_entity_graph_single_pipeline.py
@@ -16,9 +16,9 @@ from neo4j_graphrag.experimental.components.kg_writer import Neo4jWriter
 from neo4j_graphrag.experimental.components.lexical_graph import LexicalGraphBuilder
 from neo4j_graphrag.experimental.components.schema import (
     SchemaBuilder,
-    SchemaEntity,
-    SchemaProperty,
-    SchemaRelation,
+    NodeType,
+    PropertyType,
+    RelationshipType,
 )
 from neo4j_graphrag.experimental.components.text_splitters.fixed_size_splitter import (
     FixedSizeSplitter,
@@ -118,38 +118,38 @@ async def define_and_run_pipeline(
             },
         },
         "schema": {
-            "entities": [
-                SchemaEntity(
+            "node_types": [
+                NodeType(
                     label="Person",
                     properties=[
-                        SchemaProperty(name="name", type="STRING"),
-                        SchemaProperty(name="place_of_birth", type="STRING"),
-                        SchemaProperty(name="date_of_birth", type="DATE"),
+                        PropertyType(name="name", type="STRING"),
+                        PropertyType(name="place_of_birth", type="STRING"),
+                        PropertyType(name="date_of_birth", type="DATE"),
                     ],
                 ),
-                SchemaEntity(
+                NodeType(
                     label="Organization",
                     properties=[
-                        SchemaProperty(name="name", type="STRING"),
-                        SchemaProperty(name="country", type="STRING"),
+                        PropertyType(name="name", type="STRING"),
+                        PropertyType(name="country", type="STRING"),
                     ],
                 ),
-                SchemaEntity(
+                NodeType(
                     label="Field",
                     properties=[
-                        SchemaProperty(name="name", type="STRING"),
+                        PropertyType(name="name", type="STRING"),
                     ],
                 ),
             ],
-            "relations": [
-                SchemaRelation(
+            "relationship_types": [
+                RelationshipType(
                     label="WORKED_ON",
                 ),
-                SchemaRelation(
+                RelationshipType(
                     label="WORKED_FOR",
                 ),
             ],
-            "potential_schema": [
+            "patterns": [
                 ("Person", "WORKED_ON", "Field"),
                 ("Person", "WORKED_FOR", "Organization"),
             ],

--- a/examples/customize/build_graph/pipeline/text_to_lexical_graph_to_entity_graph_two_pipelines.py
+++ b/examples/customize/build_graph/pipeline/text_to_lexical_graph_to_entity_graph_two_pipelines.py
@@ -18,9 +18,9 @@ from neo4j_graphrag.experimental.components.lexical_graph import LexicalGraphBui
 from neo4j_graphrag.experimental.components.neo4j_reader import Neo4jChunkReader
 from neo4j_graphrag.experimental.components.schema import (
     SchemaBuilder,
-    SchemaEntity,
-    SchemaProperty,
-    SchemaRelation,
+    NodeType,
+    PropertyType,
+    RelationshipType,
 )
 from neo4j_graphrag.experimental.components.text_splitters.fixed_size_splitter import (
     FixedSizeSplitter,
@@ -138,38 +138,38 @@ async def read_chunk_and_perform_entity_extraction(
             "lexical_graph_config": lexical_graph_config,
         },
         "schema": {
-            "entities": [
-                SchemaEntity(
+            "node_types": [
+                NodeType(
                     label="Person",
                     properties=[
-                        SchemaProperty(name="name", type="STRING"),
-                        SchemaProperty(name="place_of_birth", type="STRING"),
-                        SchemaProperty(name="date_of_birth", type="DATE"),
+                        PropertyType(name="name", type="STRING"),
+                        PropertyType(name="place_of_birth", type="STRING"),
+                        PropertyType(name="date_of_birth", type="DATE"),
                     ],
                 ),
-                SchemaEntity(
+                NodeType(
                     label="Organization",
                     properties=[
-                        SchemaProperty(name="name", type="STRING"),
-                        SchemaProperty(name="country", type="STRING"),
+                        PropertyType(name="name", type="STRING"),
+                        PropertyType(name="country", type="STRING"),
                     ],
                 ),
-                SchemaEntity(
+                NodeType(
                     label="Field",
                     properties=[
-                        SchemaProperty(name="name", type="STRING"),
+                        PropertyType(name="name", type="STRING"),
                     ],
                 ),
             ],
-            "relations": [
-                SchemaRelation(
+            "relationship_types": [
+                RelationshipType(
                     label="WORKED_ON",
                 ),
-                SchemaRelation(
+                RelationshipType(
                     label="WORKED_FOR",
                 ),
             ],
-            "potential_schema": [
+            "patterns": [
                 ("Person", "WORKED_ON", "Field"),
                 ("Person", "WORKED_FOR", "Organization"),
             ],

--- a/examples/data/extracted_schema.json
+++ b/examples/data/extracted_schema.json
@@ -1,6 +1,6 @@
 {
-  "entities": {
-    "Company": {
+  "entities": [
+    {
       "label": "Company",
       "description": "",
       "properties": [
@@ -26,7 +26,7 @@
         }
       ]
     },
-    "Person": {
+    {
       "label": "Person",
       "description": "",
       "properties": [
@@ -41,13 +41,13 @@
           "description": ""
         },
         {
-          "name": "yearJoined",
+          "name": "startYear",
           "type": "INTEGER",
           "description": ""
         }
       ]
     },
-    "Product": {
+    {
       "label": "Product",
       "description": "",
       "properties": [
@@ -67,46 +67,30 @@
           "description": ""
         }
       ]
-    },
-    "Office": {
-      "label": "Office",
-      "description": "",
-      "properties": [
-        {
-          "name": "location",
-          "type": "STRING",
-          "description": ""
-        }
-      ]
     }
-  },
-  "relations": {
-    "FOUNDED_BY": {
+  ],
+  "relations": [
+    {
       "label": "FOUNDED_BY",
       "description": "",
       "properties": []
     },
-    "WORKS_FOR": {
+    {
       "label": "WORKS_FOR",
       "description": "",
       "properties": []
     },
-    "MANAGES": {
+    {
       "label": "MANAGES",
       "description": "",
       "properties": []
     },
-    "DEVELOPED_BY": {
+    {
       "label": "DEVELOPED_BY",
       "description": "",
       "properties": []
-    },
-    "LOCATED_IN": {
-      "label": "LOCATED_IN",
-      "description": "",
-      "properties": []
     }
-  },
+  ],
   "potential_schema": [
     [
       "Company",
@@ -121,17 +105,12 @@
     [
       "Person",
       "MANAGES",
-      "Office"
+      "Company"
     ],
     [
       "Product",
       "DEVELOPED_BY",
       "Person"
-    ],
-    [
-      "Company",
-      "LOCATED_IN",
-      "Office"
     ]
   ]
 }

--- a/examples/data/extracted_schema.json
+++ b/examples/data/extracted_schema.json
@@ -1,5 +1,26 @@
 {
-  "entities": [
+  "node_types": [
+    {
+      "label": "Person",
+      "description": "",
+      "properties": [
+        {
+          "name": "name",
+          "type": "STRING",
+          "description": ""
+        },
+        {
+          "name": "position",
+          "type": "STRING",
+          "description": ""
+        },
+        {
+          "name": "startYear",
+          "type": "INTEGER",
+          "description": ""
+        }
+      ]
+    },
     {
       "label": "Company",
       "description": "",
@@ -27,27 +48,6 @@
       ]
     },
     {
-      "label": "Person",
-      "description": "",
-      "properties": [
-        {
-          "name": "name",
-          "type": "STRING",
-          "description": ""
-        },
-        {
-          "name": "position",
-          "type": "STRING",
-          "description": ""
-        },
-        {
-          "name": "startYear",
-          "type": "INTEGER",
-          "description": ""
-        }
-      ]
-    },
-    {
       "label": "Product",
       "description": "",
       "properties": [
@@ -67,14 +67,20 @@
           "description": ""
         }
       ]
+    },
+    {
+      "label": "Office",
+      "description": "",
+      "properties": [
+        {
+          "name": "location",
+          "type": "STRING",
+          "description": ""
+        }
+      ]
     }
   ],
-  "relations": [
-    {
-      "label": "FOUNDED_BY",
-      "description": "",
-      "properties": []
-    },
+  "relationship_types": [
     {
       "label": "WORKS_FOR",
       "description": "",
@@ -89,14 +95,14 @@
       "label": "DEVELOPED_BY",
       "description": "",
       "properties": []
+    },
+    {
+      "label": "LOCATED_IN",
+      "description": "",
+      "properties": []
     }
   ],
-  "potential_schema": [
-    [
-      "Company",
-      "FOUNDED_BY",
-      "Person"
-    ],
+  "patterns": [
     [
       "Person",
       "WORKS_FOR",
@@ -105,12 +111,17 @@
     [
       "Person",
       "MANAGES",
-      "Company"
+      "Office"
     ],
     [
       "Product",
       "DEVELOPED_BY",
       "Person"
+    ],
+    [
+      "Company",
+      "LOCATED_IN",
+      "Office"
     ]
   ]
 }

--- a/examples/data/extracted_schema.yaml
+++ b/examples/data/extracted_schema.yaml
@@ -1,4 +1,16 @@
-entities:
+node_types:
+- label: Person
+  description: ''
+  properties:
+  - name: name
+    type: STRING
+    description: ''
+  - name: position
+    type: STRING
+    description: ''
+  - name: startYear
+    type: INTEGER
+    description: ''
 - label: Company
   description: ''
   properties:
@@ -14,18 +26,6 @@ entities:
   - name: valuation
     type: FLOAT
     description: ''
-- label: Person
-  description: ''
-  properties:
-  - name: name
-    type: STRING
-    description: ''
-  - name: position
-    type: STRING
-    description: ''
-  - name: startYear
-    type: INTEGER
-    description: ''
 - label: Product
   description: ''
   properties:
@@ -38,10 +38,13 @@ entities:
   - name: unitsSold
     type: INTEGER
     description: ''
-relations:
-- label: FOUNDED_BY
+- label: Office
   description: ''
-  properties: []
+  properties:
+  - name: location
+    type: STRING
+    description: ''
+relationship_types:
 - label: WORKS_FOR
   description: ''
   properties: []
@@ -51,16 +54,19 @@ relations:
 - label: DEVELOPED_BY
   description: ''
   properties: []
-potential_schema:
-- - Company
-  - FOUNDED_BY
-  - Person
+- label: LOCATED_IN
+  description: ''
+  properties: []
+patterns:
 - - Person
   - WORKS_FOR
   - Company
 - - Person
   - MANAGES
-  - Company
+  - Office
 - - Product
   - DEVELOPED_BY
   - Person
+- - Company
+  - LOCATED_IN
+  - Office

--- a/examples/data/extracted_schema.yaml
+++ b/examples/data/extracted_schema.yaml
@@ -1,74 +1,56 @@
 entities:
-  Company:
-    label: Company
+- label: Company
+  description: ''
+  properties:
+  - name: name
+    type: STRING
     description: ''
-    properties:
-    - name: name
-      type: STRING
-      description: ''
-    - name: foundedYear
-      type: INTEGER
-      description: ''
-    - name: revenue
-      type: FLOAT
-      description: ''
-    - name: valuation
-      type: FLOAT
-      description: ''
-  Person:
-    label: Person
+  - name: foundedYear
+    type: INTEGER
     description: ''
-    properties:
-    - name: name
-      type: STRING
-      description: ''
-    - name: position
-      type: STRING
-      description: ''
-    - name: yearJoined
-      type: INTEGER
-      description: ''
-  Product:
-    label: Product
+  - name: revenue
+    type: FLOAT
     description: ''
-    properties:
-    - name: name
-      type: STRING
-      description: ''
-    - name: launchYear
-      type: INTEGER
-      description: ''
-    - name: unitsSold
-      type: INTEGER
-      description: ''
-  Office:
-    label: Office
+  - name: valuation
+    type: FLOAT
     description: ''
-    properties:
-    - name: location
-      type: STRING
-      description: ''
+- label: Person
+  description: ''
+  properties:
+  - name: name
+    type: STRING
+    description: ''
+  - name: position
+    type: STRING
+    description: ''
+  - name: startYear
+    type: INTEGER
+    description: ''
+- label: Product
+  description: ''
+  properties:
+  - name: name
+    type: STRING
+    description: ''
+  - name: launchYear
+    type: INTEGER
+    description: ''
+  - name: unitsSold
+    type: INTEGER
+    description: ''
 relations:
-  FOUNDED_BY:
-    label: FOUNDED_BY
-    description: ''
-    properties: []
-  WORKS_FOR:
-    label: WORKS_FOR
-    description: ''
-    properties: []
-  MANAGES:
-    label: MANAGES
-    description: ''
-    properties: []
-  DEVELOPED_BY:
-    label: DEVELOPED_BY
-    description: ''
-    properties: []
-  LOCATED_IN:
-    label: LOCATED_IN
-    description: ''
-    properties: []
+- label: FOUNDED_BY
+  description: ''
+  properties: []
+- label: WORKS_FOR
+  description: ''
+  properties: []
+- label: MANAGES
+  description: ''
+  properties: []
+- label: DEVELOPED_BY
+  description: ''
+  properties: []
 potential_schema:
 - - Company
   - FOUNDED_BY
@@ -78,10 +60,7 @@ potential_schema:
   - Company
 - - Person
   - MANAGES
-  - Office
+  - Company
 - - Product
   - DEVELOPED_BY
   - Person
-- - Company
-  - LOCATED_IN
-  - Office

--- a/examples/kg_builder.py
+++ b/examples/kg_builder.py
@@ -32,8 +32,8 @@ from neo4j_graphrag.experimental.components.kg_writer import Neo4jWriter
 from neo4j_graphrag.experimental.components.pdf_loader import PdfLoader
 from neo4j_graphrag.experimental.components.schema import (
     SchemaBuilder,
-    SchemaEntity,
-    SchemaRelation,
+    NodeType,
+    RelationshipType,
 )
 from neo4j_graphrag.experimental.components.text_splitters.fixed_size_splitter import (
     FixedSizeSplitter,
@@ -50,35 +50,35 @@ async def define_and_run_pipeline(
     from neo4j_graphrag.experimental.pipeline import Pipeline
 
     # Instantiate Entity and Relation objects
-    entities = [
-        SchemaEntity(label="PERSON", description="An individual human being."),
-        SchemaEntity(
+    node_types = [
+        NodeType(label="PERSON", description="An individual human being."),
+        NodeType(
             label="ORGANIZATION",
             description="A structured group of people with a common purpose.",
         ),
-        SchemaEntity(label="LOCATION", description="A location or place."),
-        SchemaEntity(
+        NodeType(label="LOCATION", description="A location or place."),
+        NodeType(
             label="HORCRUX",
             description="A magical item in the Harry Potter universe.",
         ),
     ]
-    relations = [
-        SchemaRelation(
+    relationship_types = [
+        RelationshipType(
             label="SITUATED_AT", description="Indicates the location of a person."
         ),
-        SchemaRelation(
+        RelationshipType(
             label="LED_BY",
             description="Indicates the leader of an organization.",
         ),
-        SchemaRelation(
+        RelationshipType(
             label="OWNS",
             description="Indicates the ownership of an item such as a Horcrux.",
         ),
-        SchemaRelation(
+        RelationshipType(
             label="INTERACTS", description="The interaction between two people."
         ),
     ]
-    potential_schema = [
+    patterns = [
         ("PERSON", "SITUATED_AT", "LOCATION"),
         ("PERSON", "INTERACTS", "PERSON"),
         ("PERSON", "OWNS", "HORCRUX"),
@@ -121,9 +121,9 @@ async def define_and_run_pipeline(
             "filepath": "examples/pipeline/Harry Potter and the Death Hallows Summary.pdf"
         },
         "schema": {
-            "entities": entities,
-            "relations": relations,
-            "potential_schema": potential_schema,
+            "node_types": node_types,
+            "relationship_types": relationship_types,
+            "patterns": patterns,
         },
     }
     return await pipe.run(pipe_inputs)

--- a/src/neo4j_graphrag/experimental/components/entity_relation_extractor.py
+++ b/src/neo4j_graphrag/experimental/components/entity_relation_extractor.py
@@ -325,9 +325,7 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
             lexical_graph = lexical_graph_result.graph
         elif lexical_graph_config:
             lexical_graph_builder = LexicalGraphBuilder(config=lexical_graph_config)
-        schema = schema or GraphSchema(
-            entities=(), relations=(), potential_schema=()
-        )
+        schema = schema or GraphSchema(entities=(), relations=(), potential_schema=())
         examples = examples or ""
         sem = asyncio.Semaphore(self.max_concurrency)
         tasks = [

--- a/src/neo4j_graphrag/experimental/components/entity_relation_extractor.py
+++ b/src/neo4j_graphrag/experimental/components/entity_relation_extractor.py
@@ -441,7 +441,7 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
         if self.enforce_schema != SchemaEnforcementMode.STRICT:
             return extracted_relationships
 
-        if schema.relations is None:
+        if schema.relationship_types is None:
             return extracted_relationships
 
         valid_rels = []

--- a/src/neo4j_graphrag/experimental/components/entity_relation_extractor.py
+++ b/src/neo4j_graphrag/experimental/components/entity_relation_extractor.py
@@ -25,7 +25,7 @@ from pydantic import ValidationError, validate_call
 
 from neo4j_graphrag.exceptions import LLMGenerationError
 from neo4j_graphrag.experimental.components.lexical_graph import LexicalGraphBuilder
-from neo4j_graphrag.experimental.components.schema import SchemaConfig
+from neo4j_graphrag.experimental.components.schema import GraphSchema, SchemaProperty
 from neo4j_graphrag.experimental.components.types import (
     DocumentInfo,
     LexicalGraphConfig,
@@ -209,7 +209,7 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
         self.prompt_template = template
 
     async def extract_for_chunk(
-        self, schema: SchemaConfig, examples: str, chunk: TextChunk
+        self, schema: GraphSchema, examples: str, chunk: TextChunk
     ) -> Neo4jGraph:
         """Run entity extraction for a given text chunk."""
         prompt = self.prompt_template.format(
@@ -275,7 +275,7 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
         self,
         sem: asyncio.Semaphore,
         chunk: TextChunk,
-        schema: SchemaConfig,
+        schema: GraphSchema,
         examples: str,
         lexical_graph_builder: Optional[LexicalGraphBuilder] = None,
     ) -> Neo4jGraph:
@@ -296,7 +296,7 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
         chunks: TextChunks,
         document_info: Optional[DocumentInfo] = None,
         lexical_graph_config: Optional[LexicalGraphConfig] = None,
-        schema: Union[SchemaConfig, None] = None,
+        schema: Union[GraphSchema, None] = None,
         examples: str = "",
         **kwargs: Any,
     ) -> Neo4jGraph:
@@ -311,7 +311,7 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
             chunks (TextChunks): List of text chunks to extract entities and relations from.
             document_info (Optional[DocumentInfo], optional): Document the chunks are coming from. Used in the lexical graph creation step.
             lexical_graph_config (Optional[LexicalGraphConfig], optional): Lexical graph configuration to customize node labels and relationship types in the lexical graph.
-            schema (SchemaConfig | None): Definition of the schema to guide the LLM in its extraction.
+            schema (GraphSchema | None): Definition of the schema to guide the LLM in its extraction.
             examples (str): Examples for few-shot learning in the prompt.
         """
         lexical_graph_builder = None
@@ -325,7 +325,7 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
             lexical_graph = lexical_graph_result.graph
         elif lexical_graph_config:
             lexical_graph_builder = LexicalGraphBuilder(config=lexical_graph_config)
-        schema = schema or SchemaConfig(entities={}, relations={}, potential_schema=[])
+        schema = schema or GraphSchema(entities=[], relations=[], potential_schema=[])
         examples = examples or ""
         sem = asyncio.Semaphore(self.max_concurrency)
         tasks = [
@@ -344,7 +344,7 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
         return graph
 
     def validate_chunk(
-        self, chunk_graph: Neo4jGraph, schema: SchemaConfig
+        self, chunk_graph: Neo4jGraph, schema: GraphSchema
     ) -> Neo4jGraph:
         """
         Perform validation after entity and relation extraction:
@@ -363,7 +363,7 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
     def _clean_graph(
         self,
         graph: Neo4jGraph,
-        schema: SchemaConfig,
+        schema: GraphSchema,
     ) -> Neo4jGraph:
         """
         Verify that the graph conforms to the provided schema.
@@ -385,7 +385,7 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
         return Neo4jGraph(nodes=filtered_nodes, relationships=filtered_rels)
 
     def _enforce_nodes(
-        self, extracted_nodes: List[Neo4jNode], schema: SchemaConfig
+        self, extracted_nodes: List[Neo4jNode], schema: GraphSchema
     ) -> List[Neo4jNode]:
         """
         Filter extracted nodes to be conformant to the schema.
@@ -400,10 +400,10 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
         valid_nodes = []
 
         for node in extracted_nodes:
-            schema_entity = schema.entities.get(node.label)
+            schema_entity = schema.entity_from_label(node.label)
             if not schema_entity:
                 continue
-            allowed_props = schema_entity.get("properties")
+            allowed_props = schema_entity.properties or []
             if allowed_props:
                 filtered_props = self._enforce_properties(
                     node.properties, allowed_props
@@ -426,7 +426,7 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
         self,
         extracted_relationships: List[Neo4jRelationship],
         filtered_nodes: List[Neo4jNode],
-        schema: SchemaConfig,
+        schema: GraphSchema,
     ) -> List[Neo4jRelationship]:
         """
         Filter extracted nodes to be conformant to the schema.
@@ -451,12 +451,14 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
         for rel in extracted_relationships:
             schema_relation = schema.relations.get(rel.type)
             if not schema_relation:
+                logger.debug(f"PRUNING:: {rel} as {rel.type} is not in the schema")
                 continue
 
             if (
                 rel.start_node_id not in valid_nodes
                 or rel.end_node_id not in valid_nodes
             ):
+                logger.debug(f"PRUNING:: {rel} as one of {rel.start_node_id} and {rel.end_node_id} is not in the graph")
                 continue
 
             start_label = valid_nodes[rel.start_node_id]
@@ -472,9 +474,10 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
                 ) in potential_schema
 
                 if not tuple_valid and not reverse_tuple_valid:
+                    logger.debug(f"PRUNING:: {rel} not in the potential schema")
                     continue
 
-            allowed_props = schema_relation.get("properties")
+            allowed_props = schema_relation.properties or []
             if allowed_props:
                 filtered_props = self._enforce_properties(rel.properties, allowed_props)
             else:
@@ -493,13 +496,13 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
         return valid_rels
 
     def _enforce_properties(
-        self, properties: Dict[str, Any], valid_properties: List[Dict[str, Any]]
+        self, properties: Dict[str, Any], valid_properties: List[SchemaProperty]
     ) -> Dict[str, Any]:
         """
         Filter properties.
         Keep only those that exist in schema (i.e., valid properties).
         """
-        valid_prop_names = {prop["name"] for prop in valid_properties}
+        valid_prop_names = {prop.name for prop in valid_properties}
         return {
             key: value for key, value in properties.items() if key in valid_prop_names
         }

--- a/src/neo4j_graphrag/experimental/components/entity_relation_extractor.py
+++ b/src/neo4j_graphrag/experimental/components/entity_relation_extractor.py
@@ -326,7 +326,7 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
         elif lexical_graph_config:
             lexical_graph_builder = LexicalGraphBuilder(config=lexical_graph_config)
         schema = schema or GraphSchema(
-            entities=frozenset(), relations=frozenset(), potential_schema=frozenset()
+            entities=(), relations=(), potential_schema=()
         )
         examples = examples or ""
         sem = asyncio.Semaphore(self.max_concurrency)

--- a/src/neo4j_graphrag/experimental/components/entity_relation_extractor.py
+++ b/src/neo4j_graphrag/experimental/components/entity_relation_extractor.py
@@ -325,7 +325,9 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
             lexical_graph = lexical_graph_result.graph
         elif lexical_graph_config:
             lexical_graph_builder = LexicalGraphBuilder(config=lexical_graph_config)
-        schema = schema or GraphSchema(entities=[], relations=[], potential_schema=[])
+        schema = schema or GraphSchema(
+            entities=frozenset(), relations=frozenset(), potential_schema=frozenset()
+        )
         examples = examples or ""
         sem = asyncio.Semaphore(self.max_concurrency)
         tasks = [
@@ -458,7 +460,9 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
                 rel.start_node_id not in valid_nodes
                 or rel.end_node_id not in valid_nodes
             ):
-                logger.debug(f"PRUNING:: {rel} as one of {rel.start_node_id} and {rel.end_node_id} is not in the graph")
+                logger.debug(
+                    f"PRUNING:: {rel} as one of {rel.start_node_id} or {rel.end_node_id} is not in the graph"
+                )
                 continue
 
             start_label = valid_nodes[rel.start_node_id]

--- a/src/neo4j_graphrag/experimental/components/schema.py
+++ b/src/neo4j_graphrag/experimental/components/schema.py
@@ -324,9 +324,9 @@ class SchemaBuilder(Component):
         and a Dictionary defining potential relationships.
 
         Args:
-            entities (List[SchemaEntity]): List of Entity objects.
-            relations (Optional[List[SchemaRelation]]): List of Relation objects.
-            potential_schema (Optional[List[Tuple[str, str, str]]]): Dictionary mapping entity names to Lists of relation names.
+            entities (Sequence[SchemaEntity]): List or tuple of SchemaEntity objects.
+            relations (Optional[Sequence[SchemaRelation]]): List or tuple of SchemaRelation objects.
+            potential_schema (Optional[Sequence[Tuple[str, str, str]]]): List or tuples of triplets: (source_entity_label, relation_label, target_entity_label).
 
         Returns:
             GraphSchema: A configured schema object.
@@ -353,9 +353,9 @@ class SchemaBuilder(Component):
         Asynchronously constructs and returns a GraphSchema object.
 
         Args:
-            entities (List[SchemaEntity]): List of Entity objects.
-            relations (List[SchemaRelation]): List of Relation objects.
-            potential_schema (Dict[str, List[str]]): Dictionary mapping entity names to Lists of relation names.
+            entities (Sequence[SchemaEntity]): List or tuple of SchemaEntity objects.
+            relations (Sequence[SchemaRelation]): List or tuple of SchemaRelation objects.
+            potential_schema (Optional[Sequence[Tuple[str, str, str]]]): List or tuples of triplets: (source_entity_label, relation_label, target_entity_label).
 
         Returns:
             GraphSchema: A configured schema object, constructed asynchronously.

--- a/src/neo4j_graphrag/experimental/components/schema.py
+++ b/src/neo4j_graphrag/experimental/components/schema.py
@@ -367,7 +367,7 @@ class SchemaBuilder(Component):
 
 class SchemaFromTextExtractor(Component):
     """
-    A component for constructing SchemaConfig objects from the output of an LLM after
+    A component for constructing GraphSchema objects from the output of an LLM after
     automatic schema extraction from text.
     """
 

--- a/src/neo4j_graphrag/experimental/pipeline/config/template_pipeline/simple_kg_builder.py
+++ b/src/neo4j_graphrag/experimental/pipeline/config/template_pipeline/simple_kg_builder.py
@@ -108,14 +108,6 @@ class SimpleKGPipelineConfig(TemplatePipelineConfig):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    @model_validator(mode="before")
-    def normalize_schema_field(cls, data: Dict[str, Any]) -> Dict[str, Any]:
-        # Normalize the 'schema' field if it is a dict
-        schema = data.get("schema")
-        if isinstance(schema, dict):
-            data["schema"] = normalize_schema_dict(schema)
-        return data
-
     @model_validator(mode="after")
     def handle_schema_precedence(self) -> Self:
         """Handle schema precedence and warnings"""

--- a/src/neo4j_graphrag/experimental/pipeline/config/template_pipeline/simple_kg_builder.py
+++ b/src/neo4j_graphrag/experimental/pipeline/config/template_pipeline/simple_kg_builder.py
@@ -220,9 +220,9 @@ class SimpleKGPipelineConfig(TemplatePipelineConfig):
                 )
                 relationship_types = tuple(
                     RelationshipType.from_text_or_dict(r)
-                    for r in self.schema_.get("node_types", ())
+                    for r in self.schema_.get("relationship_types", ())
                 )
-                ps = self.schema_.get("potential_schema")
+                ps = self.schema_.get("patterns")
                 patterns = tuple(ps) if ps else None
         else:
             # use individual components

--- a/src/neo4j_graphrag/experimental/pipeline/config/template_pipeline/simple_kg_builder.py
+++ b/src/neo4j_graphrag/experimental/pipeline/config/template_pipeline/simple_kg_builder.py
@@ -218,15 +218,11 @@ class SimpleKGPipelineConfig(TemplatePipelineConfig):
             else:
                 entities = tuple(
                     SchemaEntity.from_text_or_dict(e)
-                    for e in cast(
-                        Dict[str, Any], self.schema_.get("entities", {})
-                    ).values()
+                    for e in self.schema_.get("entities", [])
                 )
                 relations = tuple(
                     SchemaRelation.from_text_or_dict(r)
-                    for r in cast(
-                        Dict[str, Any], self.schema_.get("relations", {})
-                    ).values()
+                    for r in self.schema_.get("relations", [])
                 )
                 ps = self.schema_.get("potential_schema")
                 potential_schema = tuple(ps) if ps else None

--- a/src/neo4j_graphrag/experimental/pipeline/config/template_pipeline/simple_kg_builder.py
+++ b/src/neo4j_graphrag/experimental/pipeline/config/template_pipeline/simple_kg_builder.py
@@ -20,8 +20,6 @@ from typing import (
     Sequence,
     Union,
     Tuple,
-    Dict,
-    cast,
 )
 import logging
 import warnings

--- a/src/neo4j_graphrag/experimental/pipeline/kg_builder.py
+++ b/src/neo4j_graphrag/experimental/pipeline/kg_builder.py
@@ -43,7 +43,7 @@ from neo4j_graphrag.experimental.pipeline.types.schema import (
 )
 from neo4j_graphrag.generation.prompts import ERExtractionTemplate
 from neo4j_graphrag.llm.base import LLMInterface
-from neo4j_graphrag.experimental.components.schema import SchemaConfig
+from neo4j_graphrag.experimental.components.schema import GraphSchema
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +57,7 @@ class SimpleKGPipeline:
         llm (LLMInterface): An instance of an LLM to use for entity and relation extraction.
         driver (neo4j.Driver): A Neo4j driver instance for database connection.
         embedder (Embedder): An instance of an embedder used to generate chunk embeddings from text chunks.
-        schema (Optional[Union[SchemaConfig, dict[str, list]]]): A schema configuration defining entities,
+        schema (Optional[Union[GraphSchema, dict[str, list]]]): A schema configuration defining entities,
                                                    relations, and potential schema relationships.
                                                    This is the recommended way to provide schema information.
         entities (Optional[List[Union[str, dict[str, str], SchemaEntity]]]): DEPRECATED. A list of either:
@@ -92,7 +92,7 @@ class SimpleKGPipeline:
         entities: Optional[Sequence[EntityInputType]] = None,
         relations: Optional[Sequence[RelationInputType]] = None,
         potential_schema: Optional[List[tuple[str, str, str]]] = None,
-        schema: Optional[Union[SchemaConfig, dict[str, list[Any]]]] = None,
+        schema: Optional[Union[GraphSchema, dict[str, list[Any]]]] = None,
         enforce_schema: str = "NONE",
         from_pdf: bool = True,
         text_splitter: Optional[TextSplitter] = None,

--- a/src/neo4j_graphrag/experimental/pipeline/kg_builder.py
+++ b/src/neo4j_graphrag/experimental/pipeline/kg_builder.py
@@ -60,15 +60,15 @@ class SimpleKGPipeline:
         schema (Optional[Union[GraphSchema, dict[str, list]]]): A schema configuration defining entities,
                                                    relations, and potential schema relationships.
                                                    This is the recommended way to provide schema information.
-        entities (Optional[List[Union[str, dict[str, str], SchemaEntity]]]): DEPRECATED. A list of either:
+        entities (Optional[List[Union[str, dict[str, str], NodeType]]]): DEPRECATED. A list of either:
 
             - str: entity labels
-            - dict: following the SchemaEntity schema, ie with label, description and properties keys
+            - dict: following the NodeType schema, ie with label, description and properties keys
 
-        relations (Optional[List[Union[str, dict[str, str], SchemaRelation]]]): DEPRECATED. A list of either:
+        relations (Optional[List[Union[str, dict[str, str], RelationshipType]]]): DEPRECATED. A list of either:
 
             - str: relation label
-            - dict: following the SchemaRelation schema, ie with label, description and properties keys
+            - dict: following the RelationshipType schema, ie with label, description and properties keys
 
         potential_schema (Optional[List[tuple]]): DEPRECATED. A list of potential schema relationships.
         enforce_schema (str): Validation of the extracted entities/rels against the provided schema. Defaults to "NONE", where schema enforcement will be ignored even if the schema is provided. Possible values "None" or "STRICT".

--- a/src/neo4j_graphrag/experimental/pipeline/types/schema.py
+++ b/src/neo4j_graphrag/experimental/pipeline/types/schema.py
@@ -19,7 +19,7 @@ from typing import Union
 
 EntityInputType = Union[str, dict[str, Union[str, list[dict[str, str]]]]]
 RelationInputType = Union[str, dict[str, Union[str, list[dict[str, str]]]]]
-"""Types derived from the SchemaEntity and SchemaRelation types,
+"""Types derived from the NodeType and RelationshipType types,
  so the possible types for dict values are:
 - str (for label and description)
 - list[dict[str, str]] (for properties)

--- a/src/neo4j_graphrag/generation/prompts.py
+++ b/src/neo4j_graphrag/generation/prompts.py
@@ -204,7 +204,7 @@ Input text:
 
 class SchemaExtractionTemplate(PromptTemplate):
     DEFAULT_TEMPLATE = """
-You are a top-tier algorithm designed for extracting a labeled property graph schema in 
+You are a top-tier algorithm designed for extracting a labeled property graph schema in
 structured formats.
 
 Generate a generalized graph schema based on the input text. Identify key entity types,
@@ -219,12 +219,12 @@ IMPORTANT RULES:
 6. Do not create entity types that aren't clearly mentioned in the text.
 7. Keep your schema minimal and focused on clearly identifiable patterns in the text.
 
-Accepted property types are: BOOLEAN, DATE, DURATION, FLOAT, INTEGER, LIST, 
+Accepted property types are: BOOLEAN, DATE, DURATION, FLOAT, INTEGER, LIST,
 LOCAL_DATETIME, LOCAL_TIME, POINT, STRING, ZONED_DATETIME, ZONED_TIME.
 
 Return a valid JSON object that follows this precise structure:
 {{
-  "entities": [
+  "node_types": [
     {{
       "label": "Person",
       "properties": [
@@ -236,13 +236,13 @@ Return a valid JSON object that follows this precise structure:
     }},
     ...
   ],
-  "relations": [
+  "relationship_types": [
     {{
       "label": "WORKS_FOR"
     }},
     ...
   ],
-  "potential_schema": [
+  "patterns": [
     ["Person", "WORKS_FOR", "Company"],
     ...
   ]

--- a/tests/e2e/experimental/test_kg_builder_pipeline_e2e.py
+++ b/tests/e2e/experimental/test_kg_builder_pipeline_e2e.py
@@ -33,9 +33,9 @@ from neo4j_graphrag.experimental.components.resolver import (
 )
 from neo4j_graphrag.experimental.components.schema import (
     SchemaBuilder,
-    SchemaEntity,
-    SchemaProperty,
-    SchemaRelation,
+    NodeType,
+    PropertyType,
+    RelationshipType,
 )
 from neo4j_graphrag.experimental.components.text_splitters.fixed_size_splitter import (
     FixedSizeSplitter,
@@ -187,49 +187,49 @@ async def test_pipeline_builder_happy_path(
     pipe_inputs = {
         "splitter": {"text": harry_potter_text},
         "schema": {
-            "entities": [
-                SchemaEntity(
+            "node_types": [
+                NodeType(
                     label="Person",
                     properties=[
-                        SchemaProperty(name="name", type="STRING"),
-                        SchemaProperty(name="place_of_birth", type="STRING"),
-                        SchemaProperty(name="date_of_birth", type="DATE"),
+                        PropertyType(name="name", type="STRING"),
+                        PropertyType(name="place_of_birth", type="STRING"),
+                        PropertyType(name="date_of_birth", type="DATE"),
                     ],
                 ),
-                SchemaEntity(
+                NodeType(
                     label="Organization",
                     properties=[
-                        SchemaProperty(name="name", type="STRING"),
+                        PropertyType(name="name", type="STRING"),
                     ],
                 ),
-                SchemaEntity(
+                NodeType(
                     label="Potion",
                     properties=[
-                        SchemaProperty(name="name", type="STRING"),
+                        PropertyType(name="name", type="STRING"),
                     ],
                 ),
-                SchemaEntity(
+                NodeType(
                     label="Location",
                     properties=[
-                        SchemaProperty(name="address", type="STRING"),
+                        PropertyType(name="address", type="STRING"),
                     ],
                 ),
             ],
-            "relations": [
-                SchemaRelation(
+            "relationship_types": [
+                RelationshipType(
                     label="KNOWS",
                 ),
-                SchemaRelation(
+                RelationshipType(
                     label="PART_OF",
                 ),
-                SchemaRelation(
+                RelationshipType(
                     label="LED_BY",
                 ),
-                SchemaRelation(
+                RelationshipType(
                     label="DRINKS",
                 ),
             ],
-            "potential_schema": [
+            "patterns": [
                 ("Person", "KNOWS", "Person"),
                 ("Person", "DRINKS", "Potion"),
                 ("Person", "PART_OF", "Organization"),
@@ -356,9 +356,9 @@ async def test_pipeline_builder_failing_chunk_raise(
         # note: schema not used in this test because
         # we are mocking the LLM
         "schema": {
-            "entities": [],
-            "relations": [],
-            "potential_schema": [],
+            "node_types": (),
+            "relationship_types": (),
+            "patterns": (),
         },
     }
     with pytest.raises(LLMGenerationError):
@@ -434,9 +434,9 @@ async def test_pipeline_builder_failing_chunk_do_not_raise(
         # note: schema not used in this test because
         # we are mocking the LLM
         "schema": {
-            "entities": [],
-            "relations": [],
-            "potential_schema": [],
+            "node_types": (),
+            "relationship_types": (),
+            "patterns": (),
         },
     }
     kg_builder_pipeline.get_node_by_name(
@@ -575,9 +575,9 @@ async def test_pipeline_builder_two_documents(
         # note: schema not used in this test because
         # we are mocking the LLM
         "schema": {
-            "entities": [],
-            "relations": [],
-            "potential_schema": [],
+            "node_types": (),
+            "relationship_types": (),
+            "patterns": (),
         },
     }
     pipe_inputs_2 = {
@@ -585,9 +585,9 @@ async def test_pipeline_builder_two_documents(
         # note: schema not used in this test because
         # we are mocking the LLM
         "schema": {
-            "entities": [],
-            "relations": [],
-            "potential_schema": [],
+            "node_types": (),
+            "relationship_types": (),
+            "patterns": (),
         },
     }
     await kg_builder_pipeline.run(pipe_inputs_1)

--- a/tests/e2e/experimental/test_simplekgpipeline_e2e.py
+++ b/tests/e2e/experimental/test_simplekgpipeline_e2e.py
@@ -305,7 +305,7 @@ async def test_pipeline_builder_with_automatic_schema_extraction(
         # first call - schema extraction response
         LLMResponse(
             content="""{
-                "entities": [
+                "node_types": [
                     {
                         "label": "Person",
                         "description": "A character in the story",
@@ -322,14 +322,14 @@ async def test_pipeline_builder_with_automatic_schema_extraction(
                         ]
                     }
                 ],
-                "relations": [
+                "relationship_types": [
                     {
                         "label": "LOCATED_AT",
                         "description": "Indicates where a person is located",
                         "properties": []
                     }
                 ],
-                "potential_schema": [
+                "patterns": [
                     ["Person", "LOCATED_AT", "Location"]
                 ]
             }"""

--- a/tests/unit/experimental/components/test_entity_relation_extractor.py
+++ b/tests/unit/experimental/components/test_entity_relation_extractor.py
@@ -603,15 +603,17 @@ async def test_extractor_schema_enforcement_none_relationships_in_schema() -> No
         llm=llm, create_lexical_graph=False, enforce_schema=SchemaEnforcementMode.STRICT
     )
 
-    schema = SchemaConfig(
-        entities={
-            "Person": {
-                "label": "Person",
-                "properties": [{"name": "name", "type": "STRING"}],
-            }
-        },
-        relations=None,
-        potential_schema=None,
+    schema = GraphSchema.model_validate(
+        dict(
+            node_types=[
+                {
+                    "label": "Person",
+                    "properties": [{"name": "name", "type": "STRING"}],
+                }
+            ],
+            relationship_types=None,
+            patterns=None,
+        )
     )
 
     chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
@@ -638,15 +640,17 @@ async def test_extractor_schema_enforcement_empty_relationships_in_schema() -> N
         llm=llm, create_lexical_graph=False, enforce_schema=SchemaEnforcementMode.STRICT
     )
 
-    schema = SchemaConfig(
-        entities={
-            "Person": {
-                "label": "Person",
-                "properties": [{"name": "name", "type": "STRING"}],
-            }
-        },
-        relations={},
-        potential_schema=None,
+    schema = GraphSchema.model_validate(
+        dict(
+            node_types=[
+                {
+                    "label": "Person",
+                    "properties": [{"name": "name", "type": "STRING"}],
+                }
+            ],
+            relationship_types=None,
+            patterns=None,
+        )
     )
 
     chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])

--- a/tests/unit/experimental/components/test_entity_relation_extractor.py
+++ b/tests/unit/experimental/components/test_entity_relation_extractor.py
@@ -245,14 +245,14 @@ async def test_extractor_no_schema_enforcement() -> None:
 
     schema = GraphSchema.model_validate(
         {
-            "entities": [
+            "node_types": [
                 {
                     "label": "Person",
                     "properties": [{"name": "name", "type": "STRING"}],
                 }
             ],
-            "relations": [],
-            "potential_schema": [],
+            "relationship_types": [],
+            "patterns": [],
         },
     )
 
@@ -301,14 +301,14 @@ async def test_extractor_schema_enforcement_invalid_nodes() -> None:
 
     schema = GraphSchema.model_validate(
         {
-            "entities": [
+            "node_types": [
                 {
                     "label": "Person",
                     "properties": [{"name": "name", "type": "STRING"}],
                 }
             ],
-            "relations": [],
-            "potential_schema": [],
+            "relationship_types": [],
+            "patterns": [],
         },
     )
 
@@ -336,7 +336,7 @@ async def test_extraction_schema_enforcement_invalid_node_properties() -> None:
 
     schema = GraphSchema.model_validate(
         {
-            "entities": [
+            "node_types": [
                 {
                     "label": "Person",
                     "properties": [
@@ -345,8 +345,8 @@ async def test_extraction_schema_enforcement_invalid_node_properties() -> None:
                     ],
                 }
             ],
-            "relations": [],
-            "potential_schema": [],
+            "relationship_types": [],
+            "patterns": [],
         },
     )
 
@@ -374,7 +374,7 @@ async def test_extractor_schema_enforcement_valid_nodes_with_empty_props() -> No
 
     schema = GraphSchema.model_validate(
         {
-            "entities": [
+            "node_types": [
                 {
                     "label": "Person",
                 }
@@ -405,7 +405,7 @@ async def test_extractor_schema_enforcement_invalid_relations_wrong_types() -> N
 
     schema = GraphSchema.model_validate(
         {
-            "entities": [
+            "node_types": [
                 {
                     "label": "Person",
                     "properties": [
@@ -414,8 +414,8 @@ async def test_extractor_schema_enforcement_invalid_relations_wrong_types() -> N
                     ],
                 }
             ],
-            "relations": [{"label": "LIKES"}],
-            "potential_schema": [],
+            "relationship_types": [{"label": "LIKES"}],
+            "patterns": [],
         }
     )
 
@@ -446,7 +446,7 @@ async def test_extractor_schema_enforcement_invalid_relations_wrong_start_node()
 
     schema = GraphSchema.model_validate(
         {
-            "entities": [
+            "node_types": [
                 {
                     "label": "Person",
                     "properties": [{"name": "name", "type": "STRING"}],
@@ -456,8 +456,8 @@ async def test_extractor_schema_enforcement_invalid_relations_wrong_start_node()
                     "properties": [{"name": "name", "type": "STRING"}],
                 },
             ],
-            "relations": [{"label": "LIVES_IN"}],
-            "potential_schema": [("Person", "LIVES_IN", "City")],
+            "relationship_types": [{"label": "LIVES_IN"}],
+            "patterns": [("Person", "LIVES_IN", "City")],
         }
     )
 
@@ -485,19 +485,19 @@ async def test_extractor_schema_enforcement_invalid_relation_properties() -> Non
 
     schema = GraphSchema.model_validate(
         {
-            "entities": [
+            "node_types": [
                 {
                     "label": "Person",
                     "properties": [{"name": "name", "type": "STRING"}],
                 }
             ],
-            "relations": [
+            "relationship_types": [
                 {
                     "label": "LIKES",
                     "properties": [{"name": "strength", "type": "STRING"}],
                 }
             ],
-            "potential_schema": [],
+            "patterns": [],
         }
     )
 
@@ -528,14 +528,14 @@ async def test_extractor_schema_enforcement_removed_relation_start_end_nodes() -
 
     schema = GraphSchema.model_validate(
         {
-            "entities": [
+            "node_types": [
                 {
                     "label": "Person",
                     "properties": [{"name": "name", "type": "STRING"}],
                 }
             ],
-            "relations": [{"label": "LIKES"}],
-            "potential_schema": [("Person", "LIKES", "Person")],
+            "relationship_types": [{"label": "LIKES"}],
+            "patterns": [("Person", "LIKES", "Person")],
         }
     )
 
@@ -563,7 +563,7 @@ async def test_extractor_schema_enforcement_inverted_relation_direction() -> Non
 
     schema = GraphSchema.model_validate(
         {
-            "entities": [
+            "node_types": [
                 {
                     "label": "Person",
                     "properties": [{"name": "name", "type": "STRING"}],
@@ -573,8 +573,8 @@ async def test_extractor_schema_enforcement_inverted_relation_direction() -> Non
                     "properties": [{"name": "name", "type": "STRING"}],
                 },
             ],
-            "relations": [{"label": "LIVES_IN"}],
-            "potential_schema": [("Person", "LIVES_IN", "City")],
+            "relationship_types": [{"label": "LIVES_IN"}],
+            "patterns": [("Person", "LIVES_IN", "City")],
         }
     )
 

--- a/tests/unit/experimental/components/test_entity_relation_extractor.py
+++ b/tests/unit/experimental/components/test_entity_relation_extractor.py
@@ -243,13 +243,16 @@ async def test_extractor_no_schema_enforcement() -> None:
         llm=llm, create_lexical_graph=False, enforce_schema=SchemaEnforcementMode.NONE
     )
 
-    schema = GraphSchema.model_validate({
-        "entities": [{
-            "label": "Person",
-            "properties": [{"name": "name", "type": "STRING"}],
-        }],
-        "relations": [],
-        "potential_schema": []
+    schema = GraphSchema.model_validate(
+        {
+            "entities": [
+                {
+                    "label": "Person",
+                    "properties": [{"name": "name", "type": "STRING"}],
+                }
+            ],
+            "relations": [],
+            "potential_schema": [],
         },
     )
 
@@ -296,13 +299,16 @@ async def test_extractor_schema_enforcement_invalid_nodes() -> None:
         llm=llm, create_lexical_graph=False, enforce_schema=SchemaEnforcementMode.STRICT
     )
 
-    schema = GraphSchema.model_validate({
-        "entities": [{
-            "label": "Person",
-            "properties": [{"name": "name", "type": "STRING"}],
-        }],
-        "relations": [],
-        "potential_schema": []
+    schema = GraphSchema.model_validate(
+        {
+            "entities": [
+                {
+                    "label": "Person",
+                    "properties": [{"name": "name", "type": "STRING"}],
+                }
+            ],
+            "relations": [],
+            "potential_schema": [],
         },
     )
 
@@ -328,16 +334,19 @@ async def test_extraction_schema_enforcement_invalid_node_properties() -> None:
         llm=llm, create_lexical_graph=False, enforce_schema=SchemaEnforcementMode.STRICT
     )
 
-    schema = GraphSchema.model_validate({
-        "entities": [{
-            "label": "Person",
-            "properties": [
-                {"name": "name", "type": "STRING"},
-                {"name": "age", "type": "STRING"}
+    schema = GraphSchema.model_validate(
+        {
+            "entities": [
+                {
+                    "label": "Person",
+                    "properties": [
+                        {"name": "name", "type": "STRING"},
+                        {"name": "age", "type": "STRING"},
+                    ],
+                }
             ],
-        }],
-        "relations": [],
-        "potential_schema": []
+            "relations": [],
+            "potential_schema": [],
         },
     )
 
@@ -363,11 +372,15 @@ async def test_extractor_schema_enforcement_valid_nodes_with_empty_props() -> No
         llm=llm, create_lexical_graph=False, enforce_schema=SchemaEnforcementMode.STRICT
     )
 
-    schema = GraphSchema.model_validate({
-        "entities": [{
-            "label": "Person",
-        }],
-    })
+    schema = GraphSchema.model_validate(
+        {
+            "entities": [
+                {
+                    "label": "Person",
+                }
+            ],
+        }
+    )
     chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
 
     result: Neo4jGraph = await extractor.run(chunks, schema=schema)
@@ -390,17 +403,21 @@ async def test_extractor_schema_enforcement_invalid_relations_wrong_types() -> N
         llm=llm, create_lexical_graph=False, enforce_schema=SchemaEnforcementMode.STRICT
     )
 
-    schema = GraphSchema.model_validate({
-        "entities": [{
-            "label": "Person",
-            "properties": [
-                {"name": "name", "type": "STRING"},
-                {"name": "age", "type": "STRING"}
+    schema = GraphSchema.model_validate(
+        {
+            "entities": [
+                {
+                    "label": "Person",
+                    "properties": [
+                        {"name": "name", "type": "STRING"},
+                        {"name": "age", "type": "STRING"},
+                    ],
+                }
             ],
-        }],
-        "relations": [{"label": "LIKES"}],
-        "potential_schema": []
-    })
+            "relations": [{"label": "LIKES"}],
+            "potential_schema": [],
+        }
+    )
 
     chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
 
@@ -427,20 +444,22 @@ async def test_extractor_schema_enforcement_invalid_relations_wrong_start_node()
         llm=llm, create_lexical_graph=False, enforce_schema=SchemaEnforcementMode.STRICT
     )
 
-    schema = GraphSchema.model_validate({
-        "entities":[
-            {
-                "label": "Person",
-                "properties": [{"name": "name", "type": "STRING"}],
-            },
-            {
-                "label": "City",
-                "properties": [{"name": "name", "type": "STRING"}],
-            },
-        ],
-        "relations":[{"label": "LIVES_IN"}],
-        "potential_schema":[("Person", "LIVES_IN", "City")],
-    })
+    schema = GraphSchema.model_validate(
+        {
+            "entities": [
+                {
+                    "label": "Person",
+                    "properties": [{"name": "name", "type": "STRING"}],
+                },
+                {
+                    "label": "City",
+                    "properties": [{"name": "name", "type": "STRING"}],
+                },
+            ],
+            "relations": [{"label": "LIVES_IN"}],
+            "potential_schema": [("Person", "LIVES_IN", "City")],
+        }
+    )
 
     chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
 
@@ -464,21 +483,23 @@ async def test_extractor_schema_enforcement_invalid_relation_properties() -> Non
         llm=llm, create_lexical_graph=False, enforce_schema=SchemaEnforcementMode.STRICT
     )
 
-    schema = GraphSchema.model_validate({
-        "entities": [
-            {
-                "label": "Person",
-                "properties": [{"name": "name", "type": "STRING"}],
-            }
-        ],
-        "relations":[
-            {
-                "label": "LIKES",
-                "properties": [{"name": "strength", "type": "STRING"}],
-            }
-        ],
-        "potential_schema":[],
-    })
+    schema = GraphSchema.model_validate(
+        {
+            "entities": [
+                {
+                    "label": "Person",
+                    "properties": [{"name": "name", "type": "STRING"}],
+                }
+            ],
+            "relations": [
+                {
+                    "label": "LIKES",
+                    "properties": [{"name": "strength", "type": "STRING"}],
+                }
+            ],
+            "potential_schema": [],
+        }
+    )
 
     chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
 
@@ -505,16 +526,18 @@ async def test_extractor_schema_enforcement_removed_relation_start_end_nodes() -
         llm=llm, create_lexical_graph=False, enforce_schema=SchemaEnforcementMode.STRICT
     )
 
-    schema = GraphSchema.model_validate({
-        "entities": [
-            {
-                "label": "Person",
-                "properties": [{"name": "name", "type": "STRING"}],
-            }
-        ],
-        "relations": [{"label": "LIKES"}],
-        "potential_schema": [("Person", "LIKES", "Person")],
-    })
+    schema = GraphSchema.model_validate(
+        {
+            "entities": [
+                {
+                    "label": "Person",
+                    "properties": [{"name": "name", "type": "STRING"}],
+                }
+            ],
+            "relations": [{"label": "LIKES"}],
+            "potential_schema": [("Person", "LIKES", "Person")],
+        }
+    )
 
     chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
 
@@ -538,20 +561,22 @@ async def test_extractor_schema_enforcement_inverted_relation_direction() -> Non
         llm=llm, create_lexical_graph=False, enforce_schema=SchemaEnforcementMode.STRICT
     )
 
-    schema = GraphSchema.model_validate({
-        "entities": [
-            {
-                "label": "Person",
-                "properties": [{"name": "name", "type": "STRING"}],
-            },
-            {
-                "label": "City",
-                "properties": [{"name": "name", "type": "STRING"}],
-            },
-        ],
-        "relations": [{"label": "LIVES_IN"}],
-        "potential_schema": [("Person", "LIVES_IN", "City")],
-    })
+    schema = GraphSchema.model_validate(
+        {
+            "entities": [
+                {
+                    "label": "Person",
+                    "properties": [{"name": "name", "type": "STRING"}],
+                },
+                {
+                    "label": "City",
+                    "properties": [{"name": "name", "type": "STRING"}],
+                },
+            ],
+            "relations": [{"label": "LIVES_IN"}],
+            "potential_schema": [("Person", "LIVES_IN", "City")],
+        }
+    )
 
     chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
 

--- a/tests/unit/experimental/components/test_entity_relation_extractor.py
+++ b/tests/unit/experimental/components/test_entity_relation_extractor.py
@@ -648,7 +648,7 @@ async def test_extractor_schema_enforcement_empty_relationships_in_schema() -> N
                     "properties": [{"name": "name", "type": "STRING"}],
                 }
             ],
-            relationship_types=None,
+            relationship_types=[],
             patterns=None,
         )
     )

--- a/tests/unit/experimental/components/test_schema.py
+++ b/tests/unit/experimental/components/test_schema.py
@@ -18,7 +18,6 @@ import json
 from unittest.mock import AsyncMock
 
 import pytest
-from pydantic import ValidationError
 
 from neo4j_graphrag.exceptions import SchemaValidationError, SchemaExtractionError
 from neo4j_graphrag.experimental.components.schema import (
@@ -95,9 +94,7 @@ def potential_schema_with_invalid_entity() -> tuple[tuple[str, str, str], ...]:
 
 @pytest.fixture
 def potential_schema_with_invalid_relation() -> tuple[tuple[str, str, str], ...]:
-    return (
-        ("PERSON", "NON_EXISTENT_RELATION", "ORGANIZATION"),
-    )
+    return (("PERSON", "NON_EXISTENT_RELATION", "ORGANIZATION"),)
 
 
 @pytest.fixture
@@ -140,9 +137,7 @@ async def test_run_method(
     potential_schema: tuple[tuple[str, str, str], ...],
 ) -> None:
     schema = await schema_builder.run(
-        list(valid_entities),
-        list(valid_relations),
-        list(potential_schema)
+        list(valid_entities), list(valid_relations), list(potential_schema)
     )
 
     assert schema.entities == valid_entities
@@ -175,7 +170,9 @@ def test_create_schema_model_invalid_relation(
 ) -> None:
     with pytest.raises(SchemaValidationError) as exc_info:
         schema_builder.create_schema_model(
-            list(valid_entities), list(valid_relations), list(potential_schema_with_invalid_relation)
+            list(valid_entities),
+            list(valid_relations),
+            list(potential_schema_with_invalid_relation),
         )
     assert "Relation 'NON_EXISTENT_RELATION' is not defined" in str(
         exc_info.value

--- a/tests/unit/experimental/components/test_schema.py
+++ b/tests/unit/experimental/components/test_schema.py
@@ -418,9 +418,7 @@ def test_create_schema_model_no_relations_or_potential_schema(
     assert len(schema_instance.entities) == 2
     person = schema_instance.entity_from_label("PERSON")
 
-    assert (
-        person.description == "An individual human being."
-    )
+    assert person.description == "An individual human being."
     assert person.properties == [
         SchemaProperty(
             name="name",
@@ -431,14 +429,11 @@ def test_create_schema_model_no_relations_or_potential_schema(
             name="birth date",
             type="ZONED_DATETIME",
             description="",
-        )
+        ),
     ]
 
     org = schema_instance.entity_from_label("ORGANIZATION")
-    assert (
-        org.description
-        == "A structured group of people with a common purpose."
-    )
+    assert org.description == "A structured group of people with a common purpose."
 
     age = schema_instance.entity_from_label("AGE")
     assert age.description == "Age of a person in years."

--- a/tests/unit/experimental/components/test_schema.py
+++ b/tests/unit/experimental/components/test_schema.py
@@ -415,19 +415,33 @@ def test_create_schema_model_no_relations_or_potential_schema(
 ) -> None:
     schema_instance = schema_builder.create_schema_model(valid_entities)
 
+    assert len(schema_instance.entities) == 2
+    person = schema_instance.entity_from_label("PERSON")
+
     assert (
-        schema_instance.entities["PERSON"]["description"]
-        == "An individual human being."
+        person.description == "An individual human being."
     )
-    assert schema_instance.entities["PERSON"]["properties"] == [
-        {"description": "", "name": "birth date", "type": "ZONED_DATETIME"},
-        {"description": "", "name": "name", "type": "STRING"},
+    assert person.properties == [
+        SchemaProperty(
+            name="name",
+            type="STRING",
+            description="",
+        ),
+        SchemaProperty(
+            name="birth date",
+            type="ZONED_DATETIME",
+            description="",
+        )
     ]
+
+    org = schema_instance.entity_from_label("ORGANIZATION")
     assert (
-        schema_instance.entities["ORGANIZATION"]["description"]
+        org.description
         == "A structured group of people with a common purpose."
     )
-    assert schema_instance.entities["AGE"]["description"] == "Age of a person in years."
+
+    age = schema_instance.entity_from_label("AGE")
+    assert age.description == "Age of a person in years."
 
 
 def test_create_schema_model_missing_relations(

--- a/tests/unit/experimental/pipeline/config/template_pipeline/test_simple_kg_builder.py
+++ b/tests/unit/experimental/pipeline/config/template_pipeline/test_simple_kg_builder.py
@@ -39,8 +39,10 @@ from neo4j_graphrag.experimental.pipeline.config.template_pipeline import (
     SimpleKGPipelineConfig,
 )
 from neo4j_graphrag.experimental.pipeline.exceptions import PipelineDefinitionError
-from neo4j_graphrag.experimental.pipeline.types.schema import EntityInputType, \
-    RelationInputType
+from neo4j_graphrag.experimental.pipeline.types.schema import (
+    EntityInputType,
+    RelationInputType,
+)
 from neo4j_graphrag.generation.prompts import ERExtractionTemplate
 from neo4j_graphrag.llm import LLMInterface
 

--- a/tests/unit/experimental/pipeline/config/template_pipeline/test_simple_kg_builder.py
+++ b/tests/unit/experimental/pipeline/config/template_pipeline/test_simple_kg_builder.py
@@ -26,8 +26,8 @@ from neo4j_graphrag.experimental.components.kg_writer import Neo4jWriter
 from neo4j_graphrag.experimental.components.pdf_loader import PdfLoader
 from neo4j_graphrag.experimental.components.schema import (
     SchemaBuilder,
-    SchemaEntity,
-    SchemaRelation,
+    NodeType,
+    RelationshipType,
     SchemaFromTextExtractor,
 )
 from neo4j_graphrag.experimental.components.text_splitters.fixed_size_splitter import (
@@ -142,9 +142,9 @@ def test_simple_kg_pipeline_config_schema_run_params() -> None:
         potential_schema=[("Person", "KNOWS", "Person")],
     )
     assert config._get_run_params_for_schema() == {
-        "entities": (SchemaEntity(label="Person"),),
-        "relations": (SchemaRelation(label="KNOWS"),),
-        "potential_schema": (("Person", "KNOWS", "Person"),),
+        "node_types": (NodeType(label="Person"),),
+        "relationship_types": (RelationshipType(label="KNOWS"),),
+        "patterns": (("Person", "KNOWS", "Person"),),
     }
 
 

--- a/tests/unit/experimental/pipeline/config/template_pipeline/test_simple_kg_builder.py
+++ b/tests/unit/experimental/pipeline/config/template_pipeline/test_simple_kg_builder.py
@@ -39,6 +39,8 @@ from neo4j_graphrag.experimental.pipeline.config.template_pipeline import (
     SimpleKGPipelineConfig,
 )
 from neo4j_graphrag.experimental.pipeline.exceptions import PipelineDefinitionError
+from neo4j_graphrag.experimental.pipeline.types.schema import EntityInputType, \
+    RelationInputType
 from neo4j_graphrag.generation.prompts import ERExtractionTemplate
 from neo4j_graphrag.llm import LLMInterface
 
@@ -318,7 +320,7 @@ def test_simple_kg_pipeline_config_run_params_both_file_and_text() -> None:
 
 
 def test_simple_kg_pipeline_config_process_schema_with_precedence_legacy() -> None:
-    entities = [
+    entities: list[EntityInputType] = [
         "Person",
         {
             "label": "Organization",
@@ -331,7 +333,7 @@ def test_simple_kg_pipeline_config_process_schema_with_precedence_legacy() -> No
             ],
         },
     ]
-    relations = [
+    relations: list[RelationInputType] = [
         "WORKS_FOR",
         {
             "label": "CREATED",
@@ -366,6 +368,7 @@ def test_simple_kg_pipeline_config_process_schema_with_precedence_legacy() -> No
     assert len(relationship_types[0].properties) == 0
     assert relationship_types[1].label == "CREATED"
     assert len(relationship_types[1].properties) == 2
+    assert patterns is not None
     assert len(patterns) == 2
 
 
@@ -420,6 +423,7 @@ def test_simple_kg_pipeline_config_process_schema_with_precedence_schema_dict() 
     assert len(relationship_types[0].properties) == 0
     assert relationship_types[1].label == "CREATED"
     assert len(relationship_types[1].properties) == 2
+    assert patterns is not None
     assert len(patterns) == 2
 
 
@@ -478,4 +482,5 @@ def test_simple_kg_pipeline_config_process_schema_with_precedence_schema_object(
     assert len(relationship_types[0].properties) == 0
     assert relationship_types[1].label == "CREATED"
     assert len(relationship_types[1].properties) == 2
+    assert patterns is not None
     assert len(patterns) == 2

--- a/tests/unit/experimental/pipeline/config/template_pipeline/test_simple_kg_builder.py
+++ b/tests/unit/experimental/pipeline/config/template_pipeline/test_simple_kg_builder.py
@@ -142,11 +142,9 @@ def test_simple_kg_pipeline_config_schema_run_params() -> None:
         potential_schema=[("Person", "KNOWS", "Person")],
     )
     assert config._get_run_params_for_schema() == {
-        "entities": [SchemaEntity(label="Person")],
-        "relations": [SchemaRelation(label="KNOWS")],
-        "potential_schema": [
-            ("Person", "KNOWS", "Person"),
-        ],
+        "entities": (SchemaEntity(label="Person"),),
+        "relations": (SchemaRelation(label="KNOWS"),),
+        "potential_schema": (("Person", "KNOWS", "Person"),),
     }
 
 

--- a/tests/unit/experimental/pipeline/test_kg_builder.py
+++ b/tests/unit/experimental/pipeline/test_kg_builder.py
@@ -116,10 +116,6 @@ async def test_knowledge_graph_builder_with_entities_and_file(_: Mock) -> None:
         from_pdf=True,
     )
 
-    # assert kg_builder.entities == entities
-    # assert kg_builder.relations == relations
-    # assert kg_builder.potential_schema == potential_schema
-
     file_path = "path/to/test.pdf"
 
     internal_entities = [SchemaEntity(label=label) for label in entities]
@@ -132,9 +128,9 @@ async def test_knowledge_graph_builder_with_entities_and_file(_: Mock) -> None:
     ) as mock_run:
         await kg_builder.run_async(file_path=file_path)
         pipe_inputs = mock_run.call_args[1]["data"]
-        assert pipe_inputs["schema"]["entities"] == internal_entities
-        assert pipe_inputs["schema"]["relations"] == internal_relations
-        assert pipe_inputs["schema"]["potential_schema"] == potential_schema
+        assert pipe_inputs["schema"]["entities"] == tuple(internal_entities)
+        assert pipe_inputs["schema"]["relations"] == tuple(internal_relations)
+        assert pipe_inputs["schema"]["potential_schema"] == tuple(potential_schema)
 
 
 def test_simple_kg_pipeline_on_error_invalid_value() -> None:

--- a/tests/unit/experimental/pipeline/test_kg_builder.py
+++ b/tests/unit/experimental/pipeline/test_kg_builder.py
@@ -19,8 +19,8 @@ import neo4j
 import pytest
 from neo4j_graphrag.embeddings import Embedder
 from neo4j_graphrag.experimental.components.schema import (
-    SchemaEntity,
-    SchemaRelation,
+    NodeType,
+    RelationshipType,
 )
 from neo4j_graphrag.experimental.components.types import LexicalGraphConfig
 from neo4j_graphrag.experimental.pipeline.exceptions import PipelineDefinitionError
@@ -118,8 +118,8 @@ async def test_knowledge_graph_builder_with_entities_and_file(_: Mock) -> None:
 
     file_path = "path/to/test.pdf"
 
-    internal_entities = [SchemaEntity(label=label) for label in entities]
-    internal_relations = [SchemaRelation(label=label) for label in relations]
+    internal_node_types = [NodeType(label=label) for label in entities]
+    internal_relationship_types = [RelationshipType(label=label) for label in relations]
 
     with patch.object(
         kg_builder.runner.pipeline,
@@ -128,9 +128,11 @@ async def test_knowledge_graph_builder_with_entities_and_file(_: Mock) -> None:
     ) as mock_run:
         await kg_builder.run_async(file_path=file_path)
         pipe_inputs = mock_run.call_args[1]["data"]
-        assert pipe_inputs["schema"]["entities"] == tuple(internal_entities)
-        assert pipe_inputs["schema"]["relations"] == tuple(internal_relations)
-        assert pipe_inputs["schema"]["potential_schema"] == tuple(potential_schema)
+        assert pipe_inputs["schema"]["node_types"] == tuple(internal_node_types)
+        assert pipe_inputs["schema"]["relationship_types"] == tuple(
+            internal_relationship_types
+        )
+        assert pipe_inputs["schema"]["patterns"] == tuple(potential_schema)
 
 
 def test_simple_kg_pipeline_on_error_invalid_value() -> None:


### PR DESCRIPTION
# Description

- Rename SchemaConfig to GraphSchema
- Use `NodeType` (previously SchemaEntity) and `RelationshipType` (previously SchemaRelation) to define GraphSchema
- Rename `entities`/`relations`/`potential_schema` to `node_types`/`relationship_types`/`patterns`
- Use tuples instead of lists for immutability (required to make the `_*_index` always consistent in the schema object) -> this validation is done by Pydantic and is transparent for users who provide nodes_types/relationship_types/patterns as list of str or dicts.


## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Low

## How Has This Been Tested?
- [x] Unit tests
- [x] E2E tests
- [x] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] Unit tests have been updated
- [x] E2E tests have been updated
- [x] Examples have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [x] CHANGELOG.md updated if appropriate
