### PR TITLE
Fix VertexAILLM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - Fixed a bug where `spacy` and `rapidfuzz` needed to be installed even if not using the relevant entity resolvers.
+- Fixed a bug where `VertexAILLM.(a)invoke_with_tools` called with multiple tools would raise an error.
 
 ### Changed
 

--- a/examples/customize/llms/vertexai_tool_calls.py
+++ b/examples/customize/llms/vertexai_tool_calls.py
@@ -97,8 +97,13 @@ async def main() -> None:
     # Initialize the VertexAI LLM
     generation_config = GenerationConfig(temperature=0.0)
     llm = VertexAILLM(
-        model_name="gemini-1.5-flash-001",
+        model_name="gemini-2.0-flash-001",
         generation_config=generation_config,
+        # tool_config=ToolConfig(
+        #     function_calling_config=ToolConfig.FunctionCallingConfig(
+        #         mode=ToolConfig.FunctionCallingConfig.Mode.ANY,
+        #         # allowed_function_names=["extract_person_info"],
+        #     ))
     )
 
     # Example text containing information about a company

--- a/examples/customize/llms/vertexai_tool_calls.py
+++ b/examples/customize/llms/vertexai_tool_calls.py
@@ -88,7 +88,7 @@ def process_tool_call(response: ToolCallResponse) -> str:
     if tool_call.name == "extract_person_info":
         return person_info_tool.execute(**tool_call.arguments)  # type: ignore[no-any-return]
     elif tool_call.name == "extract_company_info":
-        return company_info_tool.execute(**tool_call.arguments)
+        return str(company_info_tool.execute(**tool_call.arguments))
     else:
         raise ValueError("Unknown tool call")
 

--- a/examples/customize/llms/vertexai_tool_calls.py
+++ b/examples/customize/llms/vertexai_tool_calls.py
@@ -101,8 +101,7 @@ async def main() -> None:
         generation_config=generation_config,
     )
 
-    # Example text containing information about a person
-    # text = "Stella Hane is a 35-year-old software engineer who loves coding."
+    # Example text containing information about a company
     text1 = "Neo4j is a software company created in 2017"
 
     print("\n=== Synchronous Tool Call ===")
@@ -116,7 +115,7 @@ async def main() -> None:
     print(sync_result)
 
     print("\n=== Asynchronous Tool Call ===")
-    # Make an asynchronous tool call with a different text
+    # Make an asynchronous tool call with a different text about a person
     text2 = "Molly Hane, 32, works as a data scientist and enjoys machine learning."
     async_response = await llm.ainvoke_with_tools(
         input=f"Extract information about the person from this text: {text2}",

--- a/examples/customize/llms/vertexai_tool_calls.py
+++ b/examples/customize/llms/vertexai_tool_calls.py
@@ -102,7 +102,7 @@ async def main() -> None:
     )
 
     # Example text containing information about a company
-    text1 = "Neo4j is a software company created in 2017"
+    text1 = "Neo4j is a software company created in 2007"
 
     print("\n=== Synchronous Tool Call ===")
     # Make a synchronous tool call

--- a/examples/customize/llms/vertexai_tool_calls.py
+++ b/examples/customize/llms/vertexai_tool_calls.py
@@ -4,6 +4,7 @@ Both synchronous and asynchronous examples are provided.
 """
 
 import asyncio
+from typing import Optional
 
 from dotenv import load_dotenv
 from vertexai.generative_models import GenerationConfig
@@ -17,7 +18,7 @@ load_dotenv()
 
 
 # Create a custom Tool implementation for person info extraction
-parameters = ObjectParameter(
+person_tool_parameters = ObjectParameter(
     description="Parameters for extracting person information",
     properties={
         "name": StringParameter(description="The person's full name"),
@@ -29,7 +30,9 @@ parameters = ObjectParameter(
 )
 
 
-def run_tool(name: str, age: int, occupation: str) -> str:
+def run_person_tool(
+    name: str, age: Optional[int] = None, occupation: Optional[str] = None
+) -> str:
     """A simple function that summarizes person information from input parameters."""
     return f"Found person {name} with age {age} and occupation {occupation}"
 
@@ -37,12 +40,40 @@ def run_tool(name: str, age: int, occupation: str) -> str:
 person_info_tool = Tool(
     name="extract_person_info",
     description="Extract information about a person from text",
-    parameters=parameters,
-    execute_func=run_tool,
+    parameters=person_tool_parameters,
+    execute_func=run_person_tool,
+)
+
+company_tool_parameters = ObjectParameter(
+    description="Parameters for extracting company information",
+    properties={
+        "name": StringParameter(description="The company's full name"),
+        "industry": StringParameter(description="The company's industry"),
+        "creation_year": IntegerParameter(description="The company's creation year"),
+    },
+    required_properties=["name"],
+    additional_properties=False,
+)
+
+
+def run_company_tool(
+    name: str, industry: Optional[str] = None, creation_year: Optional[int] = None
+) -> str:
+    """A simple function that summarizes company information from input parameters."""
+    return (
+        f"Found company {name} operating in industry {industry} since {creation_year}"
+    )
+
+
+company_info_tool = Tool(
+    name="extract_company_info",
+    description="Extract information about a company from text",
+    parameters=company_tool_parameters,
+    execute_func=run_company_tool,
 )
 
 # Create the tool instance
-TOOLS = [person_info_tool]
+TOOLS = [person_info_tool, company_info_tool]
 
 
 def process_tool_call(response: ToolCallResponse) -> str:
@@ -54,7 +85,12 @@ def process_tool_call(response: ToolCallResponse) -> str:
     print(f"\nTool called: {tool_call.name}")
     print(f"Arguments: {tool_call.arguments}")
     print(f"Additional content: {response.content or 'None'}")
-    return person_info_tool.execute(**tool_call.arguments)  # type: ignore[no-any-return]
+    if tool_call.name == "extract_person_info":
+        return person_info_tool.execute(**tool_call.arguments)  # type: ignore[no-any-return]
+    elif tool_call.name == "extract_company_info":
+        return company_info_tool.execute(**tool_call.arguments)
+    else:
+        raise ValueError("Unknown tool call")
 
 
 async def main() -> None:
@@ -66,12 +102,13 @@ async def main() -> None:
     )
 
     # Example text containing information about a person
-    text = "Stella Hane is a 35-year-old software engineer who loves coding."
+    # text = "Stella Hane is a 35-year-old software engineer who loves coding."
+    text1 = "Neo4j is a software company created in 2017"
 
     print("\n=== Synchronous Tool Call ===")
     # Make a synchronous tool call
     sync_response = llm.invoke_with_tools(
-        input=f"Extract information about the person from this text: {text}",
+        input=f"Extract information about the person from this text: {text1}",
         tools=TOOLS,
     )
     sync_result = process_tool_call(sync_response)

--- a/src/neo4j_graphrag/llm/vertexai_llm.py
+++ b/src/neo4j_graphrag/llm/vertexai_llm.py
@@ -200,16 +200,6 @@ class VertexAILLM(LLMInterface):
             )
         ]
 
-    def _get_options(self, tool_mode: bool = False) -> dict[str, Any]:
-        options = dict(self.options)
-        if tool_mode:
-            # we want a tool back, remove generation_config if defined
-            options.pop("generation_config", None)
-        else:
-            # no tools, remove tool_config if defined
-            options.pop("tool_config", None)
-        return options
-
     def _get_model(
         self,
         system_instruction: Optional[str] = None,
@@ -217,7 +207,13 @@ class VertexAILLM(LLMInterface):
     ) -> GenerativeModel:
         system_message = [system_instruction] if system_instruction is not None else []
         vertex_ai_tools = self._get_llm_tools(tools)
-        options = self._get_options(tool_mode=tools is not None)
+        options = dict(self.options)
+        if tools:
+            # we want a tool back, remove generation_config if defined
+            options.pop("generation_config", None)
+        else:
+            # no tools, remove tool_config if defined
+            options.pop("tool_config", None)
         model = GenerativeModel(
             model_name=self.model_name,
             system_instruction=system_message,

--- a/src/neo4j_graphrag/llm/vertexai_llm.py
+++ b/src/neo4j_graphrag/llm/vertexai_llm.py
@@ -210,7 +210,9 @@ class VertexAILLM(LLMInterface):
                 config_dict = config.to_dict()
                 if config_dict.get("response_mime_type"):
                     config_dict["response_mime_type"] = None
-                    options["generation_config"] = GenerationConfig.from_dict(config_dict)
+                    options["generation_config"] = GenerationConfig.from_dict(
+                        config_dict
+                    )
         else:
             # no tools, drop tool_config if defined
             options.pop("tool_config", None)

--- a/src/neo4j_graphrag/llm/vertexai_llm.py
+++ b/src/neo4j_graphrag/llm/vertexai_llm.py
@@ -35,13 +35,11 @@ try:
         Content,
         FunctionCall,
         FunctionDeclaration,
-        GenerationConfig,
         GenerationResponse,
         GenerativeModel,
         Part,
         ResponseValidationError,
         Tool as VertexAITool,
-        ToolConfig,
     )
 except ImportError:
     GenerativeModel = None

--- a/src/neo4j_graphrag/llm/vertexai_llm.py
+++ b/src/neo4j_graphrag/llm/vertexai_llm.py
@@ -215,7 +215,7 @@ class VertexAILLM(LLMInterface):
         input: str,
         message_history: Optional[Union[List[LLMMessage], MessageHistory]],
         tools: Optional[Sequence[Tool]],
-    ):
+    ) -> dict[str, Any]:
         options = dict(self.options)
         if tools:
             # we want a tool back, remove generation_config if defined

--- a/src/neo4j_graphrag/llm/vertexai_llm.py
+++ b/src/neo4j_graphrag/llm/vertexai_llm.py
@@ -256,7 +256,6 @@ class VertexAILLM(LLMInterface):
     ) -> GenerationResponse:
         model = self._get_model(system_instruction=system_instruction)
         options = self._get_call_params(input, message_history, tools)
-        print(options)
         response = model.generate_content(**options)
         return response
 

--- a/src/neo4j_graphrag/llm/vertexai_llm.py
+++ b/src/neo4j_graphrag/llm/vertexai_llm.py
@@ -41,6 +41,7 @@ try:
         Part,
         ResponseValidationError,
         Tool as VertexAITool,
+        ToolConfig,
     )
 except ImportError:
     GenerativeModel = None
@@ -204,17 +205,10 @@ class VertexAILLM(LLMInterface):
     def _get_options(self, tool_mode: bool = False) -> dict[str, Any]:
         options = dict(self.options)
         if tool_mode:
-            # remove response_mime_type from GenerationConfig
-            config = options.get("generation_config")
-            if config:
-                config_dict = config.to_dict()
-                if config_dict.get("response_mime_type"):
-                    config_dict["response_mime_type"] = None
-                    options["generation_config"] = GenerationConfig.from_dict(
-                        config_dict
-                    )
+            # we want a tool back, remove generation_config if defined
+            options.pop("generation_config", None)
         else:
-            # no tools, drop tool_config if defined
+            # no tools, remove tool_config if defined
             options.pop("tool_config", None)
         return options
 

--- a/tests/unit/llm/test_vertexai_llm.py
+++ b/tests/unit/llm/test_vertexai_llm.py
@@ -14,7 +14,6 @@
 from __future__ import annotations
 
 from typing import cast
-from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
@@ -168,7 +167,9 @@ def test_vertexai_get_messages_validation_error(GenerativeModelMock: MagicMock) 
 @pytest.mark.asyncio
 @patch("neo4j_graphrag.llm.vertexai_llm.GenerativeModel")
 @patch("neo4j_graphrag.llm.vertexai_llm.VertexAILLM.get_messages")
-async def test_vertexai_ainvoke_happy_path(mock_get_messages: Mock, GenerativeModelMock: MagicMock) -> None:
+async def test_vertexai_ainvoke_happy_path(
+    mock_get_messages: Mock, GenerativeModelMock: MagicMock
+) -> None:
     mock_response = AsyncMock()
     mock_response.text = "Return text"
     mock_model = GenerativeModelMock.return_value
@@ -179,7 +180,9 @@ async def test_vertexai_ainvoke_happy_path(mock_get_messages: Mock, GenerativeMo
     input_text = "may thy knife chip and shatter"
     response = await llm.ainvoke(input_text)
     assert response.content == "Return text"
-    mock_model.generate_content_async.assert_awaited_once_with([{"text": "Return text"}])
+    mock_model.generate_content_async.assert_awaited_once_with(
+        [{"text": "Return text"}]
+    )
 
 
 def test_vertexai_get_llm_tools(test_tool: Tool) -> None:

--- a/tests/unit/llm/test_vertexai_llm.py
+++ b/tests/unit/llm/test_vertexai_llm.py
@@ -50,11 +50,9 @@ def test_vertexai_invoke_happy_path(GenerativeModelMock: MagicMock) -> None:
     response = llm.invoke(input_text)
     assert response.content == "Return text"
     GenerativeModelMock.assert_called_once_with(
-        model_name=model_name, system_instruction=[]
+        model_name=model_name, system_instruction=[], tools=None
     )
-    user_message = mock.ANY
-    llm.model.generate_content.assert_called_once_with(user_message, **model_params)
-    last_call = llm.model.generate_content.call_args_list[0]
+    last_call = mock_model.generate_content.call_args_list[0]
     content = last_call.args[0]
     assert len(content) == 1
     assert content[0].role == "user"
@@ -62,7 +60,9 @@ def test_vertexai_invoke_happy_path(GenerativeModelMock: MagicMock) -> None:
 
 
 @patch("neo4j_graphrag.llm.vertexai_llm.GenerativeModel")
+@patch("neo4j_graphrag.llm.vertexai_llm.VertexAILLM.get_messages")
 def test_vertexai_invoke_with_system_instruction(
+    mock_get_messages: MagicMock,
     GenerativeModelMock: MagicMock,
 ) -> None:
     system_instruction = "You are a helpful assistant."
@@ -72,16 +72,18 @@ def test_vertexai_invoke_with_system_instruction(
     mock_response.text = "Return text"
     mock_model = GenerativeModelMock.return_value
     mock_model.generate_content.return_value = mock_response
+
+    mock_get_messages.return_value = [{"text": "some text"}]
+
     model_params = {"temperature": 0.5}
     llm = VertexAILLM(model_name, model_params)
 
     response = llm.invoke(input_text, system_instruction=system_instruction)
     assert response.content == "Return text"
     GenerativeModelMock.assert_called_once_with(
-        model_name=model_name, system_instruction=[system_instruction]
+        model_name=model_name, system_instruction=[system_instruction], tools=None
     )
-    user_message = mock.ANY
-    llm.model.generate_content.assert_called_once_with(user_message, **model_params)
+    mock_model.generate_content.assert_called_once_with([{"text": "some text"}])
 
 
 @patch("neo4j_graphrag.llm.vertexai_llm.GenerativeModel")
@@ -110,11 +112,9 @@ def test_vertexai_invoke_with_message_history_and_system_instruction(
     )
     assert response.content == "Return text"
     GenerativeModelMock.assert_called_once_with(
-        model_name=model_name, system_instruction=[system_instruction]
+        model_name=model_name, system_instruction=[system_instruction], tools=None
     )
-    user_message = mock.ANY
-    llm.model.generate_content.assert_called_once_with(user_message, **model_params)
-    last_call = llm.model.generate_content.call_args_list[0]
+    last_call = mock_model.generate_content.call_args_list[0]
     content = last_call.args[0]
     assert len(content) == 3  # question + 2 messages in history
 
@@ -167,19 +167,19 @@ def test_vertexai_get_messages_validation_error(GenerativeModelMock: MagicMock) 
 
 @pytest.mark.asyncio
 @patch("neo4j_graphrag.llm.vertexai_llm.GenerativeModel")
-async def test_vertexai_ainvoke_happy_path(GenerativeModelMock: MagicMock) -> None:
+@patch("neo4j_graphrag.llm.vertexai_llm.VertexAILLM.get_messages")
+async def test_vertexai_ainvoke_happy_path(mock_get_messages: Mock, GenerativeModelMock: MagicMock) -> None:
     mock_response = AsyncMock()
     mock_response.text = "Return text"
     mock_model = GenerativeModelMock.return_value
     mock_model.generate_content_async = AsyncMock(return_value=mock_response)
+    mock_get_messages.return_value = [{"text": "Return text"}]
     model_params = {"temperature": 0.5}
     llm = VertexAILLM("gemini-1.5-flash-001", model_params)
     input_text = "may thy knife chip and shatter"
     response = await llm.ainvoke(input_text)
     assert response.content == "Return text"
-    llm.model.generate_content_async.assert_awaited_once_with(
-        [mock.ANY], **model_params
-    )
+    mock_model.generate_content_async.assert_awaited_once_with([{"text": "Return text"}])
 
 
 def test_vertexai_get_llm_tools(test_tool: Tool) -> None:

--- a/tests/unit/llm/test_vertexai_llm.py
+++ b/tests/unit/llm/test_vertexai_llm.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 
 from typing import cast
-from unittest.mock import AsyncMock, MagicMock, Mock, patch, ANY
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from neo4j_graphrag.exceptions import LLMGenerationError
@@ -26,7 +26,6 @@ from vertexai.generative_models import (
     Content,
     GenerationResponse,
     Part,
-    ToolConfig,
 )
 
 


### PR DESCRIPTION
# Description

The main reason for this PR is that, even if Google `GenerativeModel` accepts a list of tools as parameter, this is not how we should provide multiple tools. We should instead [provide a single tool with multiple function declarations](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/function-calling#python-dictionary). This PR addresses this behavior.

It also addresses a few other problems related to the way `GenerativeModel` is instantiated. The usage is:

```python
    # config for chat mode (aka invoke)
    generation_config = GenerationConfig(
        temperature=0.0,
        response_mime_type="application/json",
    )
    # config for tool mode (aka invoke_with_tools)
    # optional
    tool_config = ToolConfig(
        function_calling_config=ToolConfig.FunctionCallingConfig(
            mode=ToolConfig.FunctionCallingConfig.Mode.ANY
        ),
    )

    llm = VertexAILLM(
        model_name="gemini-2.0-flash-001",
        generation_config=generation_config,
        tool_config=tool_config,
    )
```

Then, internally:
- if `invoke` mode: we drop the tool config (it's not useful)
- if `invoke_with_tool` mode, we drop the generation config (otherwise the presence of fields like `response_mime_type`/`response_schema` raise errors)


## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: ?

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [x] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [x] Examples have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [x] CHANGELOG.md updated if appropriate
