### PR TITLE
Pipeline state dump and load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added support for automatic schema extraction from text using LLMs. In the `SimpleKGPipeline`, when the user provides no schema, the automatic schema extraction is enabled by default.
 - Added ability to return a user-defined message if context is empty in GraphRAG (which skips the LLM call).
+- Added pipeline state management with `run_until`, `resume_from`, `dump_state`, and `load_state` methods, enabling pipeline execution checkpointing and resumption.
 
 ### Fixed
 

--- a/docs/source/user_guide_pipeline.rst
+++ b/docs/source/user_guide_pipeline.rst
@@ -133,6 +133,36 @@ can be added to the visualization by setting `hide_unused_outputs` to `False`:
     webbrowser.open("pipeline_full.html")
 
 
+*************************
+Pipeline State Management
+*************************
+
+Pipelines support checkpointing and resumption through state management features:
+
+.. code:: python
+
+    # Run pipeline until a specific component
+    state = await pipeline.run_until(data, stop_after="component_name", state_file="state.json")
+
+    # Resume pipeline from a specific component
+    result = await pipeline.resume_from(state, data, start_from="component_name")
+
+    # Alternatively, load state from file
+    result = await pipeline.resume_from(None, data, start_from="component_name", state_file="state.json")
+
+The state contains:
+- Pipeline configuration (parameter mappings between components and validation state)
+- Execution results (outputs from completed components stored in the ResultStore)
+- Final pipeline results from previous runs
+- Component-specific state (interface available but not yet implemented by components)
+
+This enables:
+- Checkpointing long-running pipelines
+- Debugging pipeline execution
+- Resuming failed pipelines from the last successful component
+- Comparing different component implementations with deterministic inputs by saving the state before the component and reusing it, avoiding non-deterministic results from preceding components
+
+
 ************************
 Adding an Event Callback
 ************************

--- a/src/neo4j_graphrag/experimental/pipeline/component.py
+++ b/src/neo4j_graphrag/experimental/pipeline/component.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import inspect
-from typing import Any, get_type_hints
+from typing import Any, Dict, get_type_hints
 
 from pydantic import BaseModel
 
@@ -108,3 +108,25 @@ class Component(metaclass=ComponentMeta):
         """
         # default behavior to prevent a breaking change
         return await self.run(*args, **kwargs)
+
+    def serialize_state(self) -> Dict[str, Any]:
+        """Serialize component state to a dictionary.
+
+        This method can be overridden by components to customize
+        their serialization behavior. By default, it returns an empty dict.
+
+        Returns:
+            Dict[str, Any]: Serialized state of the component
+        """
+        return {}
+
+    def load_state(self, state: Dict[str, Any]) -> None:
+        """Load component state from a serialized dictionary.
+
+        This method can be overridden by components to customize
+        their deserialization behavior. By default, it does nothing.
+
+        Args:
+            state (Dict[str, Any]): Previously serialized component state
+        """
+        pass

--- a/src/neo4j_graphrag/experimental/pipeline/stores.py
+++ b/src/neo4j_graphrag/experimental/pipeline/stores.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import abc
 import asyncio
-from typing import Any
+from typing import Any, Dict
 
 
 class Store(abc.ABC):
@@ -90,6 +90,22 @@ class ResultStore(Store, abc.ABC):
     async def get_result_for_component(self, run_id: str, task_name: str) -> Any:
         return await self.get(self.get_key(run_id, task_name))
 
+    def dump(self) -> Dict[str, Any]:
+        """Dump the store data to a serializable dictionary.
+
+        Returns:
+            dict[str, Any]: A serializable representation of the store data
+        """
+        raise NotImplementedError("Subclasses must implement this method")
+
+    def load(self, data: Dict[str, Any]) -> None:
+        """Load store data from a serialized dictionary.
+
+        Args:
+            data (dict[str, Any]): Previously serialized store data
+        """
+        raise NotImplementedError("Subclasses must implement this method")
+
 
 class InMemoryStore(ResultStore):
     """Simple in-memory store.
@@ -115,3 +131,20 @@ class InMemoryStore(ResultStore):
 
     def empty(self) -> None:
         self._data = {}
+
+    def dump(self) -> Dict[str, Any]:
+        """Dump the in-memory store data to a serializable dictionary.
+
+        Returns:
+            dict[str, Any]: A serializable representation of the store data
+        """
+        return {"data": self._data.copy()}
+
+    def load(self, data: Dict[str, Any]) -> None:
+        """Load in-memory store data from a serialized dictionary.
+
+        Args:
+            data (dict[str, Any]): Previously serialized store data
+        """
+        if "data" in data:
+            self._data = data["data"].copy()

--- a/src/neo4j_graphrag/experimental/pipeline/stores.py
+++ b/src/neo4j_graphrag/experimental/pipeline/stores.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import abc
 import asyncio
-from typing import Any, Dict
+from typing import Any
 
 
 class Store(abc.ABC):
@@ -90,22 +90,6 @@ class ResultStore(Store, abc.ABC):
     async def get_result_for_component(self, run_id: str, task_name: str) -> Any:
         return await self.get(self.get_key(run_id, task_name))
 
-    def dump(self) -> Dict[str, Any]:
-        """Dump the store data to a serializable dictionary.
-
-        Returns:
-            dict[str, Any]: A serializable representation of the store data
-        """
-        raise NotImplementedError("Subclasses must implement this method")
-
-    def load(self, data: Dict[str, Any]) -> None:
-        """Load store data from a serialized dictionary.
-
-        Args:
-            data (dict[str, Any]): Previously serialized store data
-        """
-        raise NotImplementedError("Subclasses must implement this method")
-
 
 class InMemoryStore(ResultStore):
     """Simple in-memory store.
@@ -131,20 +115,3 @@ class InMemoryStore(ResultStore):
 
     def empty(self) -> None:
         self._data = {}
-
-    def dump(self) -> Dict[str, Any]:
-        """Dump the in-memory store data to a serializable dictionary.
-
-        Returns:
-            dict[str, Any]: A serializable representation of the store data
-        """
-        return {"data": self._data.copy()}
-
-    def load(self, data: Dict[str, Any]) -> None:
-        """Load in-memory store data from a serialized dictionary.
-
-        Args:
-            data (dict[str, Any]): Previously serialized store data
-        """
-        if "data" in data:
-            self._data = data["data"].copy()

--- a/tests/unit/experimental/pipeline/components.py
+++ b/tests/unit/experimental/pipeline/components.py
@@ -13,6 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import asyncio
+from typing import Dict, Any
 
 from neo4j_graphrag.experimental.pipeline import Component, DataModel
 from neo4j_graphrag.experimental.pipeline.types.context import RunContext
@@ -63,3 +64,18 @@ class SlowComponentMultiply(Component):
     async def run(self, number1: int, number2: int = 2) -> IntResultModel:
         await asyncio.sleep(self.sleep)
         return IntResultModel(result=number1 * number2)
+
+
+class StatefulComponent(Component):
+    def __init__(self) -> None:
+        self.counter = 0
+
+    async def run(self, value: int) -> IntResultModel:
+        self.counter += value
+        return IntResultModel(result=self.counter)
+
+    def serialize_state(self) -> Dict[str, Any]:
+        return {"counter": self.counter}
+
+    def load_state(self, state: Dict[str, Any]) -> None:
+        self.counter = state.get("counter", 0)

--- a/tests/unit/experimental/pipeline/test_component.py
+++ b/tests/unit/experimental/pipeline/test_component.py
@@ -18,7 +18,12 @@ import pytest
 
 from neo4j_graphrag.experimental.pipeline import Component
 from neo4j_graphrag.experimental.pipeline.types.context import RunContext
-from .components import ComponentMultiply, ComponentMultiplyWithContext, IntResultModel
+from .components import (
+    ComponentMultiply,
+    ComponentMultiplyWithContext,
+    IntResultModel,
+    StatefulComponent,
+)
 
 
 def test_component_inputs() -> None:
@@ -87,3 +92,13 @@ def test_component_missing_method() -> None:
         "You must implement either `run` or `run_with_context` in Component 'WrongComponent'"
         in str(e)
     )
+
+
+def test_stateful_component_serialize_and_load_state() -> None:
+    c = StatefulComponent()
+    c.counter = 42
+    state = c.serialize_state()
+    assert state == {"counter": 42}
+    c.counter = 0
+    c.load_state({"counter": 99})
+    assert c.counter == 99


### PR DESCRIPTION
# Description

This PR introduces state management capabilities to the `Pipeline` class, enabling:
- Checkpointing pipeline execution at specific components using `run_until`
- Resuming pipeline execution from saved states using `resume_from`
- Saving/loading pipeline state to/from a json file or or passing it directly between pipeline runs.

The state includes pipeline configuration, execution results, and final results from previous runs. This feature is particularly useful for:
- Debugging long-running pipelines
- Recovering from failures
- Comparing component implementations with deterministic inputs

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

> **Note**
>
low
>
>

Complexity:

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
- [x] CHANGELOG.md updated if appropriate
