### PR TITLE
SchemaFromExistingGraphExtractor component

### DIFF
--- a/examples/customize/build_graph/components/schema_builders/schema_from_existing_graph.py
+++ b/examples/customize/build_graph/components/schema_builders/schema_from_existing_graph.py
@@ -16,7 +16,6 @@ from neo4j_graphrag.experimental.components.schema import (
 URI = "neo4j+s://demo.neo4jlabs.com"
 AUTH = ("recommendations", "recommendations")
 DATABASE = "recommendations"
-INDEX = "moviePlotsEmbedding"
 
 
 async def main() -> None:

--- a/examples/customize/build_graph/components/schema_builders/schema_from_existing_graph.py
+++ b/examples/customize/build_graph/components/schema_builders/schema_from_existing_graph.py
@@ -1,0 +1,35 @@
+"""This example demonstrates how to use the SchemaFromExistingGraphExtractor component
+to automatically extract a schema from an existing Neo4j database.
+"""
+
+import asyncio
+
+import neo4j
+
+from neo4j_graphrag.experimental.components.schema import (
+    SchemaFromExistingGraphExtractor,
+    GraphSchema,
+)
+
+
+URI = "neo4j+s://demo.neo4jlabs.com"
+AUTH = ("recommendations", "recommendations")
+DATABASE = "recommendations"
+INDEX = "moviePlotsEmbedding"
+
+
+async def main() -> None:
+    """Run the example."""
+
+    with neo4j.GraphDatabase.driver(
+        URI,
+        auth=AUTH,
+    ) as driver:
+        extractor = SchemaFromExistingGraphExtractor(driver)
+        schema: GraphSchema = await extractor.run()
+        # schema.store_as_json("my_schema.json")
+        print(schema)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/customize/build_graph/components/schema_builders/schema_from_existing_graph.py
+++ b/examples/customize/build_graph/components/schema_builders/schema_from_existing_graph.py
@@ -3,6 +3,7 @@ to automatically extract a schema from an existing Neo4j database.
 """
 
 import asyncio
+from pprint import pprint
 
 import neo4j
 
@@ -25,10 +26,18 @@ async def main() -> None:
         URI,
         auth=AUTH,
     ) as driver:
-        extractor = SchemaFromExistingGraphExtractor(driver)
+        extractor = SchemaFromExistingGraphExtractor(
+            driver,
+            # optional:
+            neo4j_database=DATABASE,
+            additional_patterns=True,
+            additional_node_types=True,
+            additional_relationship_types=True,
+            additional_properties=True,
+        )
         schema: GraphSchema = await extractor.run()
         # schema.store_as_json("my_schema.json")
-        print(schema)
+        pprint(schema.model_dump())
 
 
 if __name__ == "__main__":

--- a/src/neo4j_graphrag/experimental/components/schema.py
+++ b/src/neo4j_graphrag/experimental/components/schema.py
@@ -703,7 +703,7 @@ class SchemaFromExistingGraphExtractor(BaseSchemaBuilder):
                 existence_constraint.append((lab, prop))
         return existence_constraint
 
-    async def run(self, *args, **kwargs) -> GraphSchema:
+    async def run(self, *args: Any, **kwargs: Any) -> GraphSchema:
         structured_schema = get_structured_schema(self.driver, database=self.database)
         existence_constraint = self._extract_required_properties(structured_schema)
 

--- a/src/neo4j_graphrag/experimental/pipeline/config/template_pipeline/simple_kg_builder.py
+++ b/src/neo4j_graphrag/experimental/pipeline/config/template_pipeline/simple_kg_builder.py
@@ -44,6 +44,7 @@ from neo4j_graphrag.experimental.components.schema import (
     SchemaBuilder,
     GraphSchema,
     SchemaFromTextExtractor,
+    BaseSchemaBuilder,
 )
 from neo4j_graphrag.experimental.components.text_splitters.base import TextSplitter
 from neo4j_graphrag.experimental.components.text_splitters.fixed_size_splitter import (
@@ -178,7 +179,7 @@ class SimpleKGPipelineConfig(TemplatePipelineConfig):
     def _get_chunk_embedder(self) -> TextChunkEmbedder:
         return TextChunkEmbedder(embedder=self.get_default_embedder())
 
-    def _get_schema(self) -> Union[SchemaBuilder, SchemaFromTextExtractor]:
+    def _get_schema(self) -> BaseSchemaBuilder:
         """
         Get the appropriate schema component based on configuration.
         Return SchemaFromTextExtractor for automatic extraction or SchemaBuilder for manual schema.

--- a/tests/unit/experimental/components/test_schema.py
+++ b/tests/unit/experimental/components/test_schema.py
@@ -962,7 +962,7 @@ async def test_schema_from_text_filters_relationships_without_labels(
 
 @pytest.mark.asyncio
 @patch("neo4j_graphrag.experimental.components.schema.get_structured_schema")
-async def test_schema_from_existing_graph(mock_get_structured_schema: Mock):
+async def test_schema_from_existing_graph(mock_get_structured_schema: Mock) -> None:
     mock_get_structured_schema.return_value = {
         "node_props": {
             "Person": [

--- a/tests/unit/experimental/components/test_schema.py
+++ b/tests/unit/experimental/components/test_schema.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import json
 from typing import Tuple, Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, patch, Mock
 
 import pytest
 from pydantic import ValidationError
@@ -29,6 +29,7 @@ from neo4j_graphrag.experimental.components.schema import (
     RelationshipType,
     SchemaFromTextExtractor,
     GraphSchema,
+    SchemaFromExistingGraphExtractor,
 )
 import os
 import tempfile
@@ -957,3 +958,66 @@ async def test_schema_from_text_filters_relationships_without_labels(
     assert len(schema.patterns) == 2
     assert ("Person", "WORKS_FOR", "Organization") in schema.patterns
     assert ("Person", "MANAGES", "Organization") in schema.patterns
+
+
+@pytest.mark.asyncio
+@patch("neo4j_graphrag.experimental.components.schema.get_structured_schema")
+async def test_schema_from_existing_graph(mock_get_structured_schema: Mock):
+    mock_get_structured_schema.return_value = {
+        "node_props": {
+            "Person": [
+                {"property": "id", "type": "INTEGER"},
+                {"property": "name", "type": "STRING"},
+            ]
+        },
+        "rel_props": {"KNOWS": [{"property": "fromDate", "type": "DATE"}]},
+        "relationships": [
+            {"start": "Person", "type": "KNOWS", "end": "Person"},
+            {"start": "Person", "type": "LIVES_IN", "end": "City"},
+        ],
+        "metadata": {
+            "constraint": [
+                {
+                    "id": 7,
+                    "name": "person_id",
+                    "type": "NODE_PROPERTY_EXISTENCE",
+                    "entityType": "NODE",
+                    "labelsOrTypes": ["Person"],
+                    "properties": ["id"],
+                    "ownedIndex": "person_id",
+                    "propertyType": None,
+                },
+            ],
+            "index": [
+                {
+                    "label": "Person",
+                    "properties": ["name"],
+                    "size": 2,
+                    "type": "RANGE",
+                    "valuesSelectivity": 1.0,
+                    "distinctValues": 2.0,
+                },
+            ],
+        },
+    }
+    driver = Mock()
+    schema_builder = SchemaFromExistingGraphExtractor(
+        driver=driver,
+    )
+    schema = await schema_builder.run()
+    assert isinstance(schema, GraphSchema)
+    assert len(schema.node_types) == 2
+    person_node_type = schema.node_type_from_label("Person")
+    assert person_node_type is not None
+    id_person_property = [p for p in person_node_type.properties if p.name == "id"][0]
+    assert id_person_property.required is True
+
+    assert schema.node_type_from_label("City") is not None
+    assert len(schema.relationship_types) == 2
+    assert schema.relationship_type_from_label("KNOWS") is not None
+    assert schema.relationship_type_from_label("LIVES_IN") is not None
+
+    assert schema.patterns == (
+        ("Person", "KNOWS", "Person"),
+        ("Person", "LIVES_IN", "City"),
+    )


### PR DESCRIPTION
# Description

This PR adds a new component: `SchemaFromExistingGraphExtractor` that builds ta `GraphSchema` object from an exiting database:

```
    with neo4j.GraphDatabase.driver(
        URI,
        auth=AUTH,
    ) as driver:
        extractor = SchemaFromExistingGraphExtractor(driver)
        schema: GraphSchema = await extractor.run()
        # schema.store_as_json("my_schema.json")
        print(schema)
```

It leverages the `get_structured_schema` function and transform its output into a `GraphSchema` object.


## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Low

## How Has This Been Tested?
- [ ] Unit tests
- [ ] E2E tests
- [x] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
