### PR TITLE
Fix invalid extracted schema

### DIFF
--- a/docs/source/user_guide_kg_builder.rst
+++ b/docs/source/user_guide_kg_builder.rst
@@ -837,7 +837,7 @@ Instead of manually defining the schema, you can use the `SchemaFromTextExtracto
     # Extract the schema from the text
     extracted_schema = await schema_extractor.run(text="Some text")
 
-The `SchemaFromTextExtractor` component analyzes the text and identifies entity types, relationship types, and their property types. It creates a complete `GraphSchema` object that can be used in the same way as a manually defined schema.
+The `SchemaFromTextExtractor` component analyzes the text and identifies node types, relationship types, their property types, and the patterns connecting them. It creates a complete `GraphSchema` object that can be used in the same way as a manually defined schema.
 
 You can also save and reload the extracted schema:
 

--- a/src/neo4j_graphrag/experimental/components/schema.py
+++ b/src/neo4j_graphrag/experimental/components/schema.py
@@ -494,7 +494,7 @@ class SchemaFromTextExtractor(Component):
                 entity2_valid = entity2 in valid_node_labels
                 relation_valid = relation in valid_relationship_labels
 
-                logging.warning(
+                logging.info(
                     f"Filtering out invalid pattern: {pattern}. "
                     f"Entity1 '{entity1}' valid: {entity1_valid}, "
                     f"Entity2 '{entity2}' valid: {entity2_valid}, "

--- a/src/neo4j_graphrag/experimental/components/schema.py
+++ b/src/neo4j_graphrag/experimental/components/schema.py
@@ -449,14 +449,14 @@ class SchemaFromTextExtractor(Component):
         """
         # Early returns for missing required types
         if not node_types:
-            logging.warning(
+            logging.info(
                 "Filtering out all patterns because no node types are defined. "
                 "Patterns reference node types that must be defined."
             )
             return []
 
         if not relationship_types:
-            logging.warning(
+            logging.info(
                 "Filtering out all patterns because no relationship types are defined. "
                 "GraphSchema validation requires relationship_types when patterns are provided."
             )
@@ -533,7 +533,7 @@ class SchemaFromTextExtractor(Component):
             # handle list
             elif isinstance(extracted_schema, list):
                 if len(extracted_schema) == 0:
-                    logging.warning(
+                    logging.info(
                         "LLM returned an empty list for schema. Falling back to empty schema."
                     )
                     extracted_schema = {}

--- a/src/neo4j_graphrag/generation/prompts.py
+++ b/src/neo4j_graphrag/generation/prompts.py
@@ -207,16 +207,16 @@ class SchemaExtractionTemplate(PromptTemplate):
 You are a top-tier algorithm designed for extracting a labeled property graph schema in
 structured formats.
 
-Generate a generalized graph schema based on the input text. Identify key entity types,
+Generate a generalized graph schema based on the input text. Identify key node types,
 their relationship types, and property types.
 
 IMPORTANT RULES:
 1. Return only abstract schema information, not concrete instances.
-2. Use singular PascalCase labels for entity types (e.g., Person, Company, Product).
-3. Use UPPER_SNAKE_CASE for relationship types (e.g., WORKS_FOR, MANAGES).
+2. Use singular PascalCase labels for node types (e.g., Person, Company, Product).
+3. Use UPPER_SNAKE_CASE labels for relationship types (e.g., WORKS_FOR, MANAGES).
 4. Include property definitions only when the type can be confidently inferred, otherwise omit them.
-5. When defining potential_schema, ensure that every entity and relation mentioned exists in your entities and relations lists.
-6. Do not create entity types that aren't clearly mentioned in the text.
+5. When defining patterns, ensure that every node label and relationship label mentioned exists in your lists of node types and relationship types.
+6. Do not create node types that aren't clearly mentioned in the text.
 7. Keep your schema minimal and focused on clearly identifiable patterns in the text.
 
 Accepted property types are: BOOLEAN, DATE, DURATION, FLOAT, INTEGER, LIST,

--- a/tests/unit/experimental/components/test_schema.py
+++ b/tests/unit/experimental/components/test_schema.py
@@ -772,6 +772,101 @@ def schema_json_with_invalid_relationship_patterns() -> str:
     """
 
 
+@pytest.fixture
+def schema_json_with_nodes_without_labels() -> str:
+    return """
+    {
+        "node_types": [
+            {
+                "label": "Person",
+                "properties": [
+                    {"name": "name", "type": "STRING"}
+                ]
+            },
+            {
+                "properties": [
+                    {"name": "name", "type": "STRING"}
+                ]
+            },
+            {
+                "label": "",
+                "properties": [
+                    {"name": "name", "type": "STRING"}
+                ]
+            },
+            {
+                "label": "Organization",
+                "properties": [
+                    {"name": "name", "type": "STRING"}
+                ]
+            }
+        ],
+        "relationship_types": [
+            {
+                "label": "WORKS_FOR",
+                "properties": [
+                    {"name": "since", "type": "DATE"}
+                ]
+            }
+        ],
+        "patterns": [
+            ["Person", "WORKS_FOR", "Organization"]
+        ]
+    }
+    """
+
+
+@pytest.fixture
+def schema_json_with_relationships_without_labels() -> str:
+    return """
+    {
+        "node_types": [
+            {
+                "label": "Person",
+                "properties": [
+                    {"name": "name", "type": "STRING"}
+                ]
+            },
+            {
+                "label": "Organization",
+                "properties": [
+                    {"name": "name", "type": "STRING"}
+                ]
+            }
+        ],
+        "relationship_types": [
+            {
+                "label": "WORKS_FOR",
+                "properties": [
+                    {"name": "since", "type": "DATE"}
+                ]
+            },
+            {
+                "properties": [
+                    {"name": "since", "type": "DATE"}
+                ]
+            },
+            {
+                "label": "",
+                "properties": [
+                    {"name": "since", "type": "DATE"}
+                ]
+            },
+            {
+                "label": "MANAGES",
+                "properties": [
+                    {"name": "since", "type": "DATE"}
+                ]
+            }
+        ],
+        "patterns": [
+            ["Person", "WORKS_FOR", "Organization"],
+            ["Person", "MANAGES", "Organization"]
+        ]
+    }
+    """
+
+
 @pytest.mark.asyncio
 async def test_schema_from_text_filters_invalid_node_patterns(
     schema_from_text: SchemaFromTextExtractor,
@@ -810,3 +905,55 @@ async def test_schema_from_text_filters_invalid_relationship_patterns(
     assert schema.patterns is not None
     assert len(schema.patterns) == 1
     assert schema.patterns[0] == ("Person", "WORKS_FOR", "Organization")
+
+
+@pytest.mark.asyncio
+async def test_schema_from_text_filters_nodes_without_labels(
+    schema_from_text: SchemaFromTextExtractor,
+    mock_llm: AsyncMock,
+    schema_json_with_nodes_without_labels: str,
+) -> None:
+    # configure the mock LLM to return schema with nodes without labels
+    mock_llm.ainvoke.return_value = LLMResponse(
+        content=schema_json_with_nodes_without_labels
+    )
+
+    # run the schema extraction
+    schema = await schema_from_text.run(text="Sample text for extraction")
+
+    # verify that nodes without labels were filtered out (2 out of 4 nodes should be removed)
+    assert len(schema.node_types) == 2
+    assert schema.node_type_from_label("Person") is not None
+    assert schema.node_type_from_label("Organization") is not None
+
+    # verify that the pattern is still valid with the remaining nodes
+    assert schema.patterns is not None
+    assert len(schema.patterns) == 1
+    assert schema.patterns[0] == ("Person", "WORKS_FOR", "Organization")
+
+
+@pytest.mark.asyncio
+async def test_schema_from_text_filters_relationships_without_labels(
+    schema_from_text: SchemaFromTextExtractor,
+    mock_llm: AsyncMock,
+    schema_json_with_relationships_without_labels: str,
+) -> None:
+    # configure the mock LLM to return schema with relationships without labels
+    mock_llm.ainvoke.return_value = LLMResponse(
+        content=schema_json_with_relationships_without_labels
+    )
+
+    # run the schema extraction
+    schema = await schema_from_text.run(text="Sample text for extraction")
+
+    # verify that relationships without labels were filtered out (2 out of 4 relationships should be removed)
+    assert schema.relationship_types is not None
+    assert len(schema.relationship_types) == 2
+    assert schema.relationship_type_from_label("WORKS_FOR") is not None
+    assert schema.relationship_type_from_label("MANAGES") is not None
+
+    # verify that the patterns are still valid with the remaining relationships
+    assert schema.patterns is not None
+    assert len(schema.patterns) == 2
+    assert ("Person", "WORKS_FOR", "Organization") in schema.patterns
+    assert ("Person", "MANAGES", "Organization") in schema.patterns


### PR DESCRIPTION
# Description

When using `SchemaFromTextExtractor` for automatic schema extraction, the LLM sometimes generates patterns that reference undefined node types or relationship types. This causes Pydantic validation errors in `GraphSchema.model_validate()`, leading to pipeline crashes.

This PR adds a post processing layer after schema is inferred to filter out invalid patterns before schema validation.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: low

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
