### PR TITLE
Removes | char from type hints to be compatible with Python 3.9

### DIFF
--- a/src/neo4j_graphrag/experimental/components/entity_relation_extractor.py
+++ b/src/neo4j_graphrag/experimental/components/entity_relation_extractor.py
@@ -187,7 +187,7 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
     def __init__(
         self,
         llm: LLMInterface,
-        prompt_template: ERExtractionTemplate | str = ERExtractionTemplate(),
+        prompt_template: Union[ERExtractionTemplate, str] = ERExtractionTemplate(),
         create_lexical_graph: bool = True,
         on_error: OnError = OnError.RAISE,
         max_concurrency: int = 5,

--- a/src/neo4j_graphrag/experimental/components/entity_relation_extractor.py
+++ b/src/neo4j_graphrag/experimental/components/entity_relation_extractor.py
@@ -291,7 +291,7 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
         chunks: TextChunks,
         document_info: Optional[DocumentInfo] = None,
         lexical_graph_config: Optional[LexicalGraphConfig] = None,
-        schema: Union[GraphSchema, None] = None,
+        schema: Optional[GraphSchema] = None,
         examples: str = "",
         **kwargs: Any,
     ) -> Neo4jGraph:

--- a/src/neo4j_graphrag/experimental/pipeline/component.py
+++ b/src/neo4j_graphrag/experimental/pipeline/component.py
@@ -15,12 +15,12 @@
 from __future__ import annotations
 
 import inspect
-from typing import Any, get_type_hints
+from typing import Any, Union, get_type_hints
 
 from pydantic import BaseModel
 
-from neo4j_graphrag.experimental.pipeline.types.context import RunContext
 from neo4j_graphrag.experimental.pipeline.exceptions import PipelineDefinitionError
+from neo4j_graphrag.experimental.pipeline.types.context import RunContext
 from neo4j_graphrag.utils.validation import issubclass_safe
 
 
@@ -80,8 +80,8 @@ class Component(metaclass=ComponentMeta):
     # these variables are filled by the metaclass
     # added here for the type checker
     # DO NOT CHANGE
-    component_inputs: dict[str, dict[str, str | bool]]
-    component_outputs: dict[str, dict[str, str | bool | type]]
+    component_inputs: dict[str, dict[str, Union[str, bool]]]
+    component_outputs: dict[str, dict[str, Union[str, bool, type]]]
 
     async def run(self, *args: Any, **kwargs: Any) -> DataModel:
         """Run the component and return its result.

--- a/src/neo4j_graphrag/experimental/pipeline/config/base.py
+++ b/src/neo4j_graphrag/experimental/pipeline/config/base.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Union
+from typing import Any, Optional
 
 from pydantic import BaseModel, PrivateAttr
 
@@ -58,5 +58,5 @@ class AbstractConfig(BaseModel):
             for param_name, param in params.items()
         }
 
-    def parse(self, resolved_data: Union[dict[str, Any], None] = None) -> Any:
+    def parse(self, resolved_data: Optional[dict[str, Any]] = None) -> Any:
         raise NotImplementedError()

--- a/src/neo4j_graphrag/experimental/pipeline/config/base.py
+++ b/src/neo4j_graphrag/experimental/pipeline/config/base.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Union
 
 from pydantic import BaseModel, PrivateAttr
 
@@ -58,5 +58,5 @@ class AbstractConfig(BaseModel):
             for param_name, param in params.items()
         }
 
-    def parse(self, resolved_data: dict[str, Any] | None = None) -> Any:
+    def parse(self, resolved_data: Union[dict[str, Any], None] = None) -> Any:
         raise NotImplementedError()

--- a/src/neo4j_graphrag/experimental/pipeline/config/object_config.py
+++ b/src/neo4j_graphrag/experimental/pipeline/config/object_config.py
@@ -64,7 +64,7 @@ class ObjectConfig(AbstractConfig, Generic[T]):
     and its constructor parameters.
     """
 
-    class_: Union[str, None] = Field(default=None, validate_default=True)
+    class_: Optional[str] = Field(default=None, validate_default=True)
     """Path to class to be instantiated."""
     params_: dict[str, ParamConfig] = {}
     """Initialization parameters."""
@@ -119,7 +119,7 @@ class ObjectConfig(AbstractConfig, Generic[T]):
             raise ValueError(f"Could not find {class_name} in {module_name}")
         return cast(type, klass)
 
-    def parse(self, resolved_data: Union[dict[str, Any], None] = None) -> T:
+    def parse(self, resolved_data: Optional[dict[str, Any]] = None) -> T:
         """Import `class_`, resolve `params_` and instantiate object."""
         self._global_data = resolved_data or {}
         logger.debug(f"OBJECT_CONFIG: parsing {self} using {resolved_data}")
@@ -153,7 +153,7 @@ class Neo4jDriverConfig(ObjectConfig[neo4j.Driver]):
         # not used
         return "not used"
 
-    def parse(self, resolved_data: Union[dict[str, Any], None] = None) -> neo4j.Driver:
+    def parse(self, resolved_data: Optional[dict[str, Any]] = None) -> neo4j.Driver:
         params = self.resolve_params(self.params_)
         # we know these params are there because of the required params validator
         uri = params.pop("uri")
@@ -176,7 +176,7 @@ class Neo4jDriverType(RootModel):  # type: ignore[type-arg]
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    def parse(self, resolved_data: Union[dict[str, Any], None] = None) -> neo4j.Driver:
+    def parse(self, resolved_data: Optional[dict[str, Any]] = None) -> neo4j.Driver:
         if isinstance(self.root, neo4j.Driver):
             return self.root
         # self.root is a Neo4jDriverConfig object
@@ -203,7 +203,7 @@ class LLMType(RootModel):  # type: ignore[type-arg]
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    def parse(self, resolved_data: Union[dict[str, Any], None] = None) -> LLMInterface:
+    def parse(self, resolved_data: Optional[dict[str, Any]] = None) -> LLMInterface:
         if isinstance(self.root, LLMInterface):
             return self.root
         return self.root.parse(resolved_data)
@@ -229,7 +229,7 @@ class EmbedderType(RootModel):  # type: ignore[type-arg]
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    def parse(self, resolved_data: Union[dict[str, Any], None] = None) -> Embedder:
+    def parse(self, resolved_data: Optional[dict[str, Any]] = None) -> Embedder:
         if isinstance(self.root, Embedder):
             return self.root
         return self.root.parse(resolved_data)
@@ -257,7 +257,7 @@ class ComponentType(RootModel):  # type: ignore[type-arg]
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    def parse(self, resolved_data: Union[dict[str, Any], None] = None) -> Component:
+    def parse(self, resolved_data: Optional[dict[str, Any]] = None) -> Component:
         if isinstance(self.root, Component):
             return self.root
         return self.root.parse(resolved_data)

--- a/src/neo4j_graphrag/experimental/pipeline/config/object_config.py
+++ b/src/neo4j_graphrag/experimental/pipeline/config/object_config.py
@@ -31,15 +31,7 @@ from __future__ import annotations
 
 import importlib
 import logging
-from typing import (
-    Any,
-    ClassVar,
-    Generic,
-    Optional,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import Any, ClassVar, Generic, Optional, TypeVar, Union, cast
 
 import neo4j
 from pydantic import (
@@ -58,7 +50,6 @@ from neo4j_graphrag.experimental.pipeline.config.param_resolver import (
 from neo4j_graphrag.llm import LLMInterface
 from neo4j_graphrag.utils.validation import issubclass_safe
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -73,7 +64,7 @@ class ObjectConfig(AbstractConfig, Generic[T]):
     and its constructor parameters.
     """
 
-    class_: str | None = Field(default=None, validate_default=True)
+    class_: Union[str, None] = Field(default=None, validate_default=True)
     """Path to class to be instantiated."""
     params_: dict[str, ParamConfig] = {}
     """Initialization parameters."""
@@ -128,7 +119,7 @@ class ObjectConfig(AbstractConfig, Generic[T]):
             raise ValueError(f"Could not find {class_name} in {module_name}")
         return cast(type, klass)
 
-    def parse(self, resolved_data: dict[str, Any] | None = None) -> T:
+    def parse(self, resolved_data: Union[dict[str, Any], None] = None) -> T:
         """Import `class_`, resolve `params_` and instantiate object."""
         self._global_data = resolved_data or {}
         logger.debug(f"OBJECT_CONFIG: parsing {self} using {resolved_data}")
@@ -162,7 +153,7 @@ class Neo4jDriverConfig(ObjectConfig[neo4j.Driver]):
         # not used
         return "not used"
 
-    def parse(self, resolved_data: dict[str, Any] | None = None) -> neo4j.Driver:
+    def parse(self, resolved_data: Union[dict[str, Any], None] = None) -> neo4j.Driver:
         params = self.resolve_params(self.params_)
         # we know these params are there because of the required params validator
         uri = params.pop("uri")
@@ -185,7 +176,7 @@ class Neo4jDriverType(RootModel):  # type: ignore[type-arg]
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    def parse(self, resolved_data: dict[str, Any] | None = None) -> neo4j.Driver:
+    def parse(self, resolved_data: Union[dict[str, Any], None] = None) -> neo4j.Driver:
         if isinstance(self.root, neo4j.Driver):
             return self.root
         # self.root is a Neo4jDriverConfig object
@@ -212,7 +203,7 @@ class LLMType(RootModel):  # type: ignore[type-arg]
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    def parse(self, resolved_data: dict[str, Any] | None = None) -> LLMInterface:
+    def parse(self, resolved_data: Union[dict[str, Any], None] = None) -> LLMInterface:
         if isinstance(self.root, LLMInterface):
             return self.root
         return self.root.parse(resolved_data)
@@ -238,7 +229,7 @@ class EmbedderType(RootModel):  # type: ignore[type-arg]
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    def parse(self, resolved_data: dict[str, Any] | None = None) -> Embedder:
+    def parse(self, resolved_data: Union[dict[str, Any], None] = None) -> Embedder:
         if isinstance(self.root, Embedder):
             return self.root
         return self.root.parse(resolved_data)
@@ -266,7 +257,7 @@ class ComponentType(RootModel):  # type: ignore[type-arg]
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    def parse(self, resolved_data: dict[str, Any] | None = None) -> Component:
+    def parse(self, resolved_data: Union[dict[str, Any], None] = None) -> Component:
         if isinstance(self.root, Component):
             return self.root
         return self.root.parse(resolved_data)

--- a/src/neo4j_graphrag/experimental/pipeline/config/runner.py
+++ b/src/neo4j_graphrag/experimental/pipeline/config/runner.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import (
     Annotated,
     Any,
+    Optional,
     Union,
 )
 
@@ -71,7 +72,7 @@ class PipelineConfigWrapper(BaseModel):
     ] = Field(discriminator=Discriminator(_get_discriminator_value))
 
     def parse(
-        self, resolved_data: Union[dict[str, Any], None] = None
+        self, resolved_data: Optional[dict[str, Any]] = None
     ) -> PipelineDefinition:
         logger.debug("PIPELINE_CONFIG: start parsing config...")
         return self.config.parse(resolved_data)

--- a/src/neo4j_graphrag/experimental/pipeline/config/runner.py
+++ b/src/neo4j_graphrag/experimental/pipeline/config/runner.py
@@ -93,7 +93,7 @@ class PipelineRunner:
     def __init__(
         self,
         pipeline_definition: PipelineDefinition,
-        config: Union[AbstractPipelineConfig, None] = None,
+        config: Optional[AbstractPipelineConfig] = None,
         do_cleaning: bool = False,
     ) -> None:
         self.config = config

--- a/src/neo4j_graphrag/experimental/pipeline/config/runner.py
+++ b/src/neo4j_graphrag/experimental/pipeline/config/runner.py
@@ -37,7 +37,6 @@ from pydantic.v1.utils import deep_update
 from typing_extensions import Self
 
 from neo4j_graphrag.experimental.pipeline import Pipeline
-from neo4j_graphrag.utils.file_handler import FileHandler
 from neo4j_graphrag.experimental.pipeline.config.pipeline_config import (
     AbstractPipelineConfig,
     PipelineConfig,
@@ -48,6 +47,7 @@ from neo4j_graphrag.experimental.pipeline.config.template_pipeline.simple_kg_bui
 from neo4j_graphrag.experimental.pipeline.config.types import PipelineType
 from neo4j_graphrag.experimental.pipeline.pipeline import PipelineResult
 from neo4j_graphrag.experimental.pipeline.types.definitions import PipelineDefinition
+from neo4j_graphrag.utils.file_handler import FileHandler
 from neo4j_graphrag.utils.logging import prettify
 
 logger = logging.getLogger(__name__)
@@ -70,7 +70,9 @@ class PipelineConfigWrapper(BaseModel):
         Annotated[SimpleKGPipelineConfig, Tag(PipelineType.SIMPLE_KG_PIPELINE)],
     ] = Field(discriminator=Discriminator(_get_discriminator_value))
 
-    def parse(self, resolved_data: dict[str, Any] | None = None) -> PipelineDefinition:
+    def parse(
+        self, resolved_data: Union[dict[str, Any], None] = None
+    ) -> PipelineDefinition:
         logger.debug("PIPELINE_CONFIG: start parsing config...")
         return self.config.parse(resolved_data)
 
@@ -90,7 +92,7 @@ class PipelineRunner:
     def __init__(
         self,
         pipeline_definition: PipelineDefinition,
-        config: AbstractPipelineConfig | None = None,
+        config: Union[AbstractPipelineConfig, None] = None,
         do_cleaning: bool = False,
     ) -> None:
         self.config = config
@@ -100,7 +102,9 @@ class PipelineRunner:
 
     @classmethod
     def from_config(
-        cls, config: AbstractPipelineConfig | dict[str, Any], do_cleaning: bool = False
+        cls,
+        config: Union[AbstractPipelineConfig, dict[str, Any]],
+        do_cleaning: bool = False,
     ) -> Self:
         wrapper = PipelineConfigWrapper.model_validate({"config": config})
         logger.debug(

--- a/src/neo4j_graphrag/experimental/pipeline/orchestrator.py
+++ b/src/neo4j_graphrag/experimental/pipeline/orchestrator.py
@@ -19,15 +19,15 @@ import logging
 import uuid
 import warnings
 from functools import partial
-from typing import TYPE_CHECKING, Any, AsyncGenerator
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Union
 
-from neo4j_graphrag.experimental.pipeline.types.context import RunContext
 from neo4j_graphrag.experimental.pipeline.exceptions import (
     PipelineDefinitionError,
     PipelineMissingDependencyError,
     PipelineStatusUpdateError,
 )
 from neo4j_graphrag.experimental.pipeline.notification import EventNotifier
+from neo4j_graphrag.experimental.pipeline.types.context import RunContext
 from neo4j_graphrag.experimental.pipeline.types.orchestration import (
     RunResult,
     RunStatus,
@@ -235,7 +235,7 @@ class Orchestrator:
         return component_inputs
 
     async def add_result_for_component(
-        self, name: str, result: dict[str, Any] | None, is_final: bool = False
+        self, name: str, result: Union[dict[str, Any], None], is_final: bool = False
     ) -> None:
         """This is where we save the results in the result store and, optionally,
         in the final result store.

--- a/src/neo4j_graphrag/experimental/pipeline/orchestrator.py
+++ b/src/neo4j_graphrag/experimental/pipeline/orchestrator.py
@@ -19,7 +19,7 @@ import logging
 import uuid
 import warnings
 from functools import partial
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Union
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Optional
 
 from neo4j_graphrag.experimental.pipeline.exceptions import (
     PipelineDefinitionError,
@@ -235,7 +235,7 @@ class Orchestrator:
         return component_inputs
 
     async def add_result_for_component(
-        self, name: str, result: Union[dict[str, Any], None], is_final: bool = False
+        self, name: str, result: Optional[dict[str, Any]], is_final: bool = False
     ) -> None:
         """This is where we save the results in the result store and, optionally,
         in the final result store.

--- a/src/neo4j_graphrag/experimental/pipeline/pipeline.py
+++ b/src/neo4j_graphrag/experimental/pipeline/pipeline.py
@@ -14,12 +14,12 @@
 #  limitations under the License.
 from __future__ import annotations
 
+import asyncio
 import logging
 import warnings
 from collections import defaultdict
 from timeit import default_timer
-from typing import Any, Optional, AsyncGenerator
-import asyncio
+from typing import Any, AsyncGenerator, Optional, Union
 
 from neo4j_graphrag.utils.logging import prettify
 
@@ -36,6 +36,12 @@ from neo4j_graphrag.experimental.pipeline.component import Component
 from neo4j_graphrag.experimental.pipeline.exceptions import (
     PipelineDefinitionError,
 )
+from neo4j_graphrag.experimental.pipeline.notification import (
+    Event,
+    EventCallbackProtocol,
+    EventType,
+    PipelineEvent,
+)
 from neo4j_graphrag.experimental.pipeline.orchestrator import Orchestrator
 from neo4j_graphrag.experimental.pipeline.pipeline_graph import (
     PipelineEdge,
@@ -43,20 +49,13 @@ from neo4j_graphrag.experimental.pipeline.pipeline_graph import (
     PipelineNode,
 )
 from neo4j_graphrag.experimental.pipeline.stores import InMemoryStore, ResultStore
+from neo4j_graphrag.experimental.pipeline.types.context import RunContext
 from neo4j_graphrag.experimental.pipeline.types.definitions import (
     ComponentDefinition,
     ConnectionDefinition,
     PipelineDefinition,
 )
 from neo4j_graphrag.experimental.pipeline.types.orchestration import RunResult
-from neo4j_graphrag.experimental.pipeline.types.context import RunContext
-from neo4j_graphrag.experimental.pipeline.notification import (
-    EventCallbackProtocol,
-    Event,
-    PipelineEvent,
-    EventType,
-)
-
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +78,7 @@ class TaskPipelineNode(PipelineNode):
 
     async def execute(
         self, context: RunContext, inputs: dict[str, Any]
-    ) -> RunResult | None:
+    ) -> Union[RunResult, None]:
         """Execute the task
 
         Returns:

--- a/src/neo4j_graphrag/experimental/pipeline/pipeline.py
+++ b/src/neo4j_graphrag/experimental/pipeline/pipeline.py
@@ -19,7 +19,7 @@ import logging
 import warnings
 from collections import defaultdict
 from timeit import default_timer
-from typing import Any, AsyncGenerator, Optional, Union
+from typing import Any, AsyncGenerator, Optional
 
 from neo4j_graphrag.utils.logging import prettify
 
@@ -78,7 +78,7 @@ class TaskPipelineNode(PipelineNode):
 
     async def execute(
         self, context: RunContext, inputs: dict[str, Any]
-    ) -> Union[RunResult, None]:
+    ) -> Optional[RunResult]:
         """Execute the task
 
         Returns:

--- a/src/neo4j_graphrag/experimental/pipeline/pipeline_graph.py
+++ b/src/neo4j_graphrag/experimental/pipeline/pipeline_graph.py
@@ -18,7 +18,7 @@ Basic graph structure for Pipeline.
 
 from __future__ import annotations
 
-from typing import Any, Generic, Optional, TypeVar
+from typing import Any, Generic, Optional, TypeVar, Union
 
 
 class PipelineNode:
@@ -124,7 +124,7 @@ class PipelineGraph(Generic[GenericNodeType, GenericEdgeType]):
                 res.append(edge)
         return res
 
-    def __contains__(self, node: GenericNodeType | str) -> bool:
+    def __contains__(self, node: Union[GenericNodeType, str]) -> bool:
         if isinstance(node, str):
             return node in self._nodes
         return node.name in self._nodes

--- a/src/neo4j_graphrag/generation/graphrag.py
+++ b/src/neo4j_graphrag/generation/graphrag.py
@@ -88,8 +88,8 @@ class GraphRAG:
         message_history: Optional[Union[List[LLMMessage], MessageHistory]] = None,
         examples: str = "",
         retriever_config: Optional[dict[str, Any]] = None,
-        return_context: bool | None = None,
-        response_fallback: str | None = None,
+        return_context: Union[bool, None] = None,
+        response_fallback: Union[str, None] = None,
     ) -> RagResultModel:
         """
         .. warning::

--- a/src/neo4j_graphrag/generation/graphrag.py
+++ b/src/neo4j_graphrag/generation/graphrag.py
@@ -88,8 +88,8 @@ class GraphRAG:
         message_history: Optional[Union[List[LLMMessage], MessageHistory]] = None,
         examples: str = "",
         retriever_config: Optional[dict[str, Any]] = None,
-        return_context: Union[bool, None] = None,
-        response_fallback: Union[str, None] = None,
+        return_context: Optional[bool] = None,
+        response_fallback: Optional[str] = None,
     ) -> RagResultModel:
         """
         .. warning::

--- a/src/neo4j_graphrag/generation/types.py
+++ b/src/neo4j_graphrag/generation/types.py
@@ -43,7 +43,7 @@ class RagSearchModel(BaseModel):
     examples: str = ""
     retriever_config: dict[str, Any] = {}
     return_context: bool = False
-    response_fallback: str | None = None
+    response_fallback: Union[str, None] = None
 
 
 class RagResultModel(BaseModel):

--- a/src/neo4j_graphrag/generation/types.py
+++ b/src/neo4j_graphrag/generation/types.py
@@ -14,7 +14,7 @@
 #  limitations under the License.
 from __future__ import annotations
 
-from typing import Any, Union
+from typing import Any, Optional
 
 from pydantic import BaseModel, ConfigDict, field_validator
 
@@ -43,11 +43,11 @@ class RagSearchModel(BaseModel):
     examples: str = ""
     retriever_config: dict[str, Any] = {}
     return_context: bool = False
-    response_fallback: Union[str, None] = None
+    response_fallback: Optional[str] = None
 
 
 class RagResultModel(BaseModel):
     answer: str
-    retriever_result: Union[RetrieverResult, None] = None
+    retriever_result: Optional[RetrieverResult] = None
 
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/tests/unit/experimental/components/test_graph_pruning.py
+++ b/tests/unit/experimental/components/test_graph_pruning.py
@@ -14,7 +14,7 @@
 #  limitations under the License.
 from __future__ import annotations
 
-from typing import Any, Union
+from typing import Any, Optional
 from unittest.mock import ANY, Mock, patch
 
 import pytest
@@ -369,7 +369,7 @@ def test_graph_pruning_validate_relationship(
     additional_relationship_types: bool,
     patterns: tuple[tuple[str, str, str], ...],
     additional_patterns: bool,
-    expected_relationship: Union[str, None],
+    expected_relationship: Optional[str],
     request: pytest.FixtureRequest,
 ) -> None:
     relationship_obj = request.getfixturevalue(relationship)

--- a/tests/unit/experimental/components/test_graph_pruning.py
+++ b/tests/unit/experimental/components/test_graph_pruning.py
@@ -13,27 +13,27 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from __future__ import annotations
-from typing import Any
-from unittest.mock import patch, Mock, ANY
+
+from typing import Any, Union
+from unittest.mock import ANY, Mock, patch
 
 import pytest
-
 from neo4j_graphrag.experimental.components.graph_pruning import (
     GraphPruning,
     GraphPruningResult,
     PruningStats,
 )
 from neo4j_graphrag.experimental.components.schema import (
+    GraphSchema,
     NodeType,
     PropertyType,
     RelationshipType,
-    GraphSchema,
 )
 from neo4j_graphrag.experimental.components.types import (
+    LexicalGraphConfig,
+    Neo4jGraph,
     Neo4jNode,
     Neo4jRelationship,
-    Neo4jGraph,
-    LexicalGraphConfig,
 )
 
 
@@ -369,7 +369,7 @@ def test_graph_pruning_validate_relationship(
     additional_relationship_types: bool,
     patterns: tuple[tuple[str, str, str], ...],
     additional_patterns: bool,
-    expected_relationship: str | None,
+    expected_relationship: Union[str, None],
     request: pytest.FixtureRequest,
 ) -> None:
     relationship_obj = request.getfixturevalue(relationship)

--- a/tests/unit/retrievers/test_base.py
+++ b/tests/unit/retrievers/test_base.py
@@ -15,7 +15,7 @@
 from __future__ import annotations  # Reminder: May be removed after Python 3.9 is EOL.
 
 import inspect
-from typing import Any, Union
+from typing import Any, Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -41,7 +41,7 @@ def test_retriever_version_support(
     mock_get_version: MagicMock,
     driver: MagicMock,
     db_version: tuple[tuple[int, ...], bool],
-    expected_exception: Union[type[ValueError], None],
+    expected_exception: Optional[type[ValueError]],
 ) -> None:
     mock_get_version.return_value = db_version
 


### PR DESCRIPTION
# Description

Removes | char from type hints to be compatible with Python 3.9


## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Low

## How Has This Been Tested?
- [X] Unit tests
- [X] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [X] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
