### PR TITLE
Fix ollama arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixed
 
 - Fixed documentation for PdfLoader
+- Fixed a bug where the `format` argument for `OllamaLLM` was not propagated to the client.
+
 
 ## 1.9.0
 

--- a/docs/source/user_guide_rag.rst
+++ b/docs/source/user_guide_rag.rst
@@ -225,6 +225,7 @@ it can be queried using the following:
     from neo4j_graphrag.llm import OllamaLLM
     llm = OllamaLLM(
         model_name="orca-mini",
+        # model_params={"options": {"temperature": 0}, "format": "json"},
         # host="...",  # when using a remote server
     )
     llm.invoke("say something")
@@ -305,17 +306,17 @@ Default Rate Limit Handler
 Rate limiting is enabled by default for all LLM instances with the following configuration:
 
 - **Max attempts**: 3
-- **Min wait**: 1.0 seconds  
+- **Min wait**: 1.0 seconds
 - **Max wait**: 60.0 seconds
 - **Multiplier**: 2.0 (exponential backoff)
 
 .. code:: python
 
     from neo4j_graphrag.llm import OpenAILLM
-    
+
     # Rate limiting is automatically enabled
     llm = OpenAILLM(model_name="gpt-4o")
-    
+
     # The LLM will automatically retry on rate limit errors
     response = llm.invoke("Hello, world!")
 
@@ -327,7 +328,7 @@ Rate limiting is enabled by default for all LLM instances with the following con
 
         from neo4j_graphrag.llm import OpenAILLM
         from neo4j_graphrag.llm.rate_limit import RetryRateLimitHandler
-        
+
         # Customize rate limiting parameters
         llm = OpenAILLM(
             model_name="gpt-4o",
@@ -348,15 +349,15 @@ You can customize the rate limiting behavior by creating your own rate limit han
 
     from neo4j_graphrag.llm import AnthropicLLM
     from neo4j_graphrag.llm.rate_limit import RateLimitHandler
-    
+
     class CustomRateLimitHandler(RateLimitHandler):
         """Implement your custom rate limiting strategy."""
         # Implement required methods: handle_sync, handle_async
         pass
-    
+
     # Create custom rate limit handler and pass it to the LLM interface
     custom_handler = CustomRateLimitHandler()
-    
+
     llm = AnthropicLLM(
         model_name="claude-3-sonnet-20240229",
         rate_limit_handler=custom_handler,
@@ -370,7 +371,7 @@ For high-throughput applications or when you handle rate limiting externally, yo
 .. code:: python
 
     from neo4j_graphrag.llm import CohereLLM, NoOpRateLimitHandler
-    
+
     # Disable rate limiting completely
     llm = CohereLLM(
         model_name="command-r-plus",

--- a/examples/customize/llms/ollama_llm.py
+++ b/examples/customize/llms/ollama_llm.py
@@ -6,6 +6,7 @@ from neo4j_graphrag.llm import LLMResponse, OllamaLLM
 
 llm = OllamaLLM(
     model_name="<model_name>",
+    # model_params={"options": {"temperature": 0}, "format": "json"},
     # host="...",  # if using a remote server
 )
 res: LLMResponse = llm.invoke("What is the additive color model?")

--- a/tests/unit/llm/test_ollama_llm.py
+++ b/tests/unit/llm/test_ollama_llm.py
@@ -49,6 +49,7 @@ def test_ollama_llm_happy_path_deprecated_options(mock_import: Mock) -> None:
             model_params=model_params,
         )
     assert len(record) == 1
+    assert isinstance(record[0].message, Warning)
     assert (
         'you must use model_params={"options": {"temperature": 0}}'
         in record[0].message.args[0]

--- a/tests/unit/llm/test_ollama_llm.py
+++ b/tests/unit/llm/test_ollama_llm.py
@@ -35,7 +35,7 @@ def test_ollama_llm_missing_dependency(mock_import: Mock) -> None:
 
 
 @patch("builtins.__import__")
-def test_ollama_llm_happy_path(mock_import: Mock) -> None:
+def test_ollama_llm_happy_path_deprecated_options(mock_import: Mock) -> None:
     mock_ollama = get_mock_ollama()
     mock_import.return_value = mock_ollama
     mock_ollama.Client.return_value.chat.return_value = MagicMock(
@@ -43,12 +43,18 @@ def test_ollama_llm_happy_path(mock_import: Mock) -> None:
     )
     model = "gpt"
     model_params = {"temperature": 0.3}
-    question = "What is graph RAG?"
-    llm = OllamaLLM(
-        model,
-        model_params=model_params,
+    with pytest.warns(DeprecationWarning) as record:
+        llm = OllamaLLM(
+            model,
+            model_params=model_params,
+        )
+    assert len(record) == 1
+    assert (
+        'you must use model_params={"options": {"temperature": 0}}'
+        in record[0].message.args[0]
     )
 
+    question = "What is graph RAG?"
     res = llm.invoke(question)
     assert isinstance(res, LLMResponse)
     assert res.content == "ollama chat response"
@@ -56,7 +62,52 @@ def test_ollama_llm_happy_path(mock_import: Mock) -> None:
         {"role": "user", "content": question},
     ]
     llm.client.chat.assert_called_once_with(  # type: ignore[attr-defined]
-        model=model, messages=messages, options=model_params
+        model=model, messages=messages, options={"temperature": 0.3}
+    )
+
+
+@patch("builtins.__import__")
+def test_ollama_llm_unsupported_streaming(mock_import: Mock) -> None:
+    mock_ollama = get_mock_ollama()
+    mock_import.return_value = mock_ollama
+    mock_ollama.Client.return_value.chat.return_value = MagicMock(
+        message=MagicMock(content="ollama chat response"),
+    )
+    model = "gpt"
+    model_params = {"stream": True}
+    with pytest.raises(ValueError):
+        OllamaLLM(
+            model,
+            model_params=model_params,
+        )
+
+
+@patch("builtins.__import__")
+def test_ollama_llm_happy_path(mock_import: Mock) -> None:
+    mock_ollama = get_mock_ollama()
+    mock_import.return_value = mock_ollama
+    mock_ollama.Client.return_value.chat.return_value = MagicMock(
+        message=MagicMock(content="ollama chat response"),
+    )
+    model = "gpt"
+    options = {"temperature": 0.3}
+    model_params = {"options": options, "format": "json"}
+    question = "What is graph RAG?"
+    llm = OllamaLLM(
+        model_name=model,
+        model_params=model_params,
+    )
+    res = llm.invoke(question)
+    assert isinstance(res, LLMResponse)
+    assert res.content == "ollama chat response"
+    messages = [
+        {"role": "user", "content": question},
+    ]
+    llm.client.chat.assert_called_once_with(  # type: ignore[attr-defined]
+        model=model,
+        messages=messages,
+        options=options,
+        format="json",
     )
 
 
@@ -68,7 +119,8 @@ def test_ollama_invoke_with_system_instruction_happy_path(mock_import: Mock) -> 
         message=MagicMock(content="ollama chat response"),
     )
     model = "gpt"
-    model_params = {"temperature": 0.3}
+    options = {"temperature": 0.3}
+    model_params = {"options": options, "format": "json"}
     llm = OllamaLLM(
         model,
         model_params=model_params,
@@ -81,7 +133,10 @@ def test_ollama_invoke_with_system_instruction_happy_path(mock_import: Mock) -> 
     messages = [{"role": "system", "content": system_instruction}]
     messages.append({"role": "user", "content": question})
     llm.client.chat.assert_called_once_with(  # type: ignore[attr-defined]
-        model=model, messages=messages, options=model_params
+        model=model,
+        messages=messages,
+        options=options,
+        format="json",
     )
 
 
@@ -93,7 +148,8 @@ def test_ollama_invoke_with_message_history_happy_path(mock_import: Mock) -> Non
         message=MagicMock(content="ollama chat response"),
     )
     model = "gpt"
-    model_params = {"temperature": 0.3}
+    options = {"temperature": 0.3}
+    model_params = {"options": options}
     llm = OllamaLLM(
         model,
         model_params=model_params,
@@ -109,7 +165,7 @@ def test_ollama_invoke_with_message_history_happy_path(mock_import: Mock) -> Non
     messages = [m for m in message_history]
     messages.append({"role": "user", "content": question})
     llm.client.chat.assert_called_once_with(  # type: ignore[attr-defined]
-        model=model, messages=messages, options=model_params
+        model=model, messages=messages, options=options
     )
 
 
@@ -123,7 +179,8 @@ def test_ollama_invoke_with_message_history_and_system_instruction(
         message=MagicMock(content="ollama chat response"),
     )
     model = "gpt"
-    model_params = {"temperature": 0.3}
+    options = {"temperature": 0.3}
+    model_params = {"options": options}
     system_instruction = "You are a helpful assistant."
     llm = OllamaLLM(
         model,
@@ -145,7 +202,7 @@ def test_ollama_invoke_with_message_history_and_system_instruction(
     messages.extend(message_history)
     messages.append({"role": "user", "content": question})
     llm.client.chat.assert_called_once_with(  # type: ignore[attr-defined]
-        model=model, messages=messages, options=model_params
+        model=model, messages=messages, options=options
     )
     assert llm.client.chat.call_count == 1  # type: ignore
 
@@ -156,7 +213,8 @@ def test_ollama_invoke_with_message_history_validation_error(mock_import: Mock) 
     mock_import.return_value = mock_ollama
     mock_ollama.ResponseError = ollama.ResponseError
     model = "gpt"
-    model_params = {"temperature": 0.3}
+    options = {"temperature": 0.3}
+    model_params = {"options": options}
     system_instruction = "You are a helpful assistant."
     llm = OllamaLLM(
         model,
@@ -187,7 +245,8 @@ async def test_ollama_ainvoke_happy_path(mock_import: Mock) -> None:
 
     mock_ollama.AsyncClient.return_value.chat = mock_chat_async
     model = "gpt"
-    model_params = {"temperature": 0.3}
+    options = {"temperature": 0.3}
+    model_params = {"options": options}
     question = "What is graph RAG?"
     llm = OllamaLLM(
         model,


### PR DESCRIPTION
# Description

(Not a fix for the issue itself but fix bug discovered thanks to this issue: https://github.com/neo4j/neo4j-graphrag-python/issues/376)

The `format` parameter for Ollama client was not propagated as intended [ollama doc](https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-chat-completion)

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High
>
>

Complexity:

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [x] Examples have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [x] CHANGELOG.md updated if appropriate
