### PR TITLE
modified retrievers to support optional node labels

### DIFF
--- a/src/neo4j_graphrag/retrievers/external/pinecone/pinecone.py
+++ b/src/neo4j_graphrag/retrievers/external/pinecone/pinecone.py
@@ -101,6 +101,7 @@ class PineconeNeo4jRetriever(ExternalRetriever):
             Callable[[neo4j.Record], RetrieverResultItem]
         ] = None,
         neo4j_database: Optional[str] = None,
+        node_label: Optional[str] = None,
     ):
         try:
             driver_model = Neo4jDriverModel(driver=driver)
@@ -116,6 +117,7 @@ class PineconeNeo4jRetriever(ExternalRetriever):
                 retrieval_query=retrieval_query,
                 result_formatter=result_formatter,
                 neo4j_database=neo4j_database,
+                node_label=node_label,
             )
         except ValidationError as e:
             raise RetrieverInitializationError(e.errors()) from e
@@ -138,6 +140,7 @@ class PineconeNeo4jRetriever(ExternalRetriever):
         self.return_properties = validated_data.return_properties
         self.retrieval_query = validated_data.retrieval_query
         self.result_formatter = validated_data.result_formatter
+        self.node_label = validated_data.node_label
 
     def get_search_results(
         self,
@@ -223,6 +226,7 @@ class PineconeNeo4jRetriever(ExternalRetriever):
         search_query = get_match_query(
             return_properties=self.return_properties,
             retrieval_query=self.retrieval_query,
+            node_label=self.node_label,
         )
 
         parameters = {

--- a/src/neo4j_graphrag/retrievers/external/pinecone/types.py
+++ b/src/neo4j_graphrag/retrievers/external/pinecone/types.py
@@ -59,3 +59,4 @@ class PineconeNeo4jRetrieverModel(BaseModel):
     retrieval_query: Optional[str] = None
     result_formatter: Optional[Callable[[neo4j.Record], RetrieverResultItem]] = None
     neo4j_database: Optional[str] = None
+    node_label: Optional[str] = None

--- a/src/neo4j_graphrag/retrievers/external/qdrant/qdrant.py
+++ b/src/neo4j_graphrag/retrievers/external/qdrant/qdrant.py
@@ -99,6 +99,7 @@ class QdrantNeo4jRetriever(ExternalRetriever):
             Callable[[neo4j.Record], RetrieverResultItem]
         ] = None,
         neo4j_database: Optional[str] = None,
+        node_label: Optional[str] = None,
     ):
         try:
             driver_model = Neo4jDriverModel(driver=driver)
@@ -116,6 +117,7 @@ class QdrantNeo4jRetriever(ExternalRetriever):
                 retrieval_query=retrieval_query,
                 result_formatter=result_formatter,
                 neo4j_database=neo4j_database,
+                node_label=node_label,
             )
         except ValidationError as e:
             raise RetrieverInitializationError(e.errors()) from e
@@ -138,6 +140,7 @@ class QdrantNeo4jRetriever(ExternalRetriever):
         self.return_properties = validated_data.return_properties
         self.retrieval_query = validated_data.retrieval_query
         self.result_formatter = validated_data.result_formatter
+        self.node_label = validated_data.node_label
 
     def get_search_results(
         self,
@@ -223,6 +226,7 @@ class QdrantNeo4jRetriever(ExternalRetriever):
         search_query = get_match_query(
             return_properties=self.return_properties,
             retrieval_query=self.retrieval_query,
+            node_label=self.node_label,
         )
 
         parameters = {

--- a/src/neo4j_graphrag/retrievers/external/qdrant/types.py
+++ b/src/neo4j_graphrag/retrievers/external/qdrant/types.py
@@ -54,3 +54,4 @@ class QdrantNeo4jRetrieverModel(BaseModel):
     retrieval_query: Optional[str] = None
     result_formatter: Optional[Callable[[neo4j.Record], RetrieverResultItem]] = None
     neo4j_database: Optional[str] = None
+    node_label: Optional[str] = None

--- a/src/neo4j_graphrag/retrievers/external/utils.py
+++ b/src/neo4j_graphrag/retrievers/external/utils.py
@@ -20,14 +20,19 @@ from neo4j_graphrag.neo4j_queries import get_query_tail
 
 
 def get_match_query(
-    return_properties: Optional[list[str]] = None, retrieval_query: Optional[str] = None
+    return_properties: Optional[list[str]] = None,
+    retrieval_query: Optional[str] = None,
+    node_label: Optional[str] = None,
 ) -> str:
     match_query = (
         "UNWIND $match_params AS match_param "
         "WITH match_param[0] AS match_id_value, match_param[1] AS score "
-        "MATCH (node) "
-        "WHERE node[$id_property] = match_id_value "
     )
+    if node_label:
+        match_query += f"MATCH (node:{node_label}) "
+    else:
+        match_query += "MATCH (node) "
+    match_query += "WHERE node[$id_property] = match_id_value "
     return match_query + get_query_tail(
         return_properties=return_properties,
         retrieval_query=retrieval_query,

--- a/src/neo4j_graphrag/retrievers/external/weaviate/types.py
+++ b/src/neo4j_graphrag/retrievers/external/weaviate/types.py
@@ -57,6 +57,7 @@ class WeaviateNeo4jRetrieverModel(BaseModel):
     retrieval_query: Optional[str] = None
     result_formatter: Optional[Callable[[neo4j.Record], RetrieverResultItem]] = None
     neo4j_database: Optional[str] = None
+    node_label: Optional[str] = None
 
 
 class WeaviateNeo4jSearchModel(VectorSearchModel):

--- a/src/neo4j_graphrag/retrievers/external/weaviate/weaviate.py
+++ b/src/neo4j_graphrag/retrievers/external/weaviate/weaviate.py
@@ -100,6 +100,7 @@ class WeaviateNeo4jRetriever(ExternalRetriever):
             Callable[[neo4j.Record], RetrieverResultItem]
         ] = None,
         neo4j_database: Optional[str] = None,
+        node_label: Optional[str] = None,
     ):
         try:
             driver_model = Neo4jDriverModel(driver=driver)
@@ -116,6 +117,7 @@ class WeaviateNeo4jRetriever(ExternalRetriever):
                 retrieval_query=retrieval_query,
                 result_formatter=result_formatter,
                 neo4j_database=neo4j_database,
+                node_label=node_label,
             )
         except ValidationError as e:
             raise RetrieverInitializationError(e.errors()) from e
@@ -134,6 +136,7 @@ class WeaviateNeo4jRetriever(ExternalRetriever):
         self.return_properties = validated_data.return_properties
         self.retrieval_query = validated_data.retrieval_query
         self.result_formatter = validated_data.result_formatter
+        self.node_label = validated_data.node_label
 
     def get_search_results(
         self,
@@ -234,6 +237,7 @@ class WeaviateNeo4jRetriever(ExternalRetriever):
         search_query = get_match_query(
             return_properties=self.return_properties,
             retrieval_query=self.retrieval_query,
+            node_label=self.node_label,
         )
 
         parameters = {


### PR DESCRIPTION
# Description

> **Note**
>
> Adds support for optional node label filtering to the external retrievers: WeaviateNeo4jRetriever, QdrantNeo4jRetriever, and PineconeNeo4jRetriever.
> 
> - Introduces an optional `node_label` parameter to the retriever constructors and models.
> - Updates Cypher query generation to use the label in the MATCH clause if provided.
> - Passes `node_label` from the retriever to the query logic.
> - Addresses issue #344.
>

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High
>
>

Complexity: Medium

## How Has This Been Tested?
- [ ] Unit tests
- [ ] E2E tests
- [x] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate