### PR TITLE
Fix e2e tests failure on merge

### DIFF
--- a/.github/workflows/scheduled-e2e-tests.yaml
+++ b/.github/workflows/scheduled-e2e-tests.yaml
@@ -3,7 +3,7 @@ name: 'Neo4j-GraphRAG Scheduled E2E Tests'
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 6 * * 1'
+    - cron: '0 6 * * 1,4' # Mon, Thu
   push:
     branches:
       - main


### PR DESCRIPTION
# Description

Problem: scheduled/main E2E fails due to runner disk limits

Solution: free disk, manual trigger, concurrency
- Add “Free up disk space” step (remove preinstalled SDKs, prune Docker/caches)
- Replace redundant Docker prune step.
- Enable manual runs via workflow_dispatch.
- Add top-level concurrency to serialise runs per branch and cancel older runs.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High
>
>

Complexity:

## How Has This Been Tested?
- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
