### PR TITLE
Fix LLMEntityRelationExtractor user guide

### DIFF
--- a/docs/source/user_guide_kg_builder.rst
+++ b/docs/source/user_guide_kg_builder.rst
@@ -897,6 +897,10 @@ It can be used in this way:
     from neo4j_graphrag.experimental.components.entity_relation_extractor import (
         LLMEntityRelationExtractor,
     )
+    from neo4j_graphrag.experimental.components.types import (
+        TextChunks,
+        TextChunk
+    )
     from neo4j_graphrag.llm import OpenAILLM
 
     extractor = LLMEntityRelationExtractor(
@@ -908,7 +912,7 @@ It can be used in this way:
             },
         )
     )
-    await extractor.run(chunks=TextChunks(chunks=[TextChunk(text="some text")]))
+    await extractor.run(chunks=TextChunks(chunks=[TextChunk(text="some text", index=0)]))
 
 
 .. warning::


### PR DESCRIPTION
# Description

The `LLMEntityRelationExtractor` example in the user guide is out of date **https://neo4j.com/docs/neo4j-graphrag-python/current/user_guide_kg_builder.html#entity-and-relation-extractor**.


## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Low

## How Has This Been Tested?
- [ ] Unit tests
- [ ] E2E tests
- [x] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [ ] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
