### PR TITLE
feat: Add Cypher 25 SEARCH clause support for vector retrievers

### DIFF
--- a/src/neo4j_graphrag/filters.py
+++ b/src/neo4j_graphrag/filters.py
@@ -367,3 +367,75 @@ def get_metadata_filter(
     param_store = ParameterStore()
     query = _construct_metadata_filter(filter, param_store, node_alias=node_alias)
     return query, param_store.params
+
+
+# Operators compatible with Cypher 25 SEARCH clause in-index filtering.
+# Only simple comparison operators (and AND combinations of them) can be
+# pushed down into the vector index scan.
+_SEARCH_COMPATIBLE_OPERATORS = {
+    OPERATOR_EQ,
+    OPERATOR_LT,
+    OPERATOR_LTE,
+    OPERATOR_GT,
+    OPERATOR_GTE,
+}
+
+
+def is_search_compatible_filter(filter: Any) -> bool:
+    """Check whether a filter dict can be evaluated inside a SEARCH clause.
+
+    The Cypher 25 SEARCH clause supports a limited subset of predicates
+    inside ``FOR ... WHERE``: simple comparisons (=, <, <=, >, >=) combined
+    with AND.  Anything else ($or, $in, $nin, $like, $ilike, $ne, $between)
+    requires the brute-force exact-KNN fallback.
+
+    Args:
+        filter: The filter dictionary to check.
+
+    Returns:
+        bool: True if the filter can be pushed into a SEARCH WHERE clause.
+    """
+    if not isinstance(filter, dict):
+        return False
+    if len(filter) == 0:
+        return True
+
+    for key, value in filter.items():
+        if key == OPERATOR_AND:
+            if not isinstance(value, list):
+                return False
+            return all(is_search_compatible_filter(item) for item in value)
+        if key == OPERATOR_OR:
+            return False
+        if key.startswith(OPERATOR_PREFIX):
+            return False
+        # key is a field name
+        if isinstance(value, dict):
+            if len(value) != 1:
+                return False
+            op = list(value.keys())[0]
+            if op not in _SEARCH_COMPATIBLE_OPERATORS:
+                return False
+        # bare value → implicit $eq, always compatible
+    return True
+
+
+def get_search_filter(
+    filter: dict[str, Any],
+    node_alias: str = DEFAULT_NODE_ALIAS,
+) -> tuple[str, dict[str, Any]]:
+    """Generate a WHERE clause suitable for use inside a SEARCH block.
+
+    This produces the same Cypher syntax as :func:`get_metadata_filter` but is
+    only called after :func:`is_search_compatible_filter` has confirmed the
+    filter is SEARCH-compatible.  The generated fragment is intended to be
+    placed inside ``SEARCH node IN (VECTOR INDEX ... FOR ... WHERE <here>)``.
+
+    Args:
+        filter: A SEARCH-compatible filter dict.
+        node_alias: The alias for the node variable in the generated Cypher.
+
+    Returns:
+        A ``(cypher_fragment, params)`` tuple.
+    """
+    return get_metadata_filter(filter, node_alias=node_alias)

--- a/src/neo4j_graphrag/indexes.py
+++ b/src/neo4j_graphrag/indexes.py
@@ -43,6 +43,7 @@ def create_vector_index(
     similarity_fn: Literal["euclidean", "cosine"],
     fail_if_exists: bool = False,
     neo4j_database: Optional[str] = None,
+    filter_properties: Optional[list[str]] = None,
 ) -> None:
     """
     This method constructs a Cypher query and executes it
@@ -89,6 +90,7 @@ def create_vector_index(
             ``euclidean`` or ``cosine``.
         fail_if_exists (bool): If True raise an error if the index already exists. Defaults to False.
         neo4j_database (Optional[str]): The name of the Neo4j database. If not provided, this defaults to the server's default database ("neo4j" by default) (`see reference to documentation <https://neo4j.com/docs/operations-manual/current/database-administration/#manage-databases-default>`_).
+        filter_properties (Optional[list[str]]): Node properties to declare as filterable in the index (Neo4j 2026.01+). When provided, generates a ``WITH [n.prop1, n.prop2]`` clause that enables in-index filtering via the Cypher 25 SEARCH clause. Defaults to None.
 
     Raises:
         ValueError: If validation of the input arguments fail.
@@ -109,8 +111,12 @@ def create_vector_index(
         ) from e
 
     try:
+        with_clause = ""
+        if filter_properties:
+            props = ", ".join([f"n.{prop}" for prop in filter_properties])
+            with_clause = f" WITH [{props}]"
         query = (
-            f"CREATE VECTOR INDEX $name {'' if fail_if_exists else 'IF NOT EXISTS'} FOR (n:{label}) ON n.{embedding_property} OPTIONS "
+            f"CREATE VECTOR INDEX $name {'' if fail_if_exists else 'IF NOT EXISTS'} FOR (n:{label}) ON n.{embedding_property}{with_clause} OPTIONS "
             "{ indexConfig: { `vector.dimensions`: toInteger($dimensions), `vector.similarity_function`: $similarity_fn } }"
         )
         logger.info(f"Creating vector index named '{name}'")

--- a/src/neo4j_graphrag/neo4j_queries.py
+++ b/src/neo4j_graphrag/neo4j_queries.py
@@ -18,7 +18,7 @@ import warnings
 from typing import Any, Optional, Union
 
 from neo4j_graphrag.exceptions import InvalidHybridSearchRankerError
-from neo4j_graphrag.filters import get_metadata_filter
+from neo4j_graphrag.filters import get_metadata_filter, get_search_filter, is_search_compatible_filter
 from neo4j_graphrag.types import EntityType, SearchType, HybridSearchRanker
 
 NODE_VECTOR_INDEX_QUERY = (
@@ -289,6 +289,64 @@ def _get_filtered_vector_query(
     )
 
 
+def _get_search_vector_query_no_filter(
+    node_label: str,
+) -> tuple[str, dict[str, Any]]:
+    """Build a SEARCH clause vector query without pre-filtering.
+
+    Uses the Cypher 25 ``MATCH ... SEARCH node IN (VECTOR INDEX ...)`` syntax
+    which leverages the ANN index directly without a WHERE predicate.
+
+    Args:
+        node_label: The label of the nodes to search.
+
+    Returns:
+        tuple[str, dict[str, Any]]: query and parameters
+    """
+    query = (
+        f"MATCH (node:`{node_label}`) "
+        "SEARCH node IN ("
+        "VECTOR INDEX $vector_index_name "
+        "FOR $query_vector "
+        "LIMIT $top_k"
+        ") SCORE AS score"
+    )
+    return query, {}
+
+
+def _get_search_vector_query(
+    filters: dict[str, Any],
+    node_label: str,
+    embedding_node_property: str,
+) -> tuple[str, dict[str, Any]]:
+    """Build a SEARCH clause vector query with in-index filtering.
+
+    Uses the Cypher 25 ``MATCH ... SEARCH node IN (VECTOR INDEX ... FOR ...
+    WHERE ... LIMIT ...) SCORE AS score`` syntax, which pushes compatible
+    predicates into the index scan itself — much faster than brute-force
+    exact KNN for filtered queries.
+
+    Args:
+        filters: A SEARCH-compatible filter dict (already validated).
+        node_label: The label of the nodes to search.
+        embedding_node_property: The name of the property holding the embeddings.
+
+    Returns:
+        tuple[str, dict[str, Any]]: query and parameters
+    """
+    where_clause, query_params = get_search_filter(filters, node_alias="node")
+    query = (
+        f"MATCH (node:`{node_label}`) "
+        "SEARCH node IN ("
+        "VECTOR INDEX $vector_index_name "
+        "FOR $query_vector "
+        f"WHERE {where_clause} "
+        "LIMIT $top_k"
+        ") SCORE AS score"
+    )
+    return query, query_params
+
+
 def get_search_query(
     search_type: SearchType,
     entity_type: EntityType = EntityType.NODE,
@@ -302,6 +360,7 @@ def get_search_query(
     use_parallel_runtime: bool = False,
     ranker: Union[str, HybridSearchRanker] = HybridSearchRanker.NAIVE,
     alpha: Optional[float] = None,
+    neo4j_version_supports_search_clause: bool = False,
 ) -> tuple[str, dict[str, Any]]:
     """
     Constructs a search query for vector or hybrid search, including optional pre-filtering
@@ -324,6 +383,7 @@ def get_search_query(
             Defaults to False.
         ranker (HybridSearchRanker): Type of ranker to order the results from retrieval.
         alpha (Optional[float]): Weight for the vector score when using the linear ranker. Only used when ranker is 'linear'. Defaults to 0.5 if not provided.
+        neo4j_version_supports_search_clause (bool): Whether the Neo4j version supports the Cypher 25 SEARCH clause (2026.01+). When True and filters are SEARCH-compatible, the query uses in-index filtering instead of brute-force exact KNN. Defaults to False.
 
     Returns:
         tuple[str, dict[str, Any]]: A tuple containing the constructed query string and
@@ -355,6 +415,17 @@ def get_search_query(
         elif search_type == SearchType.VECTOR:
             if filters:
                 if (
+                    neo4j_version_supports_search_clause
+                    and node_label is not None
+                    and embedding_node_property is not None
+                    and is_search_compatible_filter(filters)
+                ):
+                    query, params = _get_search_vector_query(
+                        filters,
+                        node_label,
+                        embedding_node_property,
+                    )
+                elif (
                     node_label is not None
                     and embedding_node_property is not None
                     and embedding_dimension is not None
@@ -370,6 +441,8 @@ def get_search_query(
                     raise Exception(
                         "Vector Search with filters requires: node_label, embedding_node_property, embedding_dimension"
                     )
+            elif neo4j_version_supports_search_clause and node_label is not None:
+                query, params = _get_search_vector_query_no_filter(node_label)
             else:
                 query, params = NODE_VECTOR_INDEX_QUERY, {}
         else:

--- a/src/neo4j_graphrag/retrievers/base.py
+++ b/src/neo4j_graphrag/retrievers/base.py
@@ -38,6 +38,7 @@ from neo4j_graphrag.types import RawSearchResult, RetrieverResult, RetrieverResu
 from neo4j_graphrag.utils.version_utils import (
     get_version,
     has_metadata_filtering_support,
+    has_search_clause_support,
     has_vector_index_support,
     is_version_5_23_or_above,
 )
@@ -112,6 +113,9 @@ class Retriever(ABC, metaclass=RetrieverMetaclass):
         if self.VERIFY_NEO4J_VERSION:
             version_tuple, is_aura, _ = get_version(self.driver, self.neo4j_database)
             self.neo4j_version_is_5_23_or_above = is_version_5_23_or_above(
+                version_tuple
+            )
+            self.neo4j_version_supports_search_clause = has_search_clause_support(
                 version_tuple
             )
             if not has_vector_index_support(

--- a/src/neo4j_graphrag/retrievers/vector.py
+++ b/src/neo4j_graphrag/retrievers/vector.py
@@ -205,6 +205,9 @@ class VectorRetriever(Retriever):
             embedding_node_property=self._embedding_node_property,
             embedding_dimension=self._embedding_dimension,
             filters=filters,
+            neo4j_version_supports_search_clause=getattr(
+                self, "neo4j_version_supports_search_clause", False
+            ),
         )
         parameters.update(search_params)
 
@@ -372,6 +375,9 @@ class VectorCypherRetriever(Retriever):
             embedding_node_property=self._node_embedding_property,
             embedding_dimension=self._embedding_dimension,
             filters=filters,
+            neo4j_version_supports_search_clause=getattr(
+                self, "neo4j_version_supports_search_clause", False
+            ),
         )
         parameters.update(search_params)
 

--- a/src/neo4j_graphrag/utils/version_utils.py
+++ b/src/neo4j_graphrag/utils/version_utils.py
@@ -116,3 +116,22 @@ def has_metadata_filtering_support(
         target_version = (5, 18, 1)
 
     return version_tuple >= target_version
+
+
+def has_search_clause_support(version_tuple: tuple[int, ...]) -> bool:
+    """
+    Determines if the Neo4j database version supports the Cypher 25 SEARCH clause
+    with in-index filtering for vector indexes.
+
+    The SEARCH clause was introduced in Neo4j 2026.01 (the first calendar-versioned
+    release) and allows vector similarity search with pre-filtering directly inside
+    the index scan, replacing the brute-force exact KNN approach for filtered queries.
+
+    Args:
+        version_tuple (tuple[int, ...]): A tuple of integers representing the database
+            version (major, minor, patch) or (year, month, patch) for calendar versions.
+
+    Returns:
+        bool: True if the version is 2026.01.0 or above, False otherwise.
+    """
+    return version_tuple >= (2026, 1, 0)

--- a/tests/unit/test_search_clause.py
+++ b/tests/unit/test_search_clause.py
@@ -1,0 +1,253 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Tests for Cypher 25 SEARCH clause support with in-index filtering."""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from neo4j_graphrag.filters import (
+    get_search_filter,
+    is_search_compatible_filter,
+)
+from neo4j_graphrag.neo4j_queries import (
+    get_search_query,
+    _get_search_vector_query,
+    _get_search_vector_query_no_filter,
+)
+from neo4j_graphrag.types import SearchType
+from neo4j_graphrag.utils.version_utils import has_search_clause_support
+
+
+# ---- Version detection ----
+
+
+class TestVersionDetection:
+    def test_neo4j_5_x_no_search_support(self) -> None:
+        assert has_search_clause_support((5, 26, 5)) is False
+
+    def test_neo4j_2026_01_has_search_support(self) -> None:
+        assert has_search_clause_support((2026, 1, 0)) is True
+
+    def test_neo4j_2026_02_has_search_support(self) -> None:
+        assert has_search_clause_support((2026, 2, 0)) is True
+
+    def test_neo4j_2025_no_search_support(self) -> None:
+        assert has_search_clause_support((2025, 12, 0)) is False
+
+
+# ---- Filter compatibility ----
+
+
+class TestFilterCompatibility:
+    def test_simple_equality_compatible(self) -> None:
+        assert is_search_compatible_filter({"name": "Alice"}) is True
+
+    def test_simple_comparison_compatible(self) -> None:
+        assert is_search_compatible_filter({"age": {"$gte": 18}}) is True
+
+    def test_multiple_and_fields_compatible(self) -> None:
+        assert is_search_compatible_filter({"age": {"$gte": 18}, "score": {"$lt": 100}}) is True
+
+    def test_explicit_and_compatible(self) -> None:
+        filt = {"$and": [{"age": {"$gte": 18}}, {"rating": {"$lte": 5}}]}
+        assert is_search_compatible_filter(filt) is True
+
+    def test_or_not_compatible(self) -> None:
+        filt = {"$or": [{"age": {"$gte": 18}}, {"name": "Bob"}]}
+        assert is_search_compatible_filter(filt) is False
+
+    def test_in_not_compatible(self) -> None:
+        assert is_search_compatible_filter({"status": {"$in": ["A", "B"]}}) is False
+
+    def test_nin_not_compatible(self) -> None:
+        assert is_search_compatible_filter({"status": {"$nin": ["X"]}}) is False
+
+    def test_like_not_compatible(self) -> None:
+        assert is_search_compatible_filter({"name": {"$like": "Ali%"}}) is False
+
+    def test_ilike_not_compatible(self) -> None:
+        assert is_search_compatible_filter({"name": {"$ilike": "ali%"}}) is False
+
+    def test_between_not_compatible(self) -> None:
+        assert is_search_compatible_filter({"age": {"$between": [10, 20]}}) is False
+
+    def test_ne_not_compatible(self) -> None:
+        assert is_search_compatible_filter({"status": {"$ne": "deleted"}}) is False
+
+    def test_empty_dict_compatible(self) -> None:
+        assert is_search_compatible_filter({}) is True
+
+    def test_non_dict_not_compatible(self) -> None:
+        assert is_search_compatible_filter("not a dict") is False  # type: ignore
+
+    def test_all_simple_operators_compatible(self) -> None:
+        for op in ["$eq", "$lt", "$gt", "$lte", "$gte"]:
+            assert is_search_compatible_filter({"field": {op: 42}}) is True
+
+
+# ---- Search filter generation ----
+
+
+class TestSearchFilter:
+    def test_simple_equality(self) -> None:
+        query, params = get_search_filter({"name": "Alice"})
+        assert query == "node.name = $param_0"
+        assert params == {"param_0": "Alice"}
+
+    def test_comparison_operator(self) -> None:
+        query, params = get_search_filter({"age": {"$gte": 18}})
+        assert query == "node.age >= $param_0"
+        assert params == {"param_0": 18}
+
+    def test_multiple_fields_and(self) -> None:
+        query, params = get_search_filter({"age": {"$gte": 18}, "score": {"$lt": 100}})
+        assert "node.age >= $param_0" in query
+        assert "node.score < $param_1" in query
+        assert " AND " in query
+        assert params == {"param_0": 18, "param_1": 100}
+
+    def test_explicit_and(self) -> None:
+        filt = {"$and": [{"age": {"$gte": 18}}, {"rating": {"$lte": 5}}]}
+        query, params = get_search_filter(filt)
+        assert "node.age >= $param_0" in query
+        assert "node.rating <= $param_1" in query
+        assert " AND " in query
+
+    def test_custom_node_alias(self) -> None:
+        query, params = get_search_filter({"name": "Bob"}, node_alias="m")
+        assert query == "m.name = $param_0"
+
+
+# ---- SEARCH query generation ----
+
+
+class TestSearchQueryGeneration:
+    def test_search_vector_query_no_filter(self) -> None:
+        query, params = _get_search_vector_query_no_filter("Movie")
+        assert "MATCH (node:`Movie`)" in query
+        assert "SEARCH node IN (" in query
+        assert "VECTOR INDEX $vector_index_name" in query
+        assert "FOR $query_vector" in query
+        assert "LIMIT $top_k" in query
+        assert "SCORE AS score" in query
+        assert "WHERE" not in query
+        assert params == {}
+
+    def test_search_vector_query_with_filter(self) -> None:
+        filters = {"rating": {"$gte": 7.0}}
+        query, params = _get_search_vector_query(filters, "Movie", "embedding")
+        assert "MATCH (node:`Movie`)" in query
+        assert "SEARCH node IN (" in query
+        assert "VECTOR INDEX $vector_index_name" in query
+        assert "WHERE node.rating >= $param_0" in query
+        assert "LIMIT $top_k" in query
+        assert "SCORE AS score" in query
+        assert params == {"param_0": 7.0}
+
+    def test_search_vector_query_with_multi_filter(self) -> None:
+        filters = {"rating": {"$gte": 7.0}, "year": {"$gt": 2000}}
+        query, params = _get_search_vector_query(filters, "Movie", "embedding")
+        assert "WHERE" in query
+        assert " AND " in query
+        assert params == {"param_0": 7.0, "param_1": 2000}
+
+
+# ---- Integration with get_search_query ----
+
+
+class TestGetSearchQueryWithSearchClause:
+    def test_vector_search_uses_search_clause_when_supported(self) -> None:
+        """When neo4j_version_supports_search_clause=True and no filters,
+        should use SEARCH clause if node_label is available."""
+        result, params = get_search_query(
+            SearchType.VECTOR,
+            node_label="Movie",
+            embedding_node_property="embedding",
+            neo4j_version_supports_search_clause=True,
+        )
+        assert "SEARCH node IN (" in result
+        assert "VECTOR INDEX" in result
+
+    def test_vector_search_uses_procedure_when_no_support(self) -> None:
+        """When neo4j_version_supports_search_clause=False, should use procedure."""
+        result, params = get_search_query(
+            SearchType.VECTOR,
+            neo4j_version_supports_search_clause=False,
+        )
+        assert "db.index.vector.queryNodes" in result
+
+    def test_vector_search_with_compatible_filters_uses_search(self) -> None:
+        """Compatible filters + SEARCH support = SEARCH ... WHERE."""
+        result, params = get_search_query(
+            SearchType.VECTOR,
+            node_label="Movie",
+            embedding_node_property="embedding",
+            embedding_dimension=1536,
+            filters={"rating": {"$gte": 7.0}},
+            neo4j_version_supports_search_clause=True,
+        )
+        assert "SEARCH node IN (" in result
+        assert "WHERE" in result
+        assert "rating" in result
+        assert params.get("param_0") == 7.0
+
+    @patch("neo4j_graphrag.neo4j_queries.get_metadata_filter", return_value=["True", {}])
+    def test_vector_search_with_incompatible_filters_falls_back(self, _mock: Any) -> None:
+        """Incompatible filters + SEARCH support = fallback to exact match."""
+        result, params = get_search_query(
+            SearchType.VECTOR,
+            node_label="Movie",
+            embedding_node_property="embedding",
+            embedding_dimension=1536,
+            filters={"status": {"$in": ["A", "B"]}},
+            neo4j_version_supports_search_clause=True,
+        )
+        # Should fallback to exact match (MATCH ... WHERE ... vector.similarity.cosine)
+        assert "SEARCH" not in result
+        assert "vector.similarity.cosine" in result
+
+    @patch("neo4j_graphrag.neo4j_queries.get_metadata_filter", return_value=["True", {}])
+    def test_vector_search_with_filters_no_search_support(self, _mock: Any) -> None:
+        """Filters + no SEARCH support = exact match."""
+        result, params = get_search_query(
+            SearchType.VECTOR,
+            node_label="Movie",
+            embedding_node_property="embedding",
+            embedding_dimension=1536,
+            filters={"rating": {"$gte": 7.0}},
+            neo4j_version_supports_search_clause=False,
+        )
+        assert "SEARCH" not in result
+        assert "vector.similarity.cosine" in result
+
+    def test_vector_search_no_label_falls_back_to_procedure(self) -> None:
+        """Without node_label, even with SEARCH support, use procedure."""
+        result, params = get_search_query(
+            SearchType.VECTOR,
+            neo4j_version_supports_search_clause=True,
+        )
+        assert "db.index.vector.queryNodes" in result
+
+    def test_hybrid_search_unaffected(self) -> None:
+        """SEARCH clause support should not affect hybrid search."""
+        result, _ = get_search_query(
+            SearchType.HYBRID,
+            neo4j_version_supports_search_clause=True,
+        )
+        assert "db.index.vector.queryNodes" in result
+        assert "db.index.fulltext.queryNodes" in result


### PR DESCRIPTION
## Summary

Adds support for the Cypher 25 `SEARCH` clause with in-index filtering for vector retrievers, as proposed in #485.

When connected to Neo4j 2026.01+, compatible filtered vector queries now use the new `MATCH ... SEARCH node IN (VECTOR INDEX ... FOR ... WHERE ...)` syntax, pushing predicates directly into the index scan instead of brute-force exact KNN. This significantly improves performance for filtered vector search workloads.

### Changes

- **Version detection**: `has_search_clause_support()` detects Neo4j 2026.01+ (calendar versioning)
- **Filter compatibility**: `is_search_compatible_filter()` identifies filters that can be pushed into the SEARCH clause (simple comparisons with AND combinations only; `$or`, `$in`, `$nin`, `$like`, `$ilike`, `$ne`, `$between` fall back to exact KNN)
- **SEARCH query generation**: `_get_search_vector_query()` and `_get_search_vector_query_no_filter()` build the new Cypher 25 syntax
- **Automatic routing**: `get_search_query()` transparently routes through SEARCH when the version supports it and filters are compatible
- **Index creation**: `filter_properties` parameter on `create_vector_index()` generates the `WITH [n.prop1, n.prop2]` clause for declaring filterable properties
- **Retriever integration**: Base retriever detects SEARCH support at init; `VectorRetriever` and `VectorCypherRetriever` pass the flag through

### Design decisions

1. **Zero breaking changes**: `neo4j_version_supports_search_clause` defaults to `False` everywhere, preserving existing behavior for all current users
2. **Automatic fallback**: Incompatible filters silently fall back to exact KNN — no user action required
3. **No filter on unfiltered search**: When SEARCH is available and `node_label` is known, uses SEARCH clause without WHERE (still leverages ANN index efficiently)

### Example generated queries

**With filters (Neo4j 2026.01+):**
```cypher
MATCH (node:`Movie`)
SEARCH node IN (
  VECTOR INDEX $vector_index_name
  FOR $query_vector
  WHERE node.rating >= $param_0 AND node.year > $param_1
  LIMIT $top_k
) SCORE AS score
```

**Index creation with filterable properties:**
```cypher
CREATE VECTOR INDEX $name IF NOT EXISTS FOR (n:Movie) ON n.embedding
WITH [n.releaseDate, n.rating]
OPTIONS { indexConfig: { `vector.dimensions`: toInteger($dimensions), `vector.similarity_function`: $similarity_fn } }
```

## Test plan

- [x] 33 new unit tests covering version detection, filter compatibility, SEARCH query generation, and routing logic
- [x] All 777 existing unit tests continue to pass (20 pre-existing failures from optional dependencies unrelated to this change)
- [ ] Integration testing against Neo4j 2026.01 instance (requires access to pre-release or calendar-versioned Neo4j)

Closes #485