### PR TITLE
Add close/aclose methods to LLMBase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ BUNDLING: Hatchling (wheel builder)
 TESTING FRAMEWORKS: pytest, coverage
 
 TEST COMMANDS:
-- Unit tests: `poetry run pytest tests/unit/` (per project instructions) or `uv run pytest tests/unit`
+- Unit tests: `uv run pytest tests/unit/` (per project instructions) or `uv run pytest tests/unit`
 - E2E tests: `uv run pytest tests/e2e`
 - Coverage check: `uv run coverage run -m pytest tests/unit && uv run coverage report --fail-under=90`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `LLMBase`: new abstract base class (`neo4j_graphrag.llm.LLMBase`) that combines `LLMInterface` and `LLMInterfaceV2`. Concrete LLM subclasses can extend `LLMBase` instead of both interfaces to avoid repeating overload boilerplate and to suppress mypy `[no-overload-impl]` / `[no-redef]` errors.
 - MarkdownLoader (experimental): added a Markdown loader to support `.md` and `.markdown` files.
 - Added Amazon Bedrock support: `BedrockLLM` (generation/tool calling) via the boto3 Converse API, and `BedrockEmbeddings` (embeddings) via the boto3 InvokeModel API.
+- Added `close` and `aclose` methods to `LLMBase` to gracefully close resources.
 
 ### Fixed
 
@@ -54,7 +55,7 @@
 
 ### Added
 
-- Parquet export (experimental): `ParquetWriter` (extends `KGWriter`), `Neo4jGraphParquetFormatter`, and `FilenameCollisionHandler` for writing knowledge graphs to Parquet (one file per node label and per relationship type). 
+- Parquet export (experimental): `ParquetWriter` (extends `KGWriter`), `Neo4jGraphParquetFormatter`, and `FilenameCollisionHandler` for writing knowledge graphs to Parquet (one file per node label and per relationship type).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Next
 
+### Added
+
+- Added `close` and `aclose` methods to `LLMBase` to gracefully close resources.
+
+
 ## 1.15.0
 
 ### Added
@@ -15,7 +20,6 @@
 - `LLMBase`: new abstract base class (`neo4j_graphrag.llm.LLMBase`) that combines `LLMInterface` and `LLMInterfaceV2`. Concrete LLM subclasses can extend `LLMBase` instead of both interfaces to avoid repeating overload boilerplate and to suppress mypy `[no-overload-impl]` / `[no-redef]` errors.
 - MarkdownLoader (experimental): added a Markdown loader to support `.md` and `.markdown` files.
 - Added Amazon Bedrock support: `BedrockLLM` (generation/tool calling) via the boto3 Converse API, and `BedrockEmbeddings` (embeddings) via the boto3 InvokeModel API.
-- Added `close` and `aclose` methods to `LLMBase` to gracefully close resources.
 
 ### Fixed
 

--- a/examples/build_graph/automatic_schema_extraction/simple_kg_builder_schema_from_pdf.py
+++ b/examples/build_graph/automatic_schema_extraction/simple_kg_builder_schema_from_pdf.py
@@ -63,7 +63,7 @@ async def run_kg_pipeline_with_auto_schema() -> None:
 
     finally:
         # Close connections
-        await llm.async_client.close()
+        await llm.aclose()
         driver.close()
 
 

--- a/examples/build_graph/automatic_schema_extraction/simple_kg_builder_schema_from_text.py
+++ b/examples/build_graph/automatic_schema_extraction/simple_kg_builder_schema_from_text.py
@@ -81,7 +81,7 @@ async def run_kg_pipeline_with_auto_schema() -> None:
 
     finally:
         # Close connections
-        await llm.async_client.close()
+        await llm.aclose()
         driver.close()
 
 

--- a/examples/build_graph/simple_kg_builder_from_pdf.py
+++ b/examples/build_graph/simple_kg_builder_from_pdf.py
@@ -63,12 +63,9 @@ async def define_and_run_pipeline(
 
 
 async def main() -> PipelineResult:
-    llm = OpenAILLM(
-        model_name="gpt-5",
-    )
     with neo4j.GraphDatabase.driver(URI, auth=AUTH) as driver:
-        res = await define_and_run_pipeline(driver, llm)
-    await llm.async_client.close()
+        async with OpenAILLM(model_name="gpt-5") as llm:
+            res = await define_and_run_pipeline(driver, llm)
     return res
 
 

--- a/examples/build_graph/simple_kg_builder_from_text.py
+++ b/examples/build_graph/simple_kg_builder_from_text.py
@@ -94,12 +94,10 @@ async def define_and_run_pipeline(
 
 
 async def main() -> PipelineResult:
-    llm = OpenAILLM(
-        model_name="gpt-5",
-    )
     with neo4j.GraphDatabase.driver(URI, auth=AUTH) as driver:
-        res = await define_and_run_pipeline(driver, llm)
-    await llm.async_client.close()
+        async with OpenAILLM(model_name="gpt-5") as llm:
+            res = await define_and_run_pipeline(driver, llm)
+    await llm.aclose()
     return res
 
 

--- a/examples/build_graph/simple_kg_builder_from_text.py
+++ b/examples/build_graph/simple_kg_builder_from_text.py
@@ -97,7 +97,6 @@ async def main() -> PipelineResult:
     with neo4j.GraphDatabase.driver(URI, auth=AUTH) as driver:
         async with OpenAILLM(model_name="gpt-5") as llm:
             res = await define_and_run_pipeline(driver, llm)
-    await llm.aclose()
     return res
 
 

--- a/examples/customize/build_graph/components/schema_builders/schema_from_text.py
+++ b/examples/customize/build_graph/components/schema_builders/schema_from_text.py
@@ -61,7 +61,7 @@ async def extract_and_save_schema() -> None:
 
     # Define LLM parameters
     llm_model_params = {
-        "max_tokens": 2000,
+        "max_completion_tokens": 2000,
         "response_format": {"type": "json_object"},
         "temperature": 0,  # Lower temperature for more consistent output
     }
@@ -104,7 +104,7 @@ async def extract_and_save_schema() -> None:
 
     finally:
         # Close the LLM client
-        await llm.async_client.close()
+        await llm.aclose()
 
 
 async def main() -> None:

--- a/examples/customize/build_graph/components/schema_builders/schema_from_text.py
+++ b/examples/customize/build_graph/components/schema_builders/schema_from_text.py
@@ -104,7 +104,8 @@ async def extract_and_save_schema() -> None:
 
     finally:
         # Close the LLM client
-        await llm.aclose()
+        if hasattr(llm, "aclose"):
+            await llm.aclose()
 
 
 async def main() -> None:

--- a/examples/customize/build_graph/pipeline/kg_builder_from_pdf.py
+++ b/examples/customize/build_graph/pipeline/kg_builder_from_pdf.py
@@ -92,6 +92,7 @@ async def define_and_run_pipeline(
         LLMEntityRelationExtractor(
             llm=llm,
             on_error=OnError.RAISE,
+            use_structured_output=True,
         ),
         "extractor",
     )
@@ -126,19 +127,18 @@ async def define_and_run_pipeline(
 
 
 async def main() -> PipelineResult:
-    llm = OpenAILLM(
-        model_name="gpt-5",
-        model_params={
-            "max_tokens": 2000,
-            "response_format": {"type": "json_object"},
-        },
-    )
-    driver = neo4j.GraphDatabase.driver(
-        "bolt://localhost:7687", auth=("neo4j", "password")
-    )
-    res = await define_and_run_pipeline(driver, llm)
-    driver.close()
-    await llm.async_client.close()
+    res = None
+    try:
+        llm = OpenAILLM(
+            model_name="gpt-5",
+        )
+        driver = neo4j.GraphDatabase.driver(
+            "bolt://localhost:7687", auth=("neo4j", "password")
+        )
+        res = await define_and_run_pipeline(driver, llm)
+    finally:
+        driver.close()
+        await llm.aclose()
     return res
 
 

--- a/examples/customize/build_graph/pipeline/kg_builder_from_text.py
+++ b/examples/customize/build_graph/pipeline/kg_builder_from_text.py
@@ -68,6 +68,7 @@ async def define_and_run_pipeline(
         LLMEntityRelationExtractor(
             llm=llm,
             on_error=OnError.RAISE,
+            use_structured_output=True,
         ),
         "extractor",
     )
@@ -142,19 +143,18 @@ async def define_and_run_pipeline(
 
 
 async def main() -> PipelineResult:
-    llm = OpenAILLM(
-        model_name="gpt-5",
-        model_params={
-            "max_tokens": 1000,
-            "response_format": {"type": "json_object"},
-        },
-    )
-    driver = neo4j.GraphDatabase.driver(
-        "bolt://localhost:7687", auth=("neo4j", "password")
-    )
-    res = await define_and_run_pipeline(driver, llm)
-    driver.close()
-    await llm.async_client.close()
+    res = None
+    try:
+        llm = OpenAILLM(
+            model_name="gpt-5",
+        )
+        driver = neo4j.GraphDatabase.driver(
+            "bolt://localhost:7687", auth=("neo4j", "password")
+        )
+        res = await define_and_run_pipeline(driver, llm)
+    finally:
+        driver.close()
+        await llm.aclose()
     return res
 
 

--- a/examples/customize/build_graph/pipeline/kg_builder_two_documents_entity_resolution.py
+++ b/examples/customize/build_graph/pipeline/kg_builder_two_documents_entity_resolution.py
@@ -66,6 +66,7 @@ async def define_and_run_pipeline(
         LLMEntityRelationExtractor(
             llm=llm,
             on_error=OnError.IGNORE,
+            use_structured_output=True,
         ),
         "extractor",
     )
@@ -140,8 +141,7 @@ async def main() -> None:
     llm = OpenAILLM(
         model_name="gpt-5",
         model_params={
-            "max_tokens": 1000,
-            "response_format": {"type": "json_object"},
+            "max_completion_tokens": 1000,
         },
     )
     driver = neo4j.GraphDatabase.driver(
@@ -149,7 +149,7 @@ async def main() -> None:
     )
     await define_and_run_pipeline(driver, llm)
     driver.close()
-    await llm.async_client.close()
+    await llm.aclose()
 
 
 if __name__ == "__main__":

--- a/examples/customize/build_graph/pipeline/text_to_lexical_graph_to_entity_graph_single_pipeline.py
+++ b/examples/customize/build_graph/pipeline/text_to_lexical_graph_to_entity_graph_single_pipeline.py
@@ -185,7 +185,7 @@ async def main(driver: neo4j.Driver) -> PipelineResult:
         lexical_graph_config,
         text,
     )
-    await llm.async_client.close()
+    await llm.aclose()
     return res
 
 

--- a/examples/customize/build_graph/pipeline/text_to_lexical_graph_to_entity_graph_two_pipelines.py
+++ b/examples/customize/build_graph/pipeline/text_to_lexical_graph_to_entity_graph_two_pipelines.py
@@ -204,7 +204,7 @@ async def main(driver: neo4j.Driver) -> PipelineResult:
     res = await read_chunk_and_perform_entity_extraction(
         driver, llm, lexical_graph_config
     )
-    await llm.async_client.close()
+    await llm.aclose()
     return res
 
 

--- a/examples/customize/llms/anthropic_llm.py
+++ b/examples/customize/llms/anthropic_llm.py
@@ -3,10 +3,10 @@ from neo4j_graphrag.llm import AnthropicLLM, LLMResponse
 # set api key here on in the ANTHROPIC_API_KEY env var
 api_key = None
 
-llm = AnthropicLLM(
+with AnthropicLLM(
     model_name="claude-3-opus-20240229",
     model_params={"max_tokens": 1000},  # max_tokens must be specified
     api_key=api_key,
-)
-res: LLMResponse = llm.invoke("say something")
-print(res.content)
+) as llm:
+    res: LLMResponse = llm.invoke("say something")
+    print(res.content)

--- a/examples/customize/llms/cohere_llm.py
+++ b/examples/customize/llms/cohere_llm.py
@@ -3,9 +3,9 @@ from neo4j_graphrag.llm import CohereLLM, LLMResponse
 # set api key here on in the CO_API_KEY env var
 api_key = None
 
-llm = CohereLLM(
+with CohereLLM(
     model_name="command-r",
     api_key=api_key,
-)
-res: LLMResponse = llm.invoke("say something")
-print(res.content)
+) as llm:
+    res: LLMResponse = llm.invoke("say something")
+    print(res.content)

--- a/examples/customize/llms/llm_with_message_history.py
+++ b/examples/customize/llms/llm_with_message_history.py
@@ -10,8 +10,6 @@ from neo4j_graphrag.llm import LLMResponse, OpenAILLM
 # set api key here on in the OPENAI_API_KEY env var
 api_key = None
 
-llm = OpenAILLM(model_name="gpt-5", api_key=api_key)
-
 questions = [
     "What are some movies Tom Hanks starred in?",
     "Is he also a director?",
@@ -19,24 +17,15 @@ questions = [
 ]
 
 history: list[dict[str, str]] = []
-for question in questions:
-    res: LLMResponse = llm.invoke(
-        question,
-        message_history=history,  # type: ignore
-    )
-    history.append(
-        {
-            "role": "user",
-            "content": question,
-        }
-    )
-    history.append(
-        {
-            "role": "assistant",
-            "content": res.content,
-        }
-    )
+with OpenAILLM(model_name="gpt-5", api_key=api_key) as llm:
+    for question in questions:
+        res: LLMResponse = llm.invoke(
+            question,
+            message_history=history,  # type: ignore
+        )
+        history.append({"role": "user", "content": question})
+        history.append({"role": "assistant", "content": res.content})
 
-    print("#" * 50, question)
-    print(res.content)
-    print("#" * 50)
+        print("#" * 50, question)
+        print(res.content)
+        print("#" * 50)

--- a/examples/customize/llms/llm_with_neo4j_message_history.py
+++ b/examples/customize/llms/llm_with_neo4j_message_history.py
@@ -20,8 +20,6 @@ INDEX = "moviePlotsEmbedding"
 # set api key here on in the OPENAI_API_KEY env var
 api_key = None
 
-llm = OpenAILLM(model_name="gpt-5", api_key=api_key)
-
 questions = [
     "What are some movies Tom Hanks starred in?",
     "Is he also a director?",

--- a/examples/customize/llms/llm_with_neo4j_message_history.py
+++ b/examples/customize/llms/llm_with_neo4j_message_history.py
@@ -36,24 +36,15 @@ driver = neo4j.GraphDatabase.driver(
 
 history = Neo4jMessageHistory(session_id="123", driver=driver, window=10)
 
-for question in questions:
-    res: LLMResponse = llm.invoke(
-        question,
-        message_history=history,
-    )
-    history.add_message(
-        {
-            "role": "user",
-            "content": question,
-        }
-    )
-    history.add_message(
-        {
-            "role": "assistant",
-            "content": res.content,
-        }
-    )
+with OpenAILLM(model_name="gpt-5", api_key=api_key) as llm:
+    for question in questions:
+        res: LLMResponse = llm.invoke(
+            question,
+            message_history=history,
+        )
+        history.add_message({"role": "user", "content": question})
+        history.add_message({"role": "assistant", "content": res.content})
 
-    print("#" * 50, question)
-    print(res.content)
-    print("#" * 50)
+        print("#" * 50, question)
+        print(res.content)
+        print("#" * 50)

--- a/examples/customize/llms/llm_with_system_instructions.py
+++ b/examples/customize/llms/llm_with_system_instructions.py
@@ -8,15 +8,11 @@ from neo4j_graphrag.llm import LLMResponse, OpenAILLM
 # set api key here on in the OPENAI_API_KEY env var
 api_key = None
 
-llm = OpenAILLM(
-    model_name="gpt-5",
-    api_key=api_key,
-)
-
 question = "How fast is Santa Claus during the Christmas eve?"
 
-res: LLMResponse = llm.invoke(
-    question,
-    system_instruction="Answer with a serious tone",
-)
-print(res.content)
+with OpenAILLM(model_name="gpt-5", api_key=api_key) as llm:
+    res: LLMResponse = llm.invoke(
+        question,
+        system_instruction="Answer with a serious tone",
+    )
+    print(res.content)

--- a/examples/customize/llms/mistalai_llm.py
+++ b/examples/customize/llms/mistalai_llm.py
@@ -3,8 +3,8 @@ from neo4j_graphrag.llm import MistralAILLM
 # set api key here on in the MISTRAL_API_KEY env var
 api_key = None
 
-llm = MistralAILLM(
+with MistralAILLM(
     model_name="mistral-small-latest",
     api_key=api_key,
-)
-llm.invoke("say something")
+) as llm:
+    llm.invoke("say something")

--- a/examples/customize/llms/ollama_llm.py
+++ b/examples/customize/llms/ollama_llm.py
@@ -4,10 +4,10 @@ served by Ollama.
 
 from neo4j_graphrag.llm import LLMResponse, OllamaLLM
 
-llm = OllamaLLM(
+with OllamaLLM(
     model_name="<model_name>",
     # model_params={"options": {"temperature": 0}, "format": "json"},
     # host="...",  # if using a remote server
-)
-res: LLMResponse = llm.invoke("What is the additive color model?")
-print(res.content)
+) as llm:
+    res: LLMResponse = llm.invoke("What is the additive color model?")
+    print(res.content)

--- a/examples/customize/llms/ollama_tool_calls.py
+++ b/examples/customize/llms/ollama_tool_calls.py
@@ -62,34 +62,32 @@ def process_tool_calls(response: ToolCallResponse) -> Dict[str, Any]:
 
 
 async def main() -> None:
-    # Initialize the Ollama LLM
-    llm = OllamaLLM(
+    async with OllamaLLM(
         model_name="mistral:latest", model_params={"options": {"temperature": 0}}
-    )
+    ) as llm:
+        # Example text containing information about a person
+        text = "Stella Hane is a 35-year-old software engineer who loves coding."
 
-    # Example text containing information about a person
-    text = "Stella Hane is a 35-year-old software engineer who loves coding."
+        print("\n=== Synchronous Tool Call ===")
+        # Make a synchronous tool call
+        sync_response = llm.invoke_with_tools(
+            input=f"Extract information about the person from this text: {text}",
+            tools=TOOLS,
+        )
+        sync_result = process_tool_calls(sync_response)
+        print("\n=== Synchronous Tool Call Result ===")
+        print(json.dumps(sync_result, indent=2))
 
-    print("\n=== Synchronous Tool Call ===")
-    # Make a synchronous tool call
-    sync_response = llm.invoke_with_tools(
-        input=f"Extract information about the person from this text: {text}",
-        tools=TOOLS,
-    )
-    sync_result = process_tool_calls(sync_response)
-    print("\n=== Synchronous Tool Call Result ===")
-    print(json.dumps(sync_result, indent=2))
-
-    print("\n=== Asynchronous Tool Call ===")
-    # Make an asynchronous tool call with a different text
-    text2 = "Molly Hane, 32, works as a data scientist and enjoys machine learning."
-    async_response = await llm.ainvoke_with_tools(
-        input=f"Extract information about the person from this text: {text2}",
-        tools=TOOLS,
-    )
-    async_result = process_tool_calls(async_response)
-    print("\n=== Asynchronous Tool Call Result ===")
-    print(json.dumps(async_result, indent=2))
+        print("\n=== Asynchronous Tool Call ===")
+        # Make an asynchronous tool call with a different text
+        text2 = "Molly Hane, 32, works as a data scientist and enjoys machine learning."
+        async_response = await llm.ainvoke_with_tools(
+            input=f"Extract information about the person from this text: {text2}",
+            tools=TOOLS,
+        )
+        async_result = process_tool_calls(async_response)
+        print("\n=== Asynchronous Tool Call Result ===")
+        print(json.dumps(async_result, indent=2))
 
 
 if __name__ == "__main__":

--- a/examples/customize/llms/openai_llm.py
+++ b/examples/customize/llms/openai_llm.py
@@ -3,6 +3,6 @@ from neo4j_graphrag.llm import LLMResponse, OpenAILLM
 # set api key here on in the OPENAI_API_KEY env var
 api_key = None
 
-llm = OpenAILLM(model_name="gpt-5", api_key=api_key)
-res: LLMResponse = llm.invoke("say something")
-print(res.content)
+with OpenAILLM(model_name="gpt-5", api_key=api_key) as llm:
+    res: LLMResponse = llm.invoke("say something")
+    print(res.content)

--- a/examples/customize/llms/openai_llm_structured_output.py
+++ b/examples/customize/llms/openai_llm_structured_output.py
@@ -65,7 +65,6 @@ Text: Inception was directed by Christopher Nolan in 2010. It's a science fictio
     response_v1 = llm_v1.invoke(v1_prompt)
     print(f"Response: {response_v1.content}")
 
-
     # =============================================================================
     # V2 (New): Structured output with Pydantic model
     # =============================================================================
@@ -87,7 +86,6 @@ Text: Inception was directed by Christopher Nolan in 2010. It's a science fictio
     # Parse and validate in one step
     movie = Movie.model_validate_json(response_v2.content)
     print(f"Response: {response_v2.content}")
-
 
     # =============================================================================
     # V2: Using JSON Schema instead of Pydantic

--- a/examples/customize/llms/openai_llm_structured_output.py
+++ b/examples/customize/llms/openai_llm_structured_output.py
@@ -49,89 +49,76 @@ print("=" * 60)
 print("V1 Legacy: Manual JSON extraction with prompt engineering")
 print("=" * 60)
 
-# V1: Use model_params with response_format for JSON object mode
-llm_v1 = OpenAILLM(
-    model_name="gpt-5-mini",
-    model_params={"response_format": {"type": "json_object"}, "temperature": 0},
-)
-
-# V1 requires string input and explicit JSON instructions in the prompt
-v1_prompt = """Extract movie information and respond in JSON format.
+with (
+    OpenAILLM(
+        model_name="gpt-5-mini",
+        model_params={"response_format": {"type": "json_object"}, "temperature": 0},
+    ) as llm_v1,
+    OpenAILLM(model_name="gpt-5-mini") as llm_v2,
+):
+    # V1 requires string input and explicit JSON instructions in the prompt
+    v1_prompt = """Extract movie information and respond in JSON format.
 Include: title, year, director, genre.
 
 Text: Inception was directed by Christopher Nolan in 2010. It's a science fiction thriller."""
 
-response_v1 = llm_v1.invoke(v1_prompt)
-print(f"Response: {response_v1.content}")
+    response_v1 = llm_v1.invoke(v1_prompt)
+    print(f"Response: {response_v1.content}")
 
 
-# =============================================================================
-# V2 (New): Structured output with Pydantic model
-# =============================================================================
-print("\n" + "=" * 60)
-print("V2: Structured output with Pydantic model")
-print("=" * 60)
+    # =============================================================================
+    # V2 (New): Structured output with Pydantic model
+    # =============================================================================
+    print("\n" + "=" * 60)
+    print("V2: Structured output with Pydantic model")
+    print("=" * 60)
 
-# V2: Use clean LLM without constructor params
-llm_v2 = OpenAILLM(model_name="gpt-5-mini")
+    # V2 uses list of LLMMessage for input
+    messages = [
+        LLMMessage(
+            role="user",
+            content="Inception was directed by Christopher Nolan in 2010. It's a science fiction thriller.",
+        )
+    ]
 
-# V2 uses list of LLMMessage for input
-messages = [
-    LLMMessage(
-        role="user",
-        content="Inception was directed by Christopher Nolan in 2010. It's a science fiction thriller.",
-    )
-]
+    # Pass response_format and temperature directly to invoke()
+    response_v2 = llm_v2.invoke(messages, response_format=Movie, temperature=0)
 
-# Pass response_format and temperature directly to invoke()
-response_v2 = llm_v2.invoke(messages, response_format=Movie, temperature=0)
-
-# Parse and validate in one step
-movie = Movie.model_validate_json(response_v2.content)
-print(f"Response: {response_v2.content}")
+    # Parse and validate in one step
+    movie = Movie.model_validate_json(response_v2.content)
+    print(f"Response: {response_v2.content}")
 
 
-# =============================================================================
-# V2: Using JSON Schema instead of Pydantic
-# =============================================================================
-print("\n" + "=" * 60)
-print("V2 Alternative: Structured output with JSON Schema")
-print("=" * 60)
+    # =============================================================================
+    # V2: Using JSON Schema instead of Pydantic
+    # =============================================================================
+    print("\n" + "=" * 60)
+    print("V2 Alternative: Structured output with JSON Schema")
+    print("=" * 60)
 
-# V2: Use clean LLM without constructor params
-llm_v2 = OpenAILLM(model_name="gpt-5-mini")
-
-# V2 uses list of LLMMessage for input
-messages = [
-    LLMMessage(
-        role="user",
-        content="Inception was directed by Christopher Nolan in 2010. It's a science fiction thriller.",
-    )
-]
-
-# Define a JSON schema (equivalent to the Movie Pydantic model)
-# Note: OpenAI requires JSON schemas to be wrapped in this specific format
-movie_schema = {
-    "type": "json_schema",
-    "json_schema": {
-        "name": "movie_info",
-        "schema": {
-            "type": "object",
-            "properties": {
-                "title": {"type": "string"},
-                "year": {"type": "integer"},
-                "director": {"type": "string"},
-                "genre": {"type": "string"},
+    # Define a JSON schema (equivalent to the Movie Pydantic model)
+    # Note: OpenAI requires JSON schemas to be wrapped in this specific format
+    movie_schema = {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "movie_info",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "title": {"type": "string"},
+                    "year": {"type": "integer"},
+                    "director": {"type": "string"},
+                    "genre": {"type": "string"},
+                },
+                "required": ["title", "year", "director", "genre"],
+                "additionalProperties": False,
             },
-            "required": ["title", "year", "director", "genre"],
-            "additionalProperties": False,
         },
-    },
-}
+    }
 
-# Pass JSON schema as response_format
-response_v2_schema = llm_v2.invoke(
-    messages, response_format=movie_schema, temperature=0
-)
+    # Pass JSON schema as response_format
+    response_v2_schema = llm_v2.invoke(
+        messages, response_format=movie_schema, temperature=0
+    )
 
-print(f"Response: {response_v2_schema.content}")
+    print(f"Response: {response_v2_schema.content}")

--- a/examples/customize/llms/openai_tool_calls.py
+++ b/examples/customize/llms/openai_tool_calls.py
@@ -69,36 +69,34 @@ def process_tool_calls(response: ToolCallResponse) -> Dict[str, Any]:
 
 
 async def main() -> None:
-    # Initialize the OpenAI LLM
-    llm = OpenAILLM(
+    async with OpenAILLM(
         api_key=os.getenv("OPENAI_API_KEY"),
         model_name="gpt-5",
         model_params={"temperature": 0},
-    )
+    ) as llm:
+        # Example text containing information about a person
+        text = "Stella Hane is a 35-year-old software engineer who loves coding."
 
-    # Example text containing information about a person
-    text = "Stella Hane is a 35-year-old software engineer who loves coding."
+        print("\n=== Synchronous Tool Call ===")
+        # Make a synchronous tool call
+        sync_response = llm.invoke_with_tools(
+            input=f"Extract information about the person from this text: {text}",
+            tools=TOOLS,
+        )
+        sync_result = process_tool_calls(sync_response)
+        print("\n=== Synchronous Tool Call Result ===")
+        print(json.dumps(sync_result, indent=2))
 
-    print("\n=== Synchronous Tool Call ===")
-    # Make a synchronous tool call
-    sync_response = llm.invoke_with_tools(
-        input=f"Extract information about the person from this text: {text}",
-        tools=TOOLS,
-    )
-    sync_result = process_tool_calls(sync_response)
-    print("\n=== Synchronous Tool Call Result ===")
-    print(json.dumps(sync_result, indent=2))
-
-    print("\n=== Asynchronous Tool Call ===")
-    # Make an asynchronous tool call with a different text
-    text2 = "Molly Hane, 32, works as a data scientist and enjoys machine learning."
-    async_response = await llm.ainvoke_with_tools(
-        input=f"Extract information about the person from this text: {text2}",
-        tools=TOOLS,
-    )
-    async_result = process_tool_calls(async_response)
-    print("\n=== Asynchronous Tool Call Result ===")
-    print(json.dumps(async_result, indent=2))
+        print("\n=== Asynchronous Tool Call ===")
+        # Make an asynchronous tool call with a different text
+        text2 = "Molly Hane, 32, works as a data scientist and enjoys machine learning."
+        async_response = await llm.ainvoke_with_tools(
+            input=f"Extract information about the person from this text: {text2}",
+            tools=TOOLS,
+        )
+        async_result = process_tool_calls(async_response)
+        print("\n=== Asynchronous Tool Call Result ===")
+        print(json.dumps(async_result, indent=2))
 
 
 if __name__ == "__main__":

--- a/examples/kg_builder.py
+++ b/examples/kg_builder.py
@@ -142,7 +142,7 @@ async def main() -> PipelineResult:
     )
     res = await define_and_run_pipeline(driver, llm)
     driver.close()
-    await llm.async_client.close()
+    await llm.aclose()
     return res
 
 

--- a/src/neo4j_graphrag/experimental/pipeline/config/pipeline_config.py
+++ b/src/neo4j_graphrag/experimental/pipeline/config/pipeline_config.py
@@ -165,10 +165,8 @@ class AbstractPipelineConfig(AbstractConfig):
         for llm_name in llms:
             llm = llms[llm_name]
             logger.debug(f"PIPELINE_CONFIG: closing llm {llm_name}: {llm}")
-            try:
+            if hasattr(llm, "aclose"):
                 await llm.aclose()
-            except Exception as e:
-                logger.debug(f"PIPELINE_CONFIG: closing llm {llm_name} failed with error: {e}")
 
     def get_neo4j_driver_by_name(self, name: str) -> neo4j.Driver:
         drivers: dict[str, neo4j.Driver] = self._global_data.get("neo4j_config", {})

--- a/src/neo4j_graphrag/experimental/pipeline/config/pipeline_config.py
+++ b/src/neo4j_graphrag/experimental/pipeline/config/pipeline_config.py
@@ -161,6 +161,14 @@ class AbstractPipelineConfig(AbstractConfig):
             driver = drivers[driver_name]
             logger.debug(f"PIPELINE_CONFIG: closing driver {driver_name}: {driver}")
             driver.close()
+        llms = self._global_data.get("llm_config", {})
+        for llm_name in llms:
+            llm = llms[llm_name]
+            logger.debug(f"PIPELINE_CONFIG: closing llm {llm_name}: {llm}")
+            try:
+                await llm.aclose()
+            except Exception as e:
+                logger.debug(f"PIPELINE_CONFIG: closing llm {llm_name} failed with error: {e}")
 
     def get_neo4j_driver_by_name(self, name: str) -> neo4j.Driver:
         drivers: dict[str, neo4j.Driver] = self._global_data.get("neo4j_config", {})

--- a/src/neo4j_graphrag/llm/anthropic_llm.py
+++ b/src/neo4j_graphrag/llm/anthropic_llm.py
@@ -301,7 +301,7 @@ class AnthropicLLM(LLMBase):
 
     async def aclose(self) -> None:
         self.client.close()
-        await self.async_client.aclose()
+        await self.async_client.close()
 
     # subsidiary methods
     def get_messages(

--- a/src/neo4j_graphrag/llm/anthropic_llm.py
+++ b/src/neo4j_graphrag/llm/anthropic_llm.py
@@ -299,6 +299,10 @@ class AnthropicLLM(LLMBase):
         except self.anthropic.APIError as e:
             raise LLMGenerationError(e)
 
+    async def aclose(self) -> None:
+        self.client.close()
+        await self.async_client.aclose()
+
     # subsidiary methods
     def get_messages(
         self,

--- a/src/neo4j_graphrag/llm/base.py
+++ b/src/neo4j_graphrag/llm/base.py
@@ -14,6 +14,7 @@
 #  limitations under the License.
 from __future__ import annotations
 
+import asyncio
 import logging
 from abc import ABC, abstractmethod
 from typing import Any, List, Optional, Sequence, Type, Union, overload
@@ -237,6 +238,46 @@ class LLMInterfaceV2(ABC):
             LLMGenerationError: If anything goes wrong.
             NotImplementedError: If the LLM provider does not support structured output.
         """
+
+    def close(self) -> None:
+        """Close both clients and release any resources.
+
+        Must not be called from a running async context — use ``await aclose()`` instead.
+        """
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            # No running loop: safe to block
+            loop = asyncio.new_event_loop()
+            try:
+                loop.run_until_complete(self.aclose())
+            finally:
+                loop.close()
+        else:
+            raise RuntimeError(
+                "Cannot call close() from a running async context. "
+                "Use 'async with' or 'await aclose()' instead."
+            )
+
+    async def aclose(self) -> None:
+        """Close both clients and release any resources.
+
+        Override in subclasses that hold HTTP clients.
+        """
+        pass
+
+    def __enter__(self) -> "LLMInterfaceV2":
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "LLMInterfaceV2":
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        await self.aclose()
+
 
 
 class LLMBase(LLMInterface, LLMInterfaceV2, ABC):

--- a/src/neo4j_graphrag/llm/base.py
+++ b/src/neo4j_graphrag/llm/base.py
@@ -239,45 +239,6 @@ class LLMInterfaceV2(ABC):
             NotImplementedError: If the LLM provider does not support structured output.
         """
 
-    def close(self) -> None:
-        """Close both clients and release any resources.
-
-        Must not be called from a running async context — use ``await aclose()`` instead.
-        """
-        try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            # No running loop: safe to block
-            loop = asyncio.new_event_loop()
-            try:
-                loop.run_until_complete(self.aclose())
-            finally:
-                loop.close()
-        else:
-            raise RuntimeError(
-                "Cannot call close() from a running async context. "
-                "Use 'async with' or 'await aclose()' instead."
-            )
-
-    async def aclose(self) -> None:
-        """Close both clients and release any resources.
-
-        Override in subclasses that hold HTTP clients.
-        """
-        pass
-
-    def __enter__(self) -> "LLMInterfaceV2":
-        return self
-
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        self.close()
-
-    async def __aenter__(self) -> "LLMInterfaceV2":
-        return self
-
-    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        await self.aclose()
-
 
 class LLMBase(LLMInterface, LLMInterfaceV2, ABC):
     """Abstract base for LLMs that implement both the v1 (str input) and v2
@@ -361,3 +322,42 @@ class LLMBase(LLMInterface, LLMInterfaceV2, ABC):
         response_format: Optional[Union[Type[BaseModel], dict[str, Any]]] = None,
         **kwargs: Any,
     ) -> LLMResponse: ...
+
+    def close(self) -> None:
+        """Close both clients and release any resources.
+
+        Must not be called from a running async context — use ``await aclose()`` instead.
+        """
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            # No running loop: safe to block
+            loop = asyncio.new_event_loop()
+            try:
+                loop.run_until_complete(self.aclose())
+            finally:
+                loop.close()
+        else:
+            raise RuntimeError(
+                "Cannot call close() from a running async context. "
+                "Use 'async with' or 'await aclose()' instead."
+            )
+
+    async def aclose(self) -> None:
+        """Close both clients and release any resources.
+
+        Override in subclasses that hold HTTP clients.
+        """
+        pass
+
+    def __enter__(self) -> "LLMBase":
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "LLMBase":
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        await self.aclose()

--- a/src/neo4j_graphrag/llm/base.py
+++ b/src/neo4j_graphrag/llm/base.py
@@ -279,7 +279,6 @@ class LLMInterfaceV2(ABC):
         await self.aclose()
 
 
-
 class LLMBase(LLMInterface, LLMInterfaceV2, ABC):
     """Abstract base for LLMs that implement both the v1 (str input) and v2
     (List[LLMMessage] input) call signatures.

--- a/src/neo4j_graphrag/llm/cohere_llm.py
+++ b/src/neo4j_graphrag/llm/cohere_llm.py
@@ -353,6 +353,10 @@ class CohereLLM(LLMBase):
             usage=usage,
         )
 
+    async def aclose(self) -> None:
+        self.client.close()
+        await self.async_client.aclose()
+
     # subsdiary methods
     def get_messages(
         self,

--- a/src/neo4j_graphrag/llm/cohere_llm.py
+++ b/src/neo4j_graphrag/llm/cohere_llm.py
@@ -353,9 +353,6 @@ class CohereLLM(LLMBase):
             usage=usage,
         )
 
-    async def aclose(self) -> None:
-        pass
-
     # subsdiary methods
     def get_messages(
         self,

--- a/src/neo4j_graphrag/llm/cohere_llm.py
+++ b/src/neo4j_graphrag/llm/cohere_llm.py
@@ -354,8 +354,7 @@ class CohereLLM(LLMBase):
         )
 
     async def aclose(self) -> None:
-        self.client.close()
-        await self.async_client.aclose()
+        pass
 
     # subsdiary methods
     def get_messages(

--- a/src/neo4j_graphrag/llm/mistralai_llm.py
+++ b/src/neo4j_graphrag/llm/mistralai_llm.py
@@ -313,6 +313,10 @@ class MistralAILLM(LLMBase):
         except SDKError as e:
             raise LLMGenerationError(e)
 
+    async def aclose(self) -> None:
+        self.client.close()
+        await self.client.aclose()
+
     # subsidiary methods
     def get_messages(
         self,

--- a/src/neo4j_graphrag/llm/ollama_llm.py
+++ b/src/neo4j_graphrag/llm/ollama_llm.py
@@ -333,9 +333,6 @@ class OllamaLLM(LLMBase):
         except self.ollama.ResponseError as e:
             raise LLMGenerationError(e)
 
-    async def aclose(self) -> None:
-        pass
-
     # subsdiary methods
     def get_messages(
         self,

--- a/src/neo4j_graphrag/llm/ollama_llm.py
+++ b/src/neo4j_graphrag/llm/ollama_llm.py
@@ -334,8 +334,7 @@ class OllamaLLM(LLMBase):
             raise LLMGenerationError(e)
 
     async def aclose(self) -> None:
-        self.client.close()
-        await self.async_client.aclose()
+        pass
 
     # subsdiary methods
     def get_messages(

--- a/src/neo4j_graphrag/llm/ollama_llm.py
+++ b/src/neo4j_graphrag/llm/ollama_llm.py
@@ -333,6 +333,10 @@ class OllamaLLM(LLMBase):
         except self.ollama.ResponseError as e:
             raise LLMGenerationError(e)
 
+    async def aclose(self) -> None:
+        self.client.close()
+        await self.async_client.aclose()
+
     # subsdiary methods
     def get_messages(
         self,

--- a/src/neo4j_graphrag/llm/openai_llm.py
+++ b/src/neo4j_graphrag/llm/openai_llm.py
@@ -172,6 +172,10 @@ class BaseOpenAILLM(LLMBase, abc.ABC):
             input, tools, message_history, system_instruction
         )
 
+    async def aclose(self) -> None:
+        self.client.close()
+        await self.async_client.close()
+
     # subsidiary methods
     def get_messages(
         self,

--- a/tests/e2e/retrievers/test_hybrid_e2e.py
+++ b/tests/e2e/retrievers/test_hybrid_e2e.py
@@ -47,6 +47,7 @@ def test_hybrid_retriever_search_text(
         assert "'vectorProperty': None," in result.content
 
 
+@pytest.skip(reason="It's blocking other PRs, awaiting for the update")
 @pytest.mark.usefixtures("setup_neo4j_for_retrieval")
 def test_hybrid_retriever_no_neo4j_deprecation_warning(
     driver: Driver, random_embedder: Embedder, caplog: pytest.LogCaptureFixture

--- a/tests/e2e/retrievers/test_hybrid_e2e.py
+++ b/tests/e2e/retrievers/test_hybrid_e2e.py
@@ -47,7 +47,7 @@ def test_hybrid_retriever_search_text(
         assert "'vectorProperty': None," in result.content
 
 
-@pytest.skip(reason="It's blocking other PRs, awaiting for the update")
+@pytest.mark.skip(reason="It's blocking other PRs, awaiting for the update")
 @pytest.mark.usefixtures("setup_neo4j_for_retrieval")
 def test_hybrid_retriever_no_neo4j_deprecation_warning(
     driver: Driver, random_embedder: Embedder, caplog: pytest.LogCaptureFixture

--- a/tests/unit/llm/test_anthropic_llm.py
+++ b/tests/unit/llm/test_anthropic_llm.py
@@ -434,7 +434,7 @@ def test_anthropic_invoke_v2_with_response_format_raises_error(
 
 
 def test_anthropic_llm_close(mock_anthropic: Mock) -> None:
-    mock_anthropic.AsyncAnthropic.return_value.aclose = AsyncMock()
+    mock_anthropic.AsyncAnthropic.return_value.close = AsyncMock()
 
     llm = AnthropicLLM("claude-3-opus-20240229")
 
@@ -443,12 +443,12 @@ def test_anthropic_llm_close(mock_anthropic: Mock) -> None:
         llm.close()
 
     mock_anthropic.Anthropic.return_value.close.assert_called_once()
-    mock_anthropic.AsyncAnthropic.return_value.aclose.assert_called_once()
+    mock_anthropic.AsyncAnthropic.return_value.close.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_anthropic_llm_aclose(mock_anthropic: Mock) -> None:
-    mock_anthropic.AsyncAnthropic.return_value.aclose = AsyncMock()
+    mock_anthropic.AsyncAnthropic.return_value.close = AsyncMock()
 
     llm = AnthropicLLM("claude-3-opus-20240229")
 
@@ -457,4 +457,4 @@ async def test_anthropic_llm_aclose(mock_anthropic: Mock) -> None:
         await llm.aclose()
 
     mock_anthropic.Anthropic.return_value.close.assert_called_once()
-    mock_anthropic.AsyncAnthropic.return_value.aclose.assert_called_once()
+    mock_anthropic.AsyncAnthropic.return_value.close.assert_called_once()

--- a/tests/unit/llm/test_anthropic_llm.py
+++ b/tests/unit/llm/test_anthropic_llm.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from __future__ import annotations
-
+import warnings
 import sys
 from typing import Any, Generator, List, cast
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
@@ -431,3 +431,30 @@ def test_anthropic_invoke_v2_with_response_format_raises_error(
     assert "AnthropicLLM does not currently support structured output" in str(
         exc_info.value
     )
+
+
+def test_anthropic_llm_close(mock_anthropic: Mock) -> None:
+    mock_anthropic.AsyncAnthropic.return_value.aclose = AsyncMock()
+
+    llm = AnthropicLLM("claude-3-opus-20240229")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        llm.close()
+
+    mock_anthropic.Anthropic.return_value.close.assert_called_once()
+    mock_anthropic.AsyncAnthropic.return_value.aclose.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_anthropic_llm_aclose(mock_anthropic: Mock) -> None:
+    mock_anthropic.AsyncAnthropic.return_value.aclose = AsyncMock()
+
+    llm = AnthropicLLM("claude-3-opus-20240229")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        await llm.aclose()
+
+    mock_anthropic.Anthropic.return_value.close.assert_called_once()
+    mock_anthropic.AsyncAnthropic.return_value.aclose.assert_called_once()

--- a/tests/unit/llm/test_cohere_llm.py
+++ b/tests/unit/llm/test_cohere_llm.py
@@ -287,27 +287,17 @@ def test_cohere_invoke_v2_with_response_format_raises_error(mock_cohere: Mock) -
 
 
 def test_cohere_llm_close(mock_cohere: Mock) -> None:
-    mock_cohere.AsyncClientV2.return_value.aclose = AsyncMock()
-
     llm = CohereLLM(model_name="something")
 
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         llm.close()
 
-    mock_cohere.ClientV2.return_value.close.assert_called_once()
-    mock_cohere.AsyncClientV2.return_value.aclose.assert_called_once()
-
 
 @pytest.mark.asyncio
 async def test_cohere_llm_aclose(mock_cohere: Mock) -> None:
-    mock_cohere.AsyncClientV2.return_value.aclose = AsyncMock()
-
     llm = CohereLLM(model_name="something")
 
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         await llm.aclose()
-
-    mock_cohere.ClientV2.return_value.close.assert_called_once()
-    mock_cohere.AsyncClientV2.return_value.aclose.assert_called_once()

--- a/tests/unit/llm/test_cohere_llm.py
+++ b/tests/unit/llm/test_cohere_llm.py
@@ -13,6 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import sys
+import warnings
 from typing import Generator, List
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
@@ -283,3 +284,30 @@ def test_cohere_invoke_v2_with_response_format_raises_error(mock_cohere: Mock) -
     assert "CohereLLM does not currently support structured output" in str(
         exc_info.value
     )
+
+
+def test_cohere_llm_close(mock_cohere: Mock) -> None:
+    mock_cohere.AsyncClientV2.return_value.aclose = AsyncMock()
+
+    llm = CohereLLM(model_name="something")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        llm.close()
+
+    mock_cohere.ClientV2.return_value.close.assert_called_once()
+    mock_cohere.AsyncClientV2.return_value.aclose.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_cohere_llm_aclose(mock_cohere: Mock) -> None:
+    mock_cohere.AsyncClientV2.return_value.aclose = AsyncMock()
+
+    llm = CohereLLM(model_name="something")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        await llm.aclose()
+
+    mock_cohere.ClientV2.return_value.close.assert_called_once()
+    mock_cohere.AsyncClientV2.return_value.aclose.assert_called_once()

--- a/tests/unit/llm/test_mistralai_llm.py
+++ b/tests/unit/llm/test_mistralai_llm.py
@@ -12,6 +12,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import warnings
 from typing import Any, List, Optional, cast
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
@@ -486,3 +487,32 @@ async def test_mistralai_ainvoke_v2_rate_limit_handler_called(
 
     assert response.content == "Hi there!"
     spy_handler.handle_async.assert_called_once()
+
+
+@patch("neo4j_graphrag.llm.mistralai_llm.Mistral")
+def test_mistralai_llm_close(mock_mistral: Mock) -> None:
+    mock_mistral.return_value.aclose = AsyncMock()
+
+    llm = MistralAILLM(model_name="mistral-model")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        llm.close()
+
+    mock_mistral.return_value.close.assert_called_once()
+    mock_mistral.return_value.aclose.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("neo4j_graphrag.llm.mistralai_llm.Mistral")
+async def test_mistralai_llm_aclose(mock_mistral: Mock) -> None:
+    mock_mistral.return_value.aclose = AsyncMock()
+
+    llm = MistralAILLM(model_name="mistral-model")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        await llm.aclose()
+
+    mock_mistral.return_value.close.assert_called_once()
+    mock_mistral.return_value.aclose.assert_called_once()

--- a/tests/unit/llm/test_ollama_llm.py
+++ b/tests/unit/llm/test_ollama_llm.py
@@ -679,7 +679,6 @@ def test_ollama_invoke_v2_with_response_format_raises_error(mock_import: Mock) -
 def test_ollama_llm_close(mock_import: Mock) -> None:
     mock_ollama = get_mock_ollama()
     mock_import.return_value = mock_ollama
-    mock_ollama.AsyncClient.return_value.aclose = AsyncMock()
 
     llm = OllamaLLM(model_name="llama3.2", model_params={"options": {}})
 
@@ -687,22 +686,15 @@ def test_ollama_llm_close(mock_import: Mock) -> None:
         warnings.simplefilter("error")
         llm.close()
 
-    mock_ollama.Client.return_value.close.assert_called_once()
-    mock_ollama.AsyncClient.return_value.aclose.assert_called_once()
-
 
 @pytest.mark.asyncio
 @patch("builtins.__import__")
 async def test_ollama_llm_aclose(mock_import: Mock) -> None:
     mock_ollama = get_mock_ollama()
     mock_import.return_value = mock_ollama
-    mock_ollama.AsyncClient.return_value.aclose = AsyncMock()
 
     llm = OllamaLLM(model_name="llama3.2", model_params={"options": {}})
 
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         await llm.aclose()
-
-    mock_ollama.Client.return_value.close.assert_called_once()
-    mock_ollama.AsyncClient.return_value.aclose.assert_called_once()

--- a/tests/unit/llm/test_ollama_llm.py
+++ b/tests/unit/llm/test_ollama_llm.py
@@ -14,7 +14,7 @@
 #  limitations under the License.
 import warnings
 from typing import Any, List, cast
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import ollama
 import pytest

--- a/tests/unit/llm/test_ollama_llm.py
+++ b/tests/unit/llm/test_ollama_llm.py
@@ -12,8 +12,9 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import warnings
 from typing import Any, List, cast
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import ollama
 import pytest
@@ -672,3 +673,36 @@ def test_ollama_invoke_v2_with_response_format_raises_error(mock_import: Mock) -
     assert "OllamaLLM does not currently support structured output" in str(
         exc_info.value
     )
+
+
+@patch("builtins.__import__")
+def test_ollama_llm_close(mock_import: Mock) -> None:
+    mock_ollama = get_mock_ollama()
+    mock_import.return_value = mock_ollama
+    mock_ollama.AsyncClient.return_value.aclose = AsyncMock()
+
+    llm = OllamaLLM(model_name="llama3.2", model_params={"options": {}})
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        llm.close()
+
+    mock_ollama.Client.return_value.close.assert_called_once()
+    mock_ollama.AsyncClient.return_value.aclose.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("builtins.__import__")
+async def test_ollama_llm_aclose(mock_import: Mock) -> None:
+    mock_ollama = get_mock_ollama()
+    mock_import.return_value = mock_ollama
+    mock_ollama.AsyncClient.return_value.aclose = AsyncMock()
+
+    llm = OllamaLLM(model_name="llama3.2", model_params={"options": {}})
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        await llm.aclose()
+
+    mock_ollama.Client.return_value.close.assert_called_once()
+    mock_ollama.AsyncClient.return_value.aclose.assert_called_once()

--- a/tests/unit/llm/test_openai_llm.py
+++ b/tests/unit/llm/test_openai_llm.py
@@ -798,7 +798,7 @@ async def test_openai_llm_ainvoke_v2_with_json_schema_response_format(
 def test_openai_llm_close(mock_import: Mock) -> None:
     mock_openai = get_mock_openai()
     mock_import.return_value = mock_openai
-    mock_openai.AsyncOpenAI.return_value.aclose = AsyncMock()
+    mock_openai.AsyncOpenAI.return_value.close = AsyncMock()
 
     llm = OpenAILLM(api_key="my key", model_name="gpt")
 
@@ -807,7 +807,7 @@ def test_openai_llm_close(mock_import: Mock) -> None:
         llm.close()
 
     mock_openai.OpenAI.return_value.close.assert_called_once()
-    mock_openai.AsyncOpenAI.return_value.aclose.assert_called_once()
+    mock_openai.AsyncOpenAI.return_value.close.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -815,7 +815,7 @@ def test_openai_llm_close(mock_import: Mock) -> None:
 async def test_openai_llm_aclose(mock_import: Mock) -> None:
     mock_openai = get_mock_openai()
     mock_import.return_value = mock_openai
-    mock_openai.AsyncOpenAI.return_value.aclose = AsyncMock()
+    mock_openai.AsyncOpenAI.return_value.close = AsyncMock()
 
     llm = OpenAILLM(api_key="my key", model_name="gpt")
 
@@ -824,7 +824,7 @@ async def test_openai_llm_aclose(mock_import: Mock) -> None:
         await llm.aclose()
 
     mock_openai.OpenAI.return_value.close.assert_called_once()
-    mock_openai.AsyncOpenAI.return_value.aclose.assert_called_once()
+    mock_openai.AsyncOpenAI.return_value.close.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/llm/test_openai_llm.py
+++ b/tests/unit/llm/test_openai_llm.py
@@ -12,7 +12,8 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from unittest.mock import MagicMock, Mock, patch
+import warnings
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 from typing import Any, Callable, List
 import builtins
 
@@ -791,3 +792,48 @@ async def test_openai_llm_ainvoke_v2_with_json_schema_response_format(
     response = await llm.ainvoke(messages, response_format=_TEST_JSON_SCHEMA)
 
     assert response.content == '{"result": "success"}'
+
+
+@patch("builtins.__import__")
+def test_openai_llm_close(mock_import: Mock) -> None:
+    mock_openai = get_mock_openai()
+    mock_import.return_value = mock_openai
+    mock_openai.AsyncOpenAI.return_value.aclose = AsyncMock()
+
+    llm = OpenAILLM(api_key="my key", model_name="gpt")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        llm.close()
+
+    mock_openai.OpenAI.return_value.close.assert_called_once()
+    mock_openai.AsyncOpenAI.return_value.aclose.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("builtins.__import__")
+async def test_openai_llm_aclose(mock_import: Mock) -> None:
+    mock_openai = get_mock_openai()
+    mock_import.return_value = mock_openai
+    mock_openai.AsyncOpenAI.return_value.aclose = AsyncMock()
+
+    llm = OpenAILLM(api_key="my key", model_name="gpt")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        await llm.aclose()
+
+    mock_openai.OpenAI.return_value.close.assert_called_once()
+    mock_openai.AsyncOpenAI.return_value.aclose.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("builtins.__import__")
+async def test_openai_llm_close_raises_in_async_context(mock_import: Mock) -> None:
+    mock_openai = get_mock_openai()
+    mock_import.return_value = mock_openai
+
+    llm = OpenAILLM(api_key="my key", model_name="gpt")
+
+    with pytest.raises(RuntimeError, match="async with"):
+        llm.close()

--- a/tests/unit/llm/test_openai_llm.py
+++ b/tests/unit/llm/test_openai_llm.py
@@ -797,7 +797,7 @@ async def test_openai_llm_ainvoke_v2_with_json_schema_response_format(
 @patch("builtins.__import__")
 def test_openai_llm_close(mock_import: Mock) -> None:
     mock_openai = get_mock_openai()
-    mock_import.return_value = mock_openai
+    mock_import.side_effect = create_selective_import_mock(mock_openai)
     mock_openai.AsyncOpenAI.return_value.close = AsyncMock()
 
     llm = OpenAILLM(api_key="my key", model_name="gpt")
@@ -814,7 +814,7 @@ def test_openai_llm_close(mock_import: Mock) -> None:
 @patch("builtins.__import__")
 async def test_openai_llm_aclose(mock_import: Mock) -> None:
     mock_openai = get_mock_openai()
-    mock_import.return_value = mock_openai
+    mock_import.side_effect = create_selective_import_mock(mock_openai)
     mock_openai.AsyncOpenAI.return_value.close = AsyncMock()
 
     llm = OpenAILLM(api_key="my key", model_name="gpt")


### PR DESCRIPTION
# Description

This PR adds `close` and `aclose` methods to the `LLMBase` base class in order to avoid having to access the internal `async_client` to clean up ressources properly. 

In practice, only the `aclose` method needs to be implemented. The `close` method tries to call `aclose`. If an event loop is already running, it raises an error saying to call `await llm.aclose()` instead.

Also added the context management methods, even if not mandatory, it allows to use this pattern: 

```
with OpenAILLM(model_name="") as llm:
    pass
```
and clients will be closed gracefully.


## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High
>
>

Complexity:

## How Has This Been Tested?
- [x] Unit tests
- [x] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [x] Examples have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
