### PR TITLE
docs(llm): fix copy-pasted model names in docstrings

### DIFF
--- a/src/neo4j_graphrag/embeddings/ollama.py
+++ b/src/neo4j_graphrag/embeddings/ollama.py
@@ -32,7 +32,7 @@ class OllamaEmbeddings(Embedder):
     This class uses the ollama Python client to generate vector embeddings for text data.
 
     Args:
-        model (str): The name of the Mistral AI text embedding model to use. Defaults to "mistral-embed".
+        model (str): The name of the Ollama text embedding model to use.
     """
 
     def __init__(

--- a/src/neo4j_graphrag/llm/anthropic_llm.py
+++ b/src/neo4j_graphrag/llm/anthropic_llm.py
@@ -57,7 +57,7 @@ class AnthropicLLM(LLMBase):
     """Interface for large language models on Anthropic
 
     Args:
-        model_name (str, optional): Name of the LLM to use. Defaults to "gemini-1.5-flash-001".
+        model_name (str): Name of the LLM to use.
         model_params (Optional[dict], optional): Additional parameters for LLMInterface(V1) passed to the model when text is sent to it. Defaults to None.
         system_instruction: Optional[str], optional): Additional instructions for setting the behavior and context for the model in a conversation. Defaults to None.
         rate_limit_handler (Optional[RateLimitHandler], optional): Handler for managing rate limits for LLMInterface(V1). Defaults to None.

--- a/src/neo4j_graphrag/llm/cohere_llm.py
+++ b/src/neo4j_graphrag/llm/cohere_llm.py
@@ -62,7 +62,7 @@ class CohereLLM(LLMBase):
     """Interface for large language models on the Cohere platform
 
     Args:
-        model_name (str, optional): Name of the LLM to use. Defaults to "gemini-1.5-flash-001".
+        model_name (str, optional): Name of the LLM to use. Defaults to "".
         model_params (Optional[dict], optional): Additional parameters for LLMInterface(V1) passed to the model when text is sent to it. Defaults to None.
         system_instruction (Optional[str], optional): Additional instructions for setting the behavior and context for the model in a conversation. Defaults to None.
         rate_limit_handler (Optional[RateLimitHandler], optional): A rate limit handler for LLMInterface(V1) to manage API rate limits. Defaults to None.

--- a/src/neo4j_graphrag/llm/ollama_llm.py
+++ b/src/neo4j_graphrag/llm/ollama_llm.py
@@ -241,7 +241,7 @@ class OllamaLLM(LLMBase):
         message_history: Optional[Union[List[LLMMessage], MessageHistory]] = None,
         system_instruction: Optional[str] = None,
     ) -> LLMResponse:
-        """Asynchronously sends a text input to the OpenAI chat
+        """Asynchronously sends a text input to the Ollama chat
         completion model and returns the response's content.
 
         Args:
@@ -251,7 +251,7 @@ class OllamaLLM(LLMBase):
             system_instruction (Optional[str]): An option to override the llm system message for this invocation.
 
         Returns:
-            LLMResponse: The response from OpenAI.
+            LLMResponse: The response from Ollama.
 
         Raises:
             LLMGenerationError: If anything goes wrong.


### PR DESCRIPTION
Fix copy-pasted docstrings across LLM and embeddings modules:

- `OllamaEmbeddings` (`embeddings/ollama.py`): referenced "Mistral AI" and "mistral-embed" → fixed to "Ollama", removed incorrect default
- `AnthropicLLM` (`llm/anthropic_llm.py`): said defaults to "gemini-1.5-flash-001" → removed (no default, param is required)
- `CohereLLM` (`llm/cohere_llm.py`): said defaults to "gemini-1.5-flash-001" → fixed to `""`
- `OllamaLLM` (`llm/ollama_llm.py`): async method docstring referenced "OpenAI" → fixed to "Ollama"


## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Low

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
