### PR TITLE
fix: scope extract_cypher regex to avoid mangling map literals

### DIFF
--- a/src/neo4j_graphrag/retrievers/text2cypher.py
+++ b/src/neo4j_graphrag/retrievers/text2cypher.py
@@ -62,14 +62,15 @@ def extract_cypher(text: str) -> str:
     Returns:
         str: Properly formatted Cypher query with correct backtick quoting.
     """
-    # Extract Cypher code enclosed in triple backticks
-    pattern = r"```(.*?)```"
+    # Extract Cypher code enclosed in triple backticks, skipping optional language tag
+    pattern = r"```(?:\s*[a-zA-Z0-9_+-]+\s*\n)?(.*?)```"
     matches = re.findall(pattern, text, re.DOTALL)
     cypher_query = matches[0] if matches else text
     # Quote node labels in backticks if they contain spaces and are not already quoted
+    # Scoped to node pattern context (var: Label) to avoid matching map value colons
     cypher_query = re.sub(
-        r":\s*(?!`\s*)(\s*)([a-zA-Z0-9_]+(?:\s+[a-zA-Z0-9_]+)+)(?!\s*`)(\s*)",
-        r":`\2`",
+        r"(\(\s*[a-zA-Z0-9_]*\s*:)\s*(?!`)([a-zA-Z0-9_]+(?:\s+[a-zA-Z0-9_]+)+)\s*(?!`)(?=[\s)\[{,])",
+        r"\1`\2`",
         cypher_query,
     )
     # Quote property keys in backticks if they contain spaces and are not already quoted
@@ -80,7 +81,7 @@ def extract_cypher(text: str) -> str:
     )
     # Quote relationship types in backticks if they contain spaces and are not already quoted
     cypher_query = re.sub(
-        r"(\[\s*[a-zA-Z0-9_]*\s*:\s*)(?!`)([a-zA-Z0-9_]+(?:\s+[a-zA-Z0-9_]+)+)(?!`)(\s*(?:\]|-))",
+        r"(\[\s*[a-zA-Z0-9_]*\s*:)\s*(?!`)([a-zA-Z0-9_]+(?:\s+[a-zA-Z0-9_]+)+)\s*(?!`)(\s*(?:\]|-))",
         r"\1`\2`\3",
         cypher_query,
     )

--- a/tests/unit/retrievers/test_text2cypher.py
+++ b/tests/unit/retrievers/test_text2cypher.py
@@ -493,6 +493,26 @@ def test_t2c_retriever_with_custom_prompt_and_schema(
             "Cypher query: ```MATCH (n)-[ : `RelationshipWithBackticks` ]->(m) RETURN n, m;```",
             "MATCH (n)-[ : `RelationshipWithBackticks` ]->(m) RETURN n, m;",
         ),
+        (
+            "Map with single-word keys unchanged",
+            "WITH collect({tk: e.ID, name: e.Name}) AS items RETURN items",
+            "WITH collect({tk: e.ID, name: e.Name}) AS items RETURN items",
+        ),
+        (
+            "Map with CASE expression values unchanged",
+            "WITH collect({s: CASE WHEN r.start > d0 THEN r.start ELSE d0 END}) AS segs RETURN segs",
+            "WITH collect({s: CASE WHEN r.start > d0 THEN r.start ELSE d0 END}) AS segs RETURN segs",
+        ),
+        (
+            "Code block with cypher language tag",
+            "```cypher\nMATCH (n) RETURN n;```",
+            "MATCH (n) RETURN n;",
+        ),
+        (
+            "collect DISTINCT with map literal",
+            "WITH collect(DISTINCT {tk: e.ID, name: e.Name, s: CASE WHEN r.start > d0 THEN r.start ELSE d0 END}) AS segs RETURN segs",
+            "WITH collect(DISTINCT {tk: e.ID, name: e.Name, s: CASE WHEN r.start > d0 THEN r.start ELSE d0 END}) AS segs RETURN segs",
+        ),
     ],
 )
 def test_extract_cypher(


### PR DESCRIPTION
## Summary
- Scoped node label regex in `extract_cypher` to only match `(var: Label)` patterns, preventing false matches on map value colons (e.g., `{s: CASE WHEN ... END}`)
- Improved code block extraction to skip language tags (e.g., ` ```cypher`)
- Added unit tests for map literals, CASE expressions, and language-tagged code blocks

Fixes https://linear.app/neo4j/issue/GENKGB-481

## Test plan
- [x] All existing `test_extract_cypher` parametrized tests pass
- [x] New tests cover: map with single-word keys, CASE in map values, `cypher` language tag, `collect(DISTINCT {...})`
- [x] Full text2cypher test suite passes (32 tests)
- [x] Ruff lint clean