### PR TITLE
fix: extract_cypher fails on valid Cypher with map literals

### DIFF
--- a/src/neo4j_graphrag/retrievers/text2cypher.py
+++ b/src/neo4j_graphrag/retrievers/text2cypher.py
@@ -62,14 +62,15 @@ def extract_cypher(text: str) -> str:
     Returns:
         str: Properly formatted Cypher query with correct backtick quoting.
     """
-    # Extract Cypher code enclosed in triple backticks
-    pattern = r"```(.*?)```"
+    # Extract Cypher code enclosed in triple backticks (strip optional language tag)
+    pattern = r"```(?:[a-zA-Z]+\n)?(.*?)```"
     matches = re.findall(pattern, text, re.DOTALL)
     cypher_query = matches[0] if matches else text
     # Quote node labels in backticks if they contain spaces and are not already quoted
+    # Anchored to node pattern (...) to avoid matching map literal values
     cypher_query = re.sub(
-        r":\s*(?!`\s*)(\s*)([a-zA-Z0-9_]+(?:\s+[a-zA-Z0-9_]+)+)(?!\s*`)(\s*)",
-        r":`\2`",
+        r"(\(\s*[A-Za-z0-9_]*\s*):\s*(?!`)([A-Za-z0-9_]+(?:\s+[A-Za-z0-9_]+)+)(?!\s*`)\s*",
+        r"\1:`\2`",
         cypher_query,
     )
     # Quote property keys in backticks if they contain spaces and are not already quoted
@@ -80,8 +81,8 @@ def extract_cypher(text: str) -> str:
     )
     # Quote relationship types in backticks if they contain spaces and are not already quoted
     cypher_query = re.sub(
-        r"(\[\s*[a-zA-Z0-9_]*\s*:\s*)(?!`)([a-zA-Z0-9_]+(?:\s+[a-zA-Z0-9_]+)+)(?!`)(\s*(?:\]|-))",
-        r"\1`\2`\3",
+        r"(\[\s*[a-zA-Z0-9_]*\s*):\s*(?!`)([a-zA-Z0-9_]+(?:\s+[a-zA-Z0-9_]+)+)(?!`)\s*(\s*(?:\]|-))",
+        r"\1:`\2`\3",
         cypher_query,
     )
     return cypher_query

--- a/tests/unit/retrievers/test_text2cypher.py
+++ b/tests/unit/retrievers/test_text2cypher.py
@@ -493,6 +493,16 @@ def test_t2c_retriever_with_custom_prompt_and_schema(
             "Cypher query: ```MATCH (n)-[ : `RelationshipWithBackticks` ]->(m) RETURN n, m;```",
             "MATCH (n)-[ : `RelationshipWithBackticks` ]->(m) RETURN n, m;",
         ),
+        (
+            "Map literal values not corrupted",
+            "WITH collect(DISTINCT {\n tk:   e.TimekeeperID,\n name: e.Name,\n title: e.Title,\n s:    CASE WHEN r.start_date > d0 THEN r.start_date ELSE d0 END\n}) AS segs\nRETURN segs",
+            "WITH collect(DISTINCT {\n tk:   e.TimekeeperID,\n name: e.Name,\n title: e.Title,\n s:    CASE WHEN r.start_date > d0 THEN r.start_date ELSE d0 END\n}) AS segs\nRETURN segs",
+        ),
+        (
+            "Code block with language tag",
+            "Here is the query: ```cypher\nMATCH (n) RETURN n;```",
+            "MATCH (n) RETURN n;",
+        ),
     ],
 )
 def test_extract_cypher(


### PR DESCRIPTION
## Summary
- Fix `extract_cypher` corrupting valid Cypher containing map literals like `collect({tk: e.TimekeeperID, name: e.Name})`
- Root cause: node label regex matched any `:` followed by multi-word text, including map values
- Fix: anchor node label regex to node pattern context `(var:` so only actual labels are backtick-quoted
- Also strip optional language tags (e.g. ` ```cypher `) from code blocks

## Test plan
- [x] New test: map literal values pass through unchanged
- [x] New test: code block with language tag is stripped
- [x] All 30 existing tests pass

Closes GENKGB-481