### PR TITLE
Introduce Neo4j-style EXISTENCE constraints for KG schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Experimental: `GraphSchemaExtractionOutput`, `ExtractedNodeType`, `ExtractedRelationshipType`, and `ExtractedPropertyType` in `neo4j_graphrag.experimental.components.graph_schema_extraction` for schema-from-text LLM structured output; `Neo4jPropertyTypeName` type alias on `PropertyType`; `GraphSchema.from_extraction_output` and `validate_extraction_dict_to_graph_schema`; `make_strict_json_schema_for_structured_output` in `neo4j_graphrag.utils.json_schema_structured_output`.
+- Experimental KG schemas: `GraphConstraintType` (`UNIQUENESS`, `EXISTENCE`) and extended `ConstraintType` so `EXISTENCE` can target a node property or a relationship property; graph pruning and schema visualization respect `EXISTENCE` constraints.
 - `LLMBase`: new abstract base class (`neo4j_graphrag.llm.LLMBase`) that combines `LLMInterface` and `LLMInterfaceV2`. Concrete LLM subclasses can extend `LLMBase` instead of both interfaces to avoid repeating overload boilerplate and to suppress mypy `[no-overload-impl]` / `[no-redef]` errors.
 - MarkdownLoader (experimental): added a Markdown loader to support `.md` and `.markdown` files.
 - Added Amazon Bedrock support: `BedrockLLM` (generation/tool calling) via the boto3 Converse API, and `BedrockEmbeddings` (embeddings) via the boto3 InvokeModel API.
@@ -16,6 +17,7 @@
 ### Changed
 
 - Schema-from-text structured output (experimental): `SchemaFromTextExtractor` with `use_structured_output=True` now uses `GraphSchemaExtractionOutput` as `response_format` instead of `GraphSchema`, then converts to `GraphSchema` via `GraphSchema.from_extraction_output`. This keeps provider JSON schemas smaller while preserving the same runtime `GraphSchema` behavior.
+- Experimental `GraphSchema`: `PropertyType.required` is deprecated in favor of `EXISTENCE` constraints on `GraphSchema.constraints`; legacy `required` flags are migrated on load. Uniqueness constraints no longer imply property existence—model mandatory properties with `EXISTENCE` explicitly (aligned with Neo4j-style constraint semantics).
 - SimpleKG pipeline (experimental): the `from_pdf` parameter is deprecated in favor of `from_file` (PDF and Markdown inputs). `from_pdf` still works but emits a deprecation warning and will be removed in a future version.
 - Data loaders (experimental): the `PdfDocument` type name is deprecated in favor of `LoadedDocument`; `PdfDocument` remains available as a backward-compatible alias with a deprecation warning.
 

--- a/docs/source/types.rst
+++ b/docs/source/types.rst
@@ -105,6 +105,16 @@ Pattern
 
 .. autoclass:: neo4j_graphrag.experimental.components.schema.Pattern
 
+GraphConstraintType
+=====================
+
+.. autoclass:: neo4j_graphrag.experimental.components.schema.GraphConstraintType
+
+ConstraintType
+================
+
+.. autoclass:: neo4j_graphrag.experimental.components.schema.ConstraintType
+
 GraphSchema
 ===========
 

--- a/docs/source/user_guide_kg_builder.rst
+++ b/docs/source/user_guide_kg_builder.rst
@@ -91,7 +91,7 @@ as shown below:
         # When no properties key is provided, a default "name" property is added automatically.
         {"label": "House", "description": "Family the person belongs to"},
         # or with an explicit list of properties the LLM will try to attach to the entity:
-        {"label": "Planet", "properties": [{"name": "name", "type": "STRING", "required": True}, {"name": "weather", "type": "STRING"}]},
+        {"label": "Planet", "properties": [{"name": "name", "type": "STRING"}, {"name": "weather", "type": "STRING"}]},
     ]
     # same thing for relationships:
     RELATIONSHIP_TYPES = [
@@ -1147,8 +1147,8 @@ By default, all extracted elements — including nodes, relationships, and prope
 Configuration Options
 ---------------------
 
-- **Required Properties** (default: ``False``)
-  Required properties may be specified at the node or relationship type level. Any extracted node or relationship missing one or more of its required properties will be pruned from the graph.
+- **Existence (mandatory properties)** — via ``GraphSchema.constraints``
+  Use constraints of type ``EXISTENCE`` (for a node property or a relationship property) to mark properties that must be present and non-null. The graph pruner removes nodes or relationships that violate these constraints. This mirrors Neo4j existence constraints; it is independent of ``UNIQUENESS`` (uniqueness does not imply existence). Legacy per-property ``required`` on ``PropertyType`` is deprecated and is migrated to ``EXISTENCE`` constraints when a schema is loaded.
 
 - **Additional Properties**
   This node- or relationship-level option determines whether extra properties not listed in the schema should be retained.
@@ -1198,7 +1198,7 @@ In addition to the user-defined configuration options described above,
 the `GraphPruning` component performs the following cleanup operations:
 
 - Nodes with empty label or ID are pruned.
-- Nodes with missing required properties are pruned.
+- Nodes or relationships missing properties required by an ``EXISTENCE`` constraint are pruned.
 - Nodes with no remaining properties are pruned.
 - Relationships with empty type are pruned.
 - Relationships with invalid source or target nodes (i.e., nodes no longer present in the graph) are pruned.

--- a/examples/customize/build_graph/components/pruners/graph_pruner.py
+++ b/examples/customize/build_graph/components/pruners/graph_pruner.py
@@ -4,6 +4,8 @@ import asyncio
 
 from neo4j_graphrag.experimental.components.graph_pruning import GraphPruning
 from neo4j_graphrag.experimental.components.schema import (
+    ConstraintType,
+    GraphConstraintType,
     GraphSchema,
     NodeType,
     Pattern,
@@ -69,8 +71,8 @@ schema = GraphSchema(
         NodeType(
             label="Person",
             properties=[
-                PropertyType(name="firstName", type="STRING", required=True),
-                PropertyType(name="lastName", type="STRING", required=True),
+                PropertyType(name="firstName", type="STRING"),
+                PropertyType(name="lastName", type="STRING"),
                 PropertyType(name="age", type="INTEGER"),
             ],
             additional_properties=False,
@@ -78,7 +80,7 @@ schema = GraphSchema(
         NodeType(
             label="Organization",
             properties=[
-                PropertyType(name="name", type="STRING", required=True),
+                PropertyType(name="name", type="STRING"),
                 PropertyType(name="address", type="STRING"),
             ],
             additional_properties=True,
@@ -97,6 +99,26 @@ schema = GraphSchema(
     patterns=(
         Pattern(source="Person", relationship="KNOWS", target="Person"),
         Pattern(source="Person", relationship="WORKS_FOR", target="Organization"),
+    ),
+    constraints=(
+        ConstraintType(
+            type=GraphConstraintType.EXISTENCE,
+            node_type="Person",
+            property_name="firstName",
+            relationship_type=None,
+        ),
+        ConstraintType(
+            type=GraphConstraintType.EXISTENCE,
+            node_type="Person",
+            property_name="lastName",
+            relationship_type=None,
+        ),
+        ConstraintType(
+            type=GraphConstraintType.EXISTENCE,
+            node_type="Organization",
+            property_name="name",
+            relationship_type=None,
+        ),
     ),
     additional_node_types=False,
     additional_relationship_types=False,

--- a/src/neo4j_graphrag/experimental/components/graph_pruning.py
+++ b/src/neo4j_graphrag/experimental/components/graph_pruning.py
@@ -199,6 +199,7 @@ class GraphPruning(Component):
         node: Neo4jNode,
         pruning_stats: PruningStats,
         schema_entity: Optional[NodeType],
+        schema: GraphSchema,
         additional_node_types: bool,
     ) -> Optional[Neo4jNode]:
         if not node.label:
@@ -223,6 +224,7 @@ class GraphPruning(Component):
         filtered_props = self._enforce_properties(
             node,
             schema_entity,
+            schema,
             pruning_stats,
             prune_empty=True,
         )
@@ -260,6 +262,7 @@ class GraphPruning(Component):
                 node,
                 pruning_stats,
                 schema_entity,
+                schema,
                 additional_node_types=schema.additional_node_types,
             )
             if new_node:
@@ -275,6 +278,7 @@ class GraphPruning(Component):
         additional_relationship_types: bool,
         patterns: tuple[Pattern, ...],
         additional_patterns: bool,
+        schema: GraphSchema,
     ) -> Optional[Neo4jRelationship]:
         if not rel.type:
             pruning_stats.add_pruned_relationship(
@@ -332,6 +336,7 @@ class GraphPruning(Component):
             filtered_props = self._enforce_properties(
                 rel,
                 relationship_type,
+                schema,
                 pruning_stats,
                 prune_empty=False,
             )
@@ -388,6 +393,7 @@ class GraphPruning(Component):
                 schema.additional_relationship_types,
                 schema.patterns,
                 schema.additional_patterns,
+                schema,
             )
             if new_rel:
                 valid_rels.append(new_rel)
@@ -397,6 +403,7 @@ class GraphPruning(Component):
         self,
         item: Union[Neo4jNode, Neo4jRelationship],
         schema_item: Union[NodeType, RelationshipType],
+        schema: GraphSchema,
         pruning_stats: PruningStats,
         prune_empty: bool = False,
     ) -> dict[str, Any]:
@@ -404,7 +411,7 @@ class GraphPruning(Component):
         Enforce properties:
         - Ensure property type: for now, just prevent having invalid property types (e.g. map)
         - Filter out those that are not in schema (i.e., valid properties) if allowed properties is False.
-        - Check that all required properties are present and not null.
+        - Check that all EXISTENCE-constrained properties are present and not null.
         """
         type_safe_properties = self._ensure_property_types(
             item.properties,
@@ -421,7 +428,9 @@ class GraphPruning(Component):
             return filtered_properties
         missing_required_properties = self._check_required_properties(
             filtered_properties,
-            valid_properties=schema_item.properties,
+            schema,
+            schema_item,
+            item,
         )
         if missing_required_properties:
             pruning_stats.add_pruned_item(
@@ -459,12 +468,22 @@ class GraphPruning(Component):
         return filtered_properties
 
     def _check_required_properties(
-        self, filtered_properties: dict[str, Any], valid_properties: list[PropertyType]
+        self,
+        filtered_properties: dict[str, Any],
+        schema: GraphSchema,
+        schema_item: Union[NodeType, RelationshipType],
+        item: Union[Neo4jNode, Neo4jRelationship],
     ) -> list[str]:
-        """Returns the list of missing required properties, if any."""
-        required_prop_names = {prop.name for prop in valid_properties if prop.required}
+        """Returns properties missing per EXISTENCE constraints (must be present and not null)."""
+        if isinstance(item, Neo4jNode):
+            required_prop_names = schema.existence_property_names_for_node(item.label)
+        else:
+            required_prop_names = schema.existence_property_names_for_relationship(
+                item.type
+            )
+        declared_names = {p.name for p in schema_item.properties}
         missing_required_properties = []
-        for req_prop in required_prop_names:
+        for req_prop in required_prop_names & declared_names:
             if filtered_properties.get(req_prop) is None:
                 missing_required_properties.append(req_prop)
         return missing_required_properties

--- a/src/neo4j_graphrag/experimental/components/graph_schema_extraction.py
+++ b/src/neo4j_graphrag/experimental/components/graph_schema_extraction.py
@@ -42,7 +42,6 @@ class ExtractedPropertyType(BaseModel):
     name: str
     type: Neo4jPropertyTypeName
     description: str = ""
-    required: bool = False
     model_config = ConfigDict(frozen=True, extra="forbid")
 
 

--- a/src/neo4j_graphrag/experimental/components/graph_schema_extraction.py
+++ b/src/neo4j_graphrag/experimental/components/graph_schema_extraction.py
@@ -18,16 +18,21 @@
 These types are a lean wire format for ``response_format`` with supported LLMs.
 Pipeline code uses :class:`~neo4j_graphrag.experimental.components.schema.GraphSchema`
 exclusively; convert via :meth:`~neo4j_graphrag.experimental.components.schema.GraphSchema.from_extraction_output`.
+
+Vertex AI builds JSON Schema from Pydantic and parses it with protobuf; it rejects
+``anyOf`` branches that use JSON Schema ``type: "null"`` (e.g. ``Optional[str]``).
+Extraction-specific models therefore avoid nullable fields (e.g. use empty string
+sentinels where runtime :class:`~neo4j_graphrag.experimental.components.schema.ConstraintType`
+uses ``None``).
 """
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from neo4j_graphrag.experimental.components.schema import (
-    ConstraintType,
     Neo4jPropertyTypeName,
     Pattern,
 )
@@ -63,6 +68,40 @@ class ExtractedRelationshipType(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class ExtractedConstraintType(BaseModel):
+    """Constraint in schema-from-text structured output (Vertex/OpenAI JSON Schema).
+
+    This is a **wire DTO** only: shapes the JSON Schema (e.g. no nullable ``relationship_type``,
+    which Vertex's protobuf parser rejects). Semantic rules match
+    :class:`~neo4j_graphrag.experimental.components.schema.ConstraintType`; those are enforced
+    when building :class:`~neo4j_graphrag.experimental.components.schema.GraphSchema`, not here.
+    """
+
+    type: Literal["UNIQUENESS", "EXISTENCE"]
+    property_name: str
+    node_type: str = ""
+    relationship_type: str = ""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+
+def wire_extraction_constraints_for_graph_schema(
+    constraints: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Map extraction constraint dicts to values compatible with :class:`~neo4j_graphrag.experimental.components.schema.ConstraintType`.
+
+    Empty ``relationship_type`` (the wire \"unset\" sentinel) becomes ``None`` for runtime validation.
+    """
+    out: list[dict[str, Any]] = []
+    for c in constraints:
+        d = dict(c)
+        rt = d.get("relationship_type")
+        if rt is None or (isinstance(rt, str) and rt.strip() == ""):
+            d["relationship_type"] = None
+        out.append(d)
+    return out
+
+
 class GraphSchemaExtractionOutput(BaseModel):
     """JSON shape for LLM schema-from-text structured output (V2).
 
@@ -73,7 +112,7 @@ class GraphSchemaExtractionOutput(BaseModel):
     node_types: list[ExtractedNodeType] = Field(default_factory=list)
     relationship_types: list[ExtractedRelationshipType] = Field(default_factory=list)
     patterns: list[Pattern] = Field(default_factory=list)
-    constraints: list[ConstraintType] = Field(default_factory=list)
+    constraints: list[ExtractedConstraintType] = Field(default_factory=list)
     model_config = ConfigDict(extra="forbid")
 
     @classmethod

--- a/src/neo4j_graphrag/experimental/components/schema.py
+++ b/src/neo4j_graphrag/experimental/components/schema.py
@@ -14,6 +14,7 @@
 #  limitations under the License.
 from __future__ import annotations
 
+import enum
 import json
 import logging
 import re
@@ -93,6 +94,17 @@ Neo4jPropertyTypeName: TypeAlias = Literal[
 _DUNDER_RE = re.compile(r"^__|__$")
 
 
+class GraphConstraintType(str, enum.Enum):
+    """Constraint kinds for :class:`ConstraintType`.
+
+    ``UNIQUENESS`` is for node properties only in this API. ``EXISTENCE`` marks a mandatory
+    (non-null) node or relationship property, analogous to Neo4j property existence constraints.
+    """
+
+    UNIQUENESS = "UNIQUENESS"
+    EXISTENCE = "EXISTENCE"
+
+
 def _reject_dunder_label(label: str, kind: str) -> str:
     """Raise ValueError if *label* starts or ends with double underscores."""
     if _DUNDER_RE.search(label):
@@ -112,7 +124,13 @@ class PropertyType(BaseModel):
     # See https://neo4j.com/docs/cypher-manual/current/values-and-types/property-structural-constructed/#property-types
     type: Neo4jPropertyTypeName
     description: str = ""
-    required: bool = False
+    required: bool = Field(
+        default=False,
+        deprecated=(
+            "Use GraphSchema.constraints with type EXISTENCE instead of PropertyType.required. "
+            "Uniqueness does not imply existence; model existence explicitly with EXISTENCE constraints."
+        ),
+    )
     model_config = ConfigDict(
         frozen=True,
     )
@@ -237,18 +255,42 @@ class RelationshipType(BaseModel):
 
 class ConstraintType(BaseModel):
     """
-    Represents a constraint on a node in the graph.
+    Represents a schema-level constraint (uniqueness or existence) on a node or
+    (for EXISTENCE only) relationship property.
     """
 
-    type: Literal[
-        "UNIQUENESS"
-    ]  # TODO: add other constraint types ["propertyExistence", "propertyType", "key"]
-    node_type: str
+    type: GraphConstraintType
     property_name: str
+    node_type: str = ""
+    relationship_type: Optional[str] = None
 
     model_config = ConfigDict(
         frozen=True,
+        use_enum_values=True,
     )
+
+    @model_validator(mode="after")
+    def validate_constraint_shape(self) -> Self:
+        if self.type == GraphConstraintType.UNIQUENESS:
+            if not (self.node_type and self.node_type.strip()):
+                raise ValueError(
+                    "UNIQUENESS constraint requires a non-empty node_type; "
+                    "relationship uniqueness is not supported on GraphSchema constraints."
+                )
+            if self.relationship_type is not None and self.relationship_type.strip():
+                raise ValueError(
+                    "UNIQUENESS constraint must not set relationship_type; "
+                    "only node-level UNIQUENESS is supported."
+                )
+        elif self.type == GraphConstraintType.EXISTENCE:
+            has_node = bool(self.node_type and self.node_type.strip())
+            has_rel = bool(self.relationship_type and self.relationship_type.strip())
+            if has_node == has_rel:
+                raise ValueError(
+                    "EXISTENCE constraint requires exactly one of node_type or relationship_type "
+                    "(non-empty), not both and not neither."
+                )
+        return self
 
 
 class Pattern(BaseModel):
@@ -344,6 +386,95 @@ class GraphSchema(DataModel):
             data["patterns"] = converted
         return data
 
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_deprecated_required_to_existence_constraints(cls, data: Any) -> Any:
+        """Convert legacy ``PropertyType.required`` to ``EXISTENCE`` constraints and clear flags."""
+        if not isinstance(data, dict):
+            return data
+        constraints = list(data.get("constraints") or [])
+
+        def _constraint_identity(c: Any) -> tuple[str, str, str, str]:
+            if isinstance(c, ConstraintType):
+                nt = c.node_type or ""
+                rt = c.relationship_type or ""
+                return (str(c.type), nt, rt, c.property_name)
+            if isinstance(c, dict):
+                return (
+                    str(c.get("type", "")),
+                    str(c.get("node_type") or ""),
+                    str(c.get("relationship_type") or ""),
+                    str(c.get("property_name") or ""),
+                )
+            return ("", "", "", "")
+
+        seen_existence: set[tuple[str, str, str]] = set()
+        for c in constraints:
+            t, nt, rt, pn = _constraint_identity(c)
+            if t in (GraphConstraintType.EXISTENCE.value, "EXISTENCE"):
+                seen_existence.add((nt or "", rt or "", pn))
+
+        for node in data.get("node_types") or []:
+            if not isinstance(node, dict):
+                continue
+            label = node.get("label")
+            if not label:
+                continue
+            for prop in node.get("properties") or []:
+                if not isinstance(prop, dict):
+                    continue
+                if prop.get("required") is not True:
+                    continue
+                pname = prop.get("name")
+                if not pname:
+                    continue
+                key = (label, "", pname)
+                if key in seen_existence:
+                    prop["required"] = False
+                    continue
+                constraints.append(
+                    {
+                        "type": GraphConstraintType.EXISTENCE.value,
+                        "node_type": label,
+                        "property_name": pname,
+                        "relationship_type": None,
+                    }
+                )
+                seen_existence.add(key)
+                prop["required"] = False
+
+        for rel in data.get("relationship_types") or []:
+            if not isinstance(rel, dict):
+                continue
+            rlabel = rel.get("label")
+            if not rlabel:
+                continue
+            for prop in rel.get("properties") or []:
+                if not isinstance(prop, dict):
+                    continue
+                if prop.get("required") is not True:
+                    continue
+                pname = prop.get("name")
+                if not pname:
+                    continue
+                key = ("", rlabel, pname)
+                if key in seen_existence:
+                    prop["required"] = False
+                    continue
+                constraints.append(
+                    {
+                        "type": GraphConstraintType.EXISTENCE.value,
+                        "node_type": "",
+                        "property_name": pname,
+                        "relationship_type": rlabel,
+                    }
+                )
+                seen_existence.add(key)
+                prop["required"] = False
+
+        data["constraints"] = tuple(constraints)
+        return data
+
     @model_validator(mode="after")
     def validate_patterns_against_node_and_rel_types(self) -> Self:
         self._node_type_index = {node.label: node for node in self.node_types}
@@ -393,27 +524,61 @@ class GraphSchema(DataModel):
         if not self.constraints:
             return self
         for constraint in self.constraints:
-            # Only validate UNIQUENESS constraints (other types will be added)
-            if constraint.type != "UNIQUENESS":
-                continue
-
             if not constraint.property_name:
                 raise SchemaValidationError(
                     f"Constraint has no property name: {constraint}. Property name is required."
                 )
-            if constraint.node_type not in self._node_type_index:
-                raise SchemaValidationError(
-                    f"Constraint references undefined node type: {constraint.node_type}"
+            ctype = constraint.type
+            if isinstance(ctype, str):
+                ctype = GraphConstraintType(ctype)
+
+            if ctype == GraphConstraintType.UNIQUENESS:
+                if constraint.node_type not in self._node_type_index:
+                    raise SchemaValidationError(
+                        f"Constraint references undefined node type: {constraint.node_type}"
+                    )
+                node_type = self._node_type_index[constraint.node_type]
+                valid_property_names = {p.name for p in node_type.properties}
+                if constraint.property_name not in valid_property_names:
+                    raise SchemaValidationError(
+                        f"Constraint references undefined property '{constraint.property_name}' "
+                        f"on node type '{constraint.node_type}'. "
+                        f"Valid properties: {valid_property_names}"
+                    )
+            elif ctype == GraphConstraintType.EXISTENCE:
+                has_node = bool(constraint.node_type and constraint.node_type.strip())
+                has_rel = bool(
+                    constraint.relationship_type
+                    and constraint.relationship_type.strip()
                 )
-            # Check if property_name exists on the node type
-            node_type = self._node_type_index[constraint.node_type]
-            valid_property_names = {p.name for p in node_type.properties}
-            if constraint.property_name not in valid_property_names:
-                raise SchemaValidationError(
-                    f"Constraint references undefined property '{constraint.property_name}' "
-                    f"on node type '{constraint.node_type}'. "
-                    f"Valid properties: {valid_property_names}"
-                )
+                if has_node:
+                    if constraint.node_type not in self._node_type_index:
+                        raise SchemaValidationError(
+                            f"Constraint references undefined node type: {constraint.node_type}"
+                        )
+                    node_type = self._node_type_index[constraint.node_type]
+                    valid_property_names = {p.name for p in node_type.properties}
+                    if constraint.property_name not in valid_property_names:
+                        raise SchemaValidationError(
+                            f"EXISTENCE constraint references undefined property "
+                            f"'{constraint.property_name}' on node type '{constraint.node_type}'. "
+                            f"Valid properties: {valid_property_names}"
+                        )
+                elif has_rel:
+                    rlabel = constraint.relationship_type
+                    assert rlabel is not None
+                    if rlabel not in self._relationship_type_index:
+                        raise SchemaValidationError(
+                            f"Constraint references undefined relationship type: {rlabel}"
+                        )
+                    rel_type = self._relationship_type_index[rlabel]
+                    valid_property_names = {p.name for p in rel_type.properties}
+                    if constraint.property_name not in valid_property_names:
+                        raise SchemaValidationError(
+                            f"EXISTENCE constraint references undefined property "
+                            f"'{constraint.property_name}' on relationship type '{rlabel}'. "
+                            f"Valid properties: {valid_property_names}"
+                        )
         return self
 
     def node_type_from_label(self, label: str) -> Optional[NodeType]:
@@ -421,6 +586,34 @@ class GraphSchema(DataModel):
 
     def relationship_type_from_label(self, label: str) -> Optional[RelationshipType]:
         return self._relationship_type_index.get(label)
+
+    def existence_property_names_for_node(self, label: str) -> set[str]:
+        """Property names that have an EXISTENCE constraint for this node label."""
+        names: set[str] = set()
+        for c in self.constraints:
+            ct = c.type
+            if isinstance(ct, str):
+                ct = GraphConstraintType(ct)
+            if ct != GraphConstraintType.EXISTENCE:
+                continue
+            if c.node_type == label and not (
+                c.relationship_type and str(c.relationship_type).strip()
+            ):
+                names.add(c.property_name)
+        return names
+
+    def existence_property_names_for_relationship(self, rel_label: str) -> set[str]:
+        """Property names that have an EXISTENCE constraint for this relationship type."""
+        names: set[str] = set()
+        for c in self.constraints:
+            ct = c.type
+            if isinstance(ct, str):
+                ct = GraphConstraintType(ct)
+            if ct != GraphConstraintType.EXISTENCE:
+                continue
+            if c.relationship_type == rel_label:
+                names.add(c.property_name)
+        return names
 
     @classmethod
     def model_json_schema(cls, **kwargs: Any) -> dict[str, Any]:  # type: ignore[override]
@@ -716,50 +909,13 @@ def _extraction_filter_invalid_patterns(
     return filtered_patterns
 
 
-def _extraction_enforce_required_for_constraint_properties(
-    node_types: List[Dict[str, Any]],
-    constraints: List[Dict[str, Any]],
-) -> None:
-    """Ensure properties with UNIQUENESS constraints are marked as required."""
-    if not constraints:
-        return
-
-    constraint_props: Dict[str, set[str]] = {}
-    for c in constraints:
-        if c.get("type") == "UNIQUENESS":
-            label = c.get("node_type")
-            prop = c.get("property_name")
-            if label and prop:
-                constraint_props.setdefault(label, set()).add(prop)
-
-    for node_type in node_types:
-        label = node_type.get("label")
-        if label not in constraint_props:
-            continue
-
-        props_to_fix = constraint_props[label]
-        for prop in node_type.get("properties", []):
-            if isinstance(prop, dict) and prop.get("name") in props_to_fix:
-                if prop.get("required") is not True:
-                    logging.info(
-                        f"Auto-setting 'required' as True for property '{prop.get('name')}' "
-                        f"on node '{label}' (has UNIQUENESS constraint)."
-                    )
-                    prop["required"] = True
-
-
 def _extraction_filter_invalid_constraints(
-    constraints: List[Dict[str, Any]], node_types: List[Dict[str, Any]]
+    constraints: List[Dict[str, Any]],
+    node_types: List[Dict[str, Any]],
+    relationship_types: Optional[List[Dict[str, Any]]] = None,
 ) -> List[Dict[str, Any]]:
-    """Filter constraints that reference unknown node types or invalid properties."""
+    """Filter constraints that reference unknown types or invalid properties."""
     if not constraints:
-        return []
-
-    if not node_types:
-        logging.info(
-            "Filtering out all constraints because no node types are defined. "
-            "Constraints reference node types that must be defined."
-        )
         return []
 
     node_type_properties: Dict[str, set[str]] = {}
@@ -770,14 +926,27 @@ def _extraction_filter_invalid_constraints(
             property_names = {p.get("name") for p in properties if p.get("name")}
             node_type_properties[label] = property_names
 
+    rel_type_properties: Dict[str, set[str]] = {}
+    for rel_dict in relationship_types or []:
+        label = rel_dict.get("label")
+        if label:
+            properties = rel_dict.get("properties", [])
+            property_names = {p.get("name") for p in properties if p.get("name")}
+            rel_type_properties[label] = property_names
+
     valid_node_labels = set(node_type_properties.keys())
+    valid_rel_labels = set(rel_type_properties.keys())
 
     filtered_constraints = []
     for constraint in constraints:
-        if constraint.get("type") != "UNIQUENESS":
+        ctype = constraint.get("type")
+        if ctype not in (
+            GraphConstraintType.UNIQUENESS.value,
+            GraphConstraintType.EXISTENCE.value,
+        ):
             logging.info(
                 f"Filtering out constraint: {constraint}. "
-                f"Only UNIQUENESS constraints are supported."
+                f"Unsupported constraint type (expected UNIQUENESS or EXISTENCE)."
             )
             continue
 
@@ -787,22 +956,78 @@ def _extraction_filter_invalid_constraints(
                 f"Property name is not provided."
             )
             continue
-        node_type = constraint.get("node_type")
-        if node_type not in valid_node_labels:
+
+        if ctype == GraphConstraintType.UNIQUENESS.value:
+            if not node_types:
+                logging.info(
+                    f"Filtering out constraint: {constraint}. "
+                    f"No node types are defined."
+                )
+                continue
+            node_type = constraint.get("node_type")
+            if not node_type or node_type not in valid_node_labels:
+                logging.info(
+                    f"Filtering out constraint: {constraint}. "
+                    f"Node type '{node_type}' is not valid. Valid node types: {valid_node_labels}"
+                )
+                continue
+            property_name = constraint.get("property_name")
+            if property_name not in node_type_properties.get(node_type, set()):
+                logging.info(
+                    f"Filtering out constraint: {constraint}. "
+                    f"Property '{property_name}' does not exist on node type '{node_type}'. "
+                    f"Valid properties: {node_type_properties.get(node_type, set())}"
+                )
+                continue
+            filtered_constraints.append(constraint)
+            continue
+
+        # EXISTENCE
+        node_type = constraint.get("node_type") or ""
+        rel_type = constraint.get("relationship_type")
+        has_node = bool(str(node_type).strip())
+        has_rel = bool(rel_type and str(rel_type).strip())
+        if has_node == has_rel:
             logging.info(
                 f"Filtering out constraint: {constraint}. "
-                f"Node type '{node_type}' is not valid. Valid node types: {valid_node_labels}"
+                f"EXISTENCE requires exactly one of node_type or relationship_type."
             )
             continue
-        property_name = constraint.get("property_name")
-        if property_name not in node_type_properties.get(node_type, set()):
-            logging.info(
-                f"Filtering out constraint: {constraint}. "
-                f"Property '{property_name}' does not exist on node type '{node_type}'. "
-                f"Valid properties: {node_type_properties.get(node_type, set())}"
-            )
-            continue
-        filtered_constraints.append(constraint)
+        if has_node:
+            if node_type not in valid_node_labels:
+                logging.info(
+                    f"Filtering out constraint: {constraint}. "
+                    f"Node type '{node_type}' is not valid. Valid node types: {valid_node_labels}"
+                )
+                continue
+            property_name = constraint.get("property_name")
+            if property_name not in node_type_properties.get(node_type, set()):
+                logging.info(
+                    f"Filtering out constraint: {constraint}. "
+                    f"Property '{property_name}' does not exist on node type '{node_type}'. "
+                    f"Valid properties: {node_type_properties.get(node_type, set())}"
+                )
+                continue
+            filtered_constraints.append(constraint)
+        else:
+            assert rel_type is not None
+            if rel_type not in valid_rel_labels:
+                logging.info(
+                    f"Filtering out constraint: {constraint}. "
+                    f"Relationship type '{rel_type}' is not valid. "
+                    f"Valid relationship types: {valid_rel_labels}"
+                )
+                continue
+            property_name = constraint.get("property_name")
+            if property_name not in rel_type_properties.get(rel_type, set()):
+                logging.info(
+                    f"Filtering out constraint: {constraint}. "
+                    f"Property '{property_name}' does not exist on relationship type '{rel_type}'. "
+                    f"Valid properties: {rel_type_properties.get(rel_type, set())}"
+                )
+                continue
+            filtered_constraints.append(constraint)
+
     return filtered_constraints
 
 
@@ -820,13 +1045,10 @@ def _extraction_apply_cross_reference_filters(
         )
 
     if extracted_constraints:
-        _extraction_enforce_required_for_constraint_properties(
-            extracted_node_types, extracted_constraints
-        )
-
-    if extracted_constraints:
         extracted_constraints = _extraction_filter_invalid_constraints(
-            extracted_constraints, extracted_node_types
+            extracted_constraints,
+            extracted_node_types,
+            extracted_relationship_types,
         )
 
     return extracted_patterns, extracted_constraints
@@ -1016,14 +1238,6 @@ class SchemaFromTextExtractor(BaseSchemaBuilder):
                     prop.pop("required", None)
 
         return node_types
-
-    def _enforce_required_for_constraint_properties(
-        self,
-        node_types: List[Dict[str, Any]],
-        constraints: List[Dict[str, Any]],
-    ) -> None:
-        """Ensure properties with UNIQUENESS constraints are marked as required."""
-        _extraction_enforce_required_for_constraint_properties(node_types, constraints)
 
     def _clean_json_content(self, content: str) -> str:
         content = content.strip()
@@ -1268,44 +1482,56 @@ class SchemaFromExistingGraphExtractor(BaseSchemaBuilder):
         self.additional_patterns = additional_patterns
 
     @staticmethod
-    def _extract_required_properties(
+    def _extract_existence_constraints_from_metadata(
         structured_schema: dict[str, Any],
-    ) -> list[tuple[str, str]]:
-        """Extract a list of (node label (or rel type), property name) for which
-         an "EXISTENCE" or "KEY" constraint is defined in the DB.
-
-         Args:
-
-             structured_schema (dict[str, Any]): the result of the `get_structured_schema()` function.
-
-        Returns:
-
-            list of tuples of (node label (or rel type), property name)
-
-        """
+    ) -> list[dict[str, Any]]:
+        """Build EXISTENCE constraint dicts from Neo4j ``SHOW CONSTRAINTS`` metadata."""
         schema_metadata = structured_schema.get("metadata", {})
-        existence_constraint = []  # list of (node label, property name)
+        result: list[dict[str, Any]] = []
+        seen: set[tuple[str, str, str, str]] = set()
+
         for constraint in schema_metadata.get("constraint", []):
-            if constraint["type"] in (
-                "NODE_PROPERTY_EXISTENCE",
-                "NODE_KEY",
-                "RELATIONSHIP_PROPERTY_EXISTENCE",
-                "RELATIONSHIP_KEY",
-            ):
-                properties = constraint["properties"]
-                labels = constraint["labelsOrTypes"]
-                # note: existence constraint only apply to a single property
-                # and a single label
-                prop = properties[0]
-                lab = labels[0]
-                existence_constraint.append((lab, prop))
-        return existence_constraint
+            ctype = constraint.get("type")
+            properties = constraint.get("properties") or []
+            labels = constraint.get("labelsOrTypes") or []
+            if not properties or not labels:
+                continue
+            prop = properties[0]
+            lab = labels[0]
+
+            if ctype in ("NODE_PROPERTY_EXISTENCE", "NODE_KEY"):
+                dedupe_key = ("EXISTENCE", lab, "", prop)
+                if dedupe_key in seen:
+                    continue
+                seen.add(dedupe_key)
+                result.append(
+                    {
+                        "type": GraphConstraintType.EXISTENCE.value,
+                        "node_type": lab,
+                        "property_name": prop,
+                        "relationship_type": None,
+                    }
+                )
+            elif ctype in ("RELATIONSHIP_PROPERTY_EXISTENCE", "RELATIONSHIP_KEY"):
+                dedupe_key = ("EXISTENCE", "", lab, prop)
+                if dedupe_key in seen:
+                    continue
+                seen.add(dedupe_key)
+                result.append(
+                    {
+                        "type": GraphConstraintType.EXISTENCE.value,
+                        "node_type": "",
+                        "property_name": prop,
+                        "relationship_type": lab,
+                    }
+                )
+
+        return result
 
     def _to_schema_entity_dict(
         self,
         key: str,
         property_dict: list[dict[str, Any]],
-        existence_constraint: list[tuple[str, str]],
     ) -> dict[str, Any]:
         entity_dict: dict[str, Any] = {
             "label": key,
@@ -1313,7 +1539,6 @@ class SchemaFromExistingGraphExtractor(BaseSchemaBuilder):
                 {
                     "name": p["property"],
                     "type": p["type"],
-                    "required": (key, p["property"]) in existence_constraint,
                 }
                 for p in property_dict
             ],
@@ -1324,19 +1549,21 @@ class SchemaFromExistingGraphExtractor(BaseSchemaBuilder):
 
     async def run(self, *args: Any, **kwargs: Any) -> GraphSchema:
         structured_schema = get_structured_schema(self.driver, database=self.database)
-        existence_constraint = self._extract_required_properties(structured_schema)
+        existence_constraints = self._extract_existence_constraints_from_metadata(
+            structured_schema
+        )
 
         # node label with properties
         node_labels = set(structured_schema["node_props"].keys())
         node_types = [
-            self._to_schema_entity_dict(key, properties, existence_constraint)
+            self._to_schema_entity_dict(key, properties)
             for key, properties in structured_schema["node_props"].items()
         ]
 
         # relationships with properties
         rel_labels = set(structured_schema["rel_props"].keys())
         relationship_types = [
-            self._to_schema_entity_dict(key, properties, existence_constraint)
+            self._to_schema_entity_dict(key, properties)
             for key, properties in structured_schema["rel_props"].items()
         ]
 
@@ -1380,6 +1607,7 @@ class SchemaFromExistingGraphExtractor(BaseSchemaBuilder):
             "node_types": node_types,
             "relationship_types": relationship_types,
             "patterns": patterns,
+            "constraints": existence_constraints,
         }
         if self.additional_node_types is not None:
             schema_dict["additional_node_types"] = self.additional_node_types

--- a/src/neo4j_graphrag/experimental/components/schema.py
+++ b/src/neo4j_graphrag/experimental/components/schema.py
@@ -392,6 +392,11 @@ class GraphSchema(DataModel):
         """Convert legacy ``PropertyType.required`` to ``EXISTENCE`` constraints and clear flags."""
         if not isinstance(data, dict):
             return data
+
+        def _property_type_required_is_true(prop: PropertyType) -> bool:
+            # Use model_dump so we do not access the deprecated ``.required`` attribute.
+            return prop.model_dump().get("required") is True
+
         constraints = list(data.get("constraints") or [])
 
         def _constraint_identity(c: Any) -> tuple[str, str, str, str]:
@@ -443,6 +448,41 @@ class GraphSchema(DataModel):
                 seen_existence.add(key)
                 prop["required"] = False
 
+        node_types_in = data.get("node_types") or []
+        if node_types_in:
+            node_types_list = list(node_types_in)
+            for i, node in enumerate(node_types_list):
+                if not isinstance(node, NodeType):
+                    continue
+                label = node.label
+                if not label:
+                    continue
+                new_props: list[PropertyType] = []
+                for prop in node.properties:
+                    if not _property_type_required_is_true(prop):
+                        new_props.append(prop)
+                        continue
+                    pname = prop.name
+                    if not pname:
+                        new_props.append(prop)
+                        continue
+                    key = (label, "", pname)
+                    if key in seen_existence:
+                        new_props.append(prop.model_copy(update={"required": False}))
+                        continue
+                    constraints.append(
+                        {
+                            "type": GraphConstraintType.EXISTENCE.value,
+                            "node_type": label,
+                            "property_name": pname,
+                            "relationship_type": None,
+                        }
+                    )
+                    seen_existence.add(key)
+                    new_props.append(prop.model_copy(update={"required": False}))
+                node_types_list[i] = node.model_copy(update={"properties": new_props})
+            data["node_types"] = tuple(node_types_list)
+
         for rel in data.get("relationship_types") or []:
             if not isinstance(rel, dict):
                 continue
@@ -471,6 +511,43 @@ class GraphSchema(DataModel):
                 )
                 seen_existence.add(key)
                 prop["required"] = False
+
+        rel_types_in = data.get("relationship_types") or []
+        if rel_types_in:
+            rel_types_list = list(rel_types_in)
+            for i, rel in enumerate(rel_types_list):
+                if not isinstance(rel, RelationshipType):
+                    continue
+                rlabel = rel.label
+                if not rlabel:
+                    continue
+                rel_new_props: list[PropertyType] = []
+                for prop in rel.properties:
+                    if not _property_type_required_is_true(prop):
+                        rel_new_props.append(prop)
+                        continue
+                    pname = prop.name
+                    if not pname:
+                        rel_new_props.append(prop)
+                        continue
+                    key = ("", rlabel, pname)
+                    if key in seen_existence:
+                        rel_new_props.append(
+                            prop.model_copy(update={"required": False})
+                        )
+                        continue
+                    constraints.append(
+                        {
+                            "type": GraphConstraintType.EXISTENCE.value,
+                            "node_type": "",
+                            "property_name": pname,
+                            "relationship_type": rlabel,
+                        }
+                    )
+                    seen_existence.add(key)
+                    rel_new_props.append(prop.model_copy(update={"required": False}))
+                rel_types_list[i] = rel.model_copy(update={"properties": rel_new_props})
+            data["relationship_types"] = tuple(rel_types_list)
 
         data["constraints"] = tuple(constraints)
         return data

--- a/src/neo4j_graphrag/experimental/components/schema.py
+++ b/src/neo4j_graphrag/experimental/components/schema.py
@@ -642,16 +642,18 @@ class GraphSchema(DataModel):
         """
         from neo4j_graphrag.experimental.components.graph_schema_extraction import (
             GraphSchemaExtractionOutput,
+            wire_extraction_constraints_for_graph_schema,
         )
 
         if not isinstance(dto, GraphSchemaExtractionOutput):
             raise TypeError(
                 f"Expected GraphSchemaExtractionOutput, got {type(dto).__name__}"
             )
-        return cast(
-            Self,
-            validate_extraction_dict_to_graph_schema(dto.model_dump(mode="python")),
+        payload = dto.model_dump(mode="python")
+        payload["constraints"] = wire_extraction_constraints_for_graph_schema(
+            payload.get("constraints") or []
         )
+        return cast(Self, validate_extraction_dict_to_graph_schema(payload))
 
     @classmethod
     def create_empty(cls) -> Self:

--- a/src/neo4j_graphrag/experimental/components/schema.py
+++ b/src/neo4j_graphrag/experimental/components/schema.py
@@ -1189,58 +1189,6 @@ class SchemaFromTextExtractor(BaseSchemaBuilder):
             relationship_types, "relationship type"
         )
 
-    def _filter_properties_required_field(
-        self, node_types: List[Dict[str, Any]]
-    ) -> List[Dict[str, Any]]:
-        """Sanitize the 'required' field in node type properties. Ensures 'required' is a valid boolean.
-        converts known string values (true, yes, 1, false, no, 0) to booleans and removes unrecognized values.
-        """
-        for node_type in node_types:
-            properties = node_type.get("properties", [])
-            if not properties:
-                continue
-            for prop in properties:
-                if not isinstance(prop, dict):
-                    continue
-
-                required_value = prop.get("required")
-
-                #  Not provided - will use Pydantic default (false)
-                if required_value is None:
-                    continue
-
-                # already a valid boolean
-                if isinstance(required_value, bool):
-                    continue
-
-                prop_name = prop.get("name", "unknown")
-                node_label = node_type.get("label", "unknown")
-
-                # Convert to string to handle int values like 1 or 0
-                required_str = str(required_value).lower()
-
-                if required_str in ("true", "yes", "1"):
-                    prop["required"] = True
-                    logging.info(
-                        f"Converted 'required' value '{required_value}' to True "
-                        f"for property '{prop_name}' on node '{node_label}'"
-                    )
-                elif required_str in ("false", "no", "0"):
-                    prop["required"] = False
-                    logging.info(
-                        f"Converted 'required' value '{required_value}' to False "
-                        f"for property '{prop_name}' on node '{node_label}'"
-                    )
-                else:
-                    logging.info(
-                        f"Removing unrecognized 'required' value '{required_value}' "
-                        f"for property '{prop_name}' on node '{node_label}'. "
-                        f"Using default (False)."
-                    )
-                    prop.pop("required", None)
-
-        return node_types
-
     def _clean_json_content(self, content: str) -> str:
         content = content.strip()
 
@@ -1310,8 +1258,11 @@ class SchemaFromTextExtractor(BaseSchemaBuilder):
 
         V1 (prompt-based) extraction requires additional filtering:
         - Remove nodes/relationships without labels
-        - Clean up invalid 'required' field values
         - Remove nodes with no properties (after property filtering)
+
+        Legacy ``required`` on properties is normalized by :class:`GraphSchema` validation
+        (migration to ``EXISTENCE`` constraints). Invalid ``required`` values fail validation
+        or are handled by Pydantic coercion where applicable.
 
         Args:
             extracted_schema: Raw schema dictionary from LLM
@@ -1327,9 +1278,6 @@ class SchemaFromTextExtractor(BaseSchemaBuilder):
         if rel_types:
             rel_types = self._filter_relationships_without_labels(rel_types)
 
-        # Filter invalid required fields
-        node_types = self._filter_properties_required_field(node_types)
-
         # Filter nodes with no properties (after property filtering)
         # This prevents validation errors from min_length=1 constraint on NodeType.properties
         nodes_before = len(node_types)
@@ -1339,8 +1287,7 @@ class SchemaFromTextExtractor(BaseSchemaBuilder):
         if len(node_types) < nodes_before:
             removed_count = nodes_before - len(node_types)
             logging.info(
-                f"Filtered out {removed_count} node type(s) with no properties after property validation. "
-                f"This can happen when all properties have invalid 'required' field values."
+                f"Filtered out {removed_count} node type(s) with no properties after property validation."
             )
 
         extracted_schema["node_types"] = node_types

--- a/src/neo4j_graphrag/experimental/utils/schema.py
+++ b/src/neo4j_graphrag/experimental/utils/schema.py
@@ -17,7 +17,7 @@ from typing import Any, Union
 try:
     from neo4j_viz import VisualizationGraph, Node, Relationship
 except ImportError:
-    VisualizationGraph = Node = Relationship = None
+    VisualizationGraph = Node = Relationship = None  # type: ignore[misc,assignment]
 
 from neo4j_graphrag.experimental.components.schema import (
     GraphSchema,
@@ -99,7 +99,7 @@ def schema_visualization(
         }
 
     nodes = [
-        Node(
+        Node(  # type: ignore[call-arg]
             id=node_type.label,
             caption=node_type.label,
             properties=_node_properties(node_type),
@@ -107,7 +107,7 @@ def schema_visualization(
         for node_type in schema_object.node_types
     ]
     relationships = [
-        Relationship(
+        Relationship(  # type: ignore[call-arg]
             source=pattern[0],
             target=pattern[2],
             caption=pattern[1],

--- a/src/neo4j_graphrag/experimental/utils/schema.py
+++ b/src/neo4j_graphrag/experimental/utils/schema.py
@@ -17,7 +17,7 @@ from typing import Any, Union
 try:
     from neo4j_viz import VisualizationGraph, Node, Relationship
 except ImportError:
-    VisualizationGraph = Node = Relationship = None  # type: ignore
+    VisualizationGraph = Node = Relationship = None
 
 from neo4j_graphrag.experimental.components.schema import (
     GraphSchema,
@@ -52,17 +52,18 @@ def schema_visualization(
 
     schema_object = GraphSchema.model_validate(schema)
 
-    def _format_property_name(p: PropertyType) -> str:
+    def _format_property_name(p: PropertyType, existence_names: set[str]) -> str:
         """
 
         Args:
             p (PropertyType): the property to be formatted
+            existence_names: property names that have an EXISTENCE constraint
 
         Returns:
-            str: the property name, suffixed with '*' if the property is required
+            str: the property name, suffixed with '*' if existence is required
 
         """
-        return p.name + ("*" if p.required else "")
+        return p.name + ("*" if p.name in existence_names else "")
 
     def _relationship_properties(rel_type: str) -> dict[str, str]:
         """Returns a dict {prop_name: prop_type} for all relationship properties.
@@ -73,11 +74,13 @@ def schema_visualization(
         Returns:
             dict[str, str]: the relationship properties {name: type} mapping for display
         """
+        existence = schema_object.existence_property_names_for_relationship(rel_type)
         for relationship_type in schema_object.relationship_types:
             if relationship_type.label != rel_type:
                 continue
             return {
-                _format_property_name(p): p.type for p in relationship_type.properties
+                _format_property_name(p, existence): p.type
+                for p in relationship_type.properties
             }
         return {}
 
@@ -90,10 +93,13 @@ def schema_visualization(
         Returns:
             dict[str, str]: the node properties {name: type} mapping for display
         """
-        return {_format_property_name(p): p.type for p in node_type.properties}
+        existence = schema_object.existence_property_names_for_node(node_type.label)
+        return {
+            _format_property_name(p, existence): p.type for p in node_type.properties
+        }
 
     nodes = [
-        Node(  # type: ignore
+        Node(
             id=node_type.label,
             caption=node_type.label,
             properties=_node_properties(node_type),
@@ -101,7 +107,7 @@ def schema_visualization(
         for node_type in schema_object.node_types
     ]
     relationships = [
-        Relationship(  # type: ignore
+        Relationship(
             source=pattern[0],
             target=pattern[2],
             caption=pattern[1],

--- a/src/neo4j_graphrag/generation/prompts.py
+++ b/src/neo4j_graphrag/generation/prompts.py
@@ -226,7 +226,7 @@ IMPORTANT RULES:
 8.5 Uniqueness does NOT imply that the property must exist on every node (existence is separate; see rule 9).
 9. EXISTENCE CONSTRAINTS (optional):
 9.1 Use EXISTENCE constraints to mark properties that MUST be present (non-null) on every instance.
-9.2 For a node property, add {{"type": "EXISTENCE", "node_type": "<Label>", "property_name": "<name>", "relationship_type": null}}.
+9.2 For a node property, add {{"type": "EXISTENCE", "node_type": "<Label>", "property_name": "<name>", "relationship_type": ""}} (use an empty string, not null, when the constraint is not on a relationship).
 9.3 For a relationship property, add {{"type": "EXISTENCE", "node_type": "", "property_name": "<name>", "relationship_type": "<REL_TYPE>"}}.
 9.4 Each EXISTENCE constraint must reference exactly one of node_type or relationship_type (non-empty), never both.
 9.5 Do not infer EXISTENCE from UNIQUENESS; they are independent (as in Neo4j Cypher constraints).
@@ -268,13 +268,13 @@ Return a valid JSON object that follows this precise structure:
       "type": "UNIQUENESS",
       "node_type": "Person",
       "property_name": "name",
-      "relationship_type": null
+      "relationship_type": ""
     }},
     {{
       "type": "EXISTENCE",
       "node_type": "Person",
       "property_name": "name",
-      "relationship_type": null
+      "relationship_type": ""
     }}
     ...
   ]

--- a/src/neo4j_graphrag/generation/prompts.py
+++ b/src/neo4j_graphrag/generation/prompts.py
@@ -218,18 +218,18 @@ IMPORTANT RULES:
 5. When defining patterns, ensure that every node label and relationship label mentioned exists in your lists of node types and relationship types.
 6. Do not create node types that aren't clearly mentioned in the text.
 7. Keep your schema minimal and focused on clearly identifiable patterns in the text.
-8. UNIQUENESS CONSTRAINTS:
-8.1 UNIQUENESS is optional; each node_type may or may not have exactly one uniqueness constraint.
+8. UNIQUENESS CONSTRAINTS (optional, node properties only):
+8.1 Each node type may have at most one UNIQUENESS constraint in typical designs.
 8.2 Only use properties that seem to not have too many missing values in the sample.
 8.3 Constraints reference node_types by label and specify which property is unique.
 8.4 If a property appears in a uniqueness constraint it MUST also appear in the corresponding node_type as a property.
-9. REQUIRED PROPERTIES:
-9.1 Mark a property as "required": true if every instance of that node/relationship type MUST have this property (non-nullable).
-9.2 Mark a property as "required": false if the property is optional and may be absent on some instances.
-9.3 Properties that are identifiers, names, or essential characteristics are typically required.
-9.4 Properties that are supplementary information (phone numbers, descriptions, metadata) are typically optional.
-9.5 When uncertain, default to "required": false.
-9.6 If a property has a UNIQUENESS constraint, it MUST be marked as "required": true.
+8.5 Uniqueness does NOT imply that the property must exist on every node (existence is separate; see rule 9).
+9. EXISTENCE CONSTRAINTS (optional):
+9.1 Use EXISTENCE constraints to mark properties that MUST be present (non-null) on every instance.
+9.2 For a node property, add {{"type": "EXISTENCE", "node_type": "<Label>", "property_name": "<name>", "relationship_type": null}}.
+9.3 For a relationship property, add {{"type": "EXISTENCE", "node_type": "", "property_name": "<name>", "relationship_type": "<REL_TYPE>"}}.
+9.4 Each EXISTENCE constraint must reference exactly one of node_type or relationship_type (non-empty), never both.
+9.5 Do not infer EXISTENCE from UNIQUENESS; they are independent (as in Neo4j Cypher constraints).
 10. Never use double underscores (__) as a prefix or suffix in node labels or relationship types (e.g. __Person__ or __KNOWS__ are forbidden).
 
 Accepted property types are: BOOLEAN, DATE, DURATION, FLOAT, INTEGER, LIST,
@@ -243,13 +243,11 @@ Return a valid JSON object that follows this precise structure:
       "properties": [
         {{
           "name": "name",
-          "type": "STRING",
-          "required": true
+          "type": "STRING"
         }},
         {{
           "name": "email",
-          "type": "STRING",
-          "required": false
+          "type": "STRING"
         }}
       ]
     }}
@@ -269,7 +267,14 @@ Return a valid JSON object that follows this precise structure:
     {{
       "type": "UNIQUENESS",
       "node_type": "Person",
-      "property_name": "name"
+      "property_name": "name",
+      "relationship_type": null
+    }},
+    {{
+      "type": "EXISTENCE",
+      "node_type": "Person",
+      "property_name": "name",
+      "relationship_type": null
     }}
     ...
   ]

--- a/tests/e2e/experimental/test_graph_pruning_component_e2e.py
+++ b/tests/e2e/experimental/test_graph_pruning_component_e2e.py
@@ -16,7 +16,10 @@ from typing import Any
 
 import pytest
 
-from neo4j_graphrag.experimental.components.graph_pruning import GraphPruning
+from neo4j_graphrag.experimental.components.graph_pruning import (
+    GraphPruning,
+    PruningReason,
+)
 from neo4j_graphrag.experimental.components.schema import GraphSchema
 from neo4j_graphrag.experimental.components.types import (
     Neo4jGraph,
@@ -238,6 +241,143 @@ async def test_graph_pruning_missing_required_property(
         ],
     )
     await _test(extracted_graph, schema_dict, filtered_graph)
+
+
+@pytest.mark.asyncio
+async def test_graph_pruning_existence_constraint_node_property_explicit(
+    extracted_graph: Neo4jGraph,
+) -> None:
+    """Same outcome as ``test_graph_pruning_missing_required_property`` using EXISTENCE only (no ``required``)."""
+    schema_dict = {
+        "node_types": [
+            {
+                "label": "Person",
+                "properties": [
+                    {"name": "name", "type": "STRING"},
+                    {"name": "height", "type": "INTEGER"},
+                ],
+                "additional_properties": True,
+            }
+        ],
+        "relationship_types": [
+            {
+                "label": "KNOWS",
+            }
+        ],
+        "patterns": [
+            ("Person", "KNOWS", "Person"),
+        ],
+        "constraints": [
+            {
+                "type": "EXISTENCE",
+                "node_type": "Person",
+                "property_name": "name",
+                "relationship_type": None,
+            }
+        ],
+        "additional_node_types": True,
+        "additional_relationship_types": True,
+        "additional_patterns": True,
+    }
+    schema = GraphSchema.model_validate(schema_dict)
+    assert schema.existence_property_names_for_node("Person") == {"name"}
+
+    filtered_graph = Neo4jGraph(
+        nodes=[
+            Neo4jNode(
+                id="1",
+                label="Person",
+                properties={
+                    "name": "John Doe",
+                },
+            ),
+            Neo4jNode(
+                id="3",
+                label="Person",
+                properties={
+                    "name": "Jane Doe",
+                    "weight": 90,
+                },
+            ),
+            Neo4jNode(
+                id="10",
+                label="Organization",
+                properties={
+                    "name": "Azerty Inc.",
+                    "created": 1999,
+                },
+            ),
+        ],
+        relationships=[
+            Neo4jRelationship(
+                start_node_id="1",
+                end_node_id="3",
+                type="KNOWS",
+            ),
+            Neo4jRelationship(
+                start_node_id="1",
+                end_node_id="10",
+                type="MANAGES",
+            ),
+            Neo4jRelationship(
+                start_node_id="1",
+                end_node_id="10",
+                type="WORKS_FOR",
+            ),
+        ],
+    )
+    await _test(extracted_graph, schema_dict, filtered_graph)
+
+
+@pytest.mark.asyncio
+async def test_graph_pruning_existence_constraint_relationship_property(
+    extracted_graph: Neo4jGraph,
+) -> None:
+    """Relationship-scoped EXISTENCE: KNOWS without ``firstMetIn`` is flagged when that property is mandatory."""
+    schema_dict = {
+        "node_types": [
+            {
+                "label": "Person",
+                "properties": [
+                    {"name": "name", "type": "STRING"},
+                    {"name": "height", "type": "INTEGER"},
+                ],
+                "additional_properties": True,
+            }
+        ],
+        "relationship_types": [
+            {
+                "label": "KNOWS",
+                "properties": [
+                    {"name": "firstMetIn", "type": "INTEGER"},
+                ],
+                "additional_properties": True,
+            }
+        ],
+        "patterns": [
+            ("Person", "KNOWS", "Person"),
+        ],
+        "constraints": [
+            {
+                "type": "EXISTENCE",
+                "node_type": "",
+                "property_name": "firstMetIn",
+                "relationship_type": "KNOWS",
+            }
+        ],
+        "additional_node_types": True,
+        "additional_relationship_types": True,
+        "additional_patterns": True,
+    }
+    schema = GraphSchema.model_validate(schema_dict)
+    assert schema.existence_property_names_for_relationship("KNOWS") == {"firstMetIn"}
+
+    pruner = GraphPruning()
+    res = await pruner.run(extracted_graph, schema)
+    assert any(
+        x.pruned_reason == PruningReason.MISSING_REQUIRED_PROPERTY
+        for x in res.pruning_stats.pruned_relationships
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/experimental/components/test_graph_pruning.py
+++ b/tests/unit/experimental/components/test_graph_pruning.py
@@ -25,6 +25,7 @@ from neo4j_graphrag.experimental.components.graph_pruning import (
     PruningStats,
 )
 from neo4j_graphrag.experimental.components.schema import (
+    GraphConstraintType,
     GraphSchema,
     NodeType,
     Pattern,
@@ -157,6 +158,35 @@ def node_type_required_name() -> NodeType:
     )
 
 
+def _graph_schema_for_node_entity(entity: NodeType | None) -> GraphSchema:
+    """Build a GraphSchema from a node type fixture (applies required→EXISTENCE migration)."""
+    if entity is None:
+        return GraphSchema(node_types=tuple())
+    return GraphSchema.model_validate({"node_types": [entity.model_dump()]})
+
+
+def _schema_for_relationship_validation(
+    patterns: tuple[Pattern, ...],
+) -> GraphSchema:
+    """Minimal valid GraphSchema for _validate_relationship tests (REL + Person/Location)."""
+    return GraphSchema.model_validate(
+        {
+            "node_types": [
+                {
+                    "label": "Person",
+                    "properties": [{"name": "name", "type": "STRING"}],
+                },
+                {
+                    "label": "Location",
+                    "properties": [{"name": "name", "type": "STRING"}],
+                },
+            ],
+            "relationship_types": [{"label": "REL"}],
+            "patterns": [tuple(p) for p in patterns],
+        }
+    )
+
+
 @pytest.mark.parametrize(
     "node, entity, additional_node_types, expected_node",
     [
@@ -211,10 +241,14 @@ def test_graph_pruning_validate_node(
     expected_node: Neo4jNode,
     request: pytest.FixtureRequest,
 ) -> None:
-    e = request.getfixturevalue(entity) if entity else None
+    e_fixture = request.getfixturevalue(entity) if entity else None
+    schema = _graph_schema_for_node_entity(e_fixture)
+    e = schema.node_type_from_label(node.label) if node.label else None
 
     pruner = GraphPruning()
-    result = pruner._validate_node(node, PruningStats(), e, additional_node_types)
+    result = pruner._validate_node(
+        node, PruningStats(), e, schema, additional_node_types
+    )
     if expected_node is not None:
         assert result == expected_node
     else:
@@ -251,15 +285,28 @@ def test_graph_pruning_enforce_relationships_lexical_graph_with_pruned_nodes(
         ),  # Missing required 'name'
     ]
 
-    # Person node type requires 'name' property
-    person_type = NodeType(
-        label="Person",
-        properties=[
-            PropertyType(name="name", type="STRING", required=True),
-            PropertyType(name="age", type="INTEGER"),
-        ],
+    # Person node type: name must exist (EXISTENCE constraint)
+    schema = GraphSchema.model_validate(
+        {
+            "node_types": [
+                {
+                    "label": "Person",
+                    "properties": [
+                        {"name": "name", "type": "STRING"},
+                        {"name": "age", "type": "INTEGER"},
+                    ],
+                }
+            ],
+            "constraints": [
+                {
+                    "type": GraphConstraintType.EXISTENCE.value,
+                    "node_type": "Person",
+                    "property_name": "name",
+                    "relationship_type": None,
+                }
+            ],
+        }
     )
-    schema = GraphSchema(node_types=(person_type,))
 
     # Filter nodes - Person should be pruned due to missing required property
     pruning_stats = PruningStats()
@@ -491,6 +538,7 @@ def test_graph_pruning_validate_relationship(
     )
 
     pruner = GraphPruning()
+    schema = _schema_for_relationship_validation(patterns)
     assert (
         pruner._validate_relationship(
             relationship_obj,
@@ -500,6 +548,7 @@ def test_graph_pruning_validate_relationship(
             additional_relationship_types,
             patterns,
             additional_patterns,
+            schema,
         )
         == expected_relationship_obj
     )
@@ -515,7 +564,7 @@ async def test_graph_pruning_run_happy_path(
     initial_graph = Neo4jGraph(
         nodes=[Neo4jNode(id="1", label="Person"), Neo4jNode(id="2", label="Location")],
     )
-    schema = GraphSchema(node_types=(node_type_required_name,))
+    schema = _graph_schema_for_node_entity(node_type_required_name)
     cleaned_graph = Neo4jGraph(nodes=[Neo4jNode(id="1", label="Person")])
     mock_clean_graph.return_value = (cleaned_graph, PruningStats())
     pruner = GraphPruning()

--- a/tests/unit/experimental/components/test_graph_schema_extraction.py
+++ b/tests/unit/experimental/components/test_graph_schema_extraction.py
@@ -1,0 +1,192 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Behavioral tests for schema-from-text extraction wire types and conversion."""
+
+from __future__ import annotations
+
+import pytest
+
+from neo4j_graphrag.exceptions import SchemaExtractionError
+from neo4j_graphrag.experimental.components.graph_schema_extraction import (
+    ExtractedConstraintType,
+    ExtractedNodeType,
+    ExtractedPropertyType,
+    ExtractedRelationshipType,
+    GraphSchemaExtractionOutput,
+    wire_extraction_constraints_for_graph_schema,
+)
+from neo4j_graphrag.experimental.components.schema import GraphSchema, Pattern
+
+
+def test_wire_extraction_constraints_empty_and_null_become_none() -> None:
+    """Maps ``\"\"`` and legacy ``null`` to ``None`` for :class:`ConstraintType`."""
+    out = wire_extraction_constraints_for_graph_schema(
+        [
+            {
+                "type": "UNIQUENESS",
+                "node_type": "Person",
+                "property_name": "id",
+                "relationship_type": "",
+            },
+            {
+                "type": "UNIQUENESS",
+                "node_type": "Org",
+                "property_name": "id",
+                "relationship_type": None,
+            },
+        ]
+    )
+    assert out[0]["relationship_type"] is None
+    assert out[1]["relationship_type"] is None
+
+
+def test_wire_extraction_constraints_preserves_relationship_scoped_existence() -> None:
+    out = wire_extraction_constraints_for_graph_schema(
+        [
+            {
+                "type": "EXISTENCE",
+                "node_type": "",
+                "property_name": "since",
+                "relationship_type": "KNOWS",
+            }
+        ]
+    )
+    assert out[0]["relationship_type"] == "KNOWS"
+
+
+def test_uniqueness_with_relationship_type_fails_at_graph_schema_validation() -> None:
+    """If a bad constraint survives extraction filters, :class:`ConstraintType` rejects it."""
+    dto = GraphSchemaExtractionOutput(
+        node_types=[
+            ExtractedNodeType(
+                label="Person",
+                properties=[ExtractedPropertyType(name="name", type="STRING")],
+            )
+        ],
+        relationship_types=[],
+        patterns=[],
+        constraints=[
+            ExtractedConstraintType(
+                type="UNIQUENESS",
+                node_type="Person",
+                property_name="name",
+                relationship_type="KNOWS",
+            ),
+        ],
+    )
+    with pytest.raises(SchemaExtractionError):
+        GraphSchema.from_extraction_output(dto)
+
+
+def test_invalid_constraints_dropped_by_extraction_filters_without_error() -> None:
+    """Cross-reference filters drop semantically invalid constraints (see ``_extraction_filter_invalid_constraints``)."""
+    dto = GraphSchemaExtractionOutput(
+        node_types=[
+            ExtractedNodeType(
+                label="Person",
+                properties=[ExtractedPropertyType(name="name", type="STRING")],
+            )
+        ],
+        relationship_types=[],
+        patterns=[],
+        constraints=[
+            ExtractedConstraintType(
+                type="UNIQUENESS",
+                node_type="",
+                property_name="name",
+                relationship_type="",
+            ),
+            ExtractedConstraintType(
+                type="EXISTENCE",
+                node_type="Person",
+                property_name="name",
+                relationship_type="KNOWS",
+            ),
+            ExtractedConstraintType(
+                type="EXISTENCE",
+                node_type="",
+                property_name="name",
+                relationship_type="",
+            ),
+        ],
+    )
+    gs = GraphSchema.from_extraction_output(dto)
+    assert len(gs.constraints) == 0
+
+
+def test_from_extraction_output_relationship_existence_constraint() -> None:
+    """Relationship-scoped EXISTENCE uses empty ``node_type`` and non-empty ``relationship_type``."""
+    dto = GraphSchemaExtractionOutput(
+        node_types=[
+            ExtractedNodeType(
+                label="Person",
+                properties=[ExtractedPropertyType(name="name", type="STRING")],
+            )
+        ],
+        relationship_types=[
+            ExtractedRelationshipType(
+                label="KNOWS",
+                properties=[ExtractedPropertyType(name="since", type="LOCAL_DATETIME")],
+            )
+        ],
+        patterns=[
+            Pattern(
+                source="Person",
+                relationship="KNOWS",
+                target="Person",
+            ),
+        ],
+        constraints=[
+            ExtractedConstraintType(
+                type="EXISTENCE",
+                node_type="",
+                property_name="since",
+                relationship_type="KNOWS",
+            ),
+        ],
+    )
+    gs = GraphSchema.from_extraction_output(dto)
+    assert gs.existence_property_names_for_relationship("KNOWS") == {"since"}
+    assert gs.existence_property_names_for_node("Person") == set()
+
+
+def test_from_extraction_output_two_constraints_same_property_distinct_kinds() -> None:
+    """Sanity: UNIQUENESS + EXISTENCE on the same property name yields two runtime constraints."""
+    dto = GraphSchemaExtractionOutput(
+        node_types=[
+            ExtractedNodeType(
+                label="Person",
+                properties=[ExtractedPropertyType(name="name", type="STRING")],
+            )
+        ],
+        relationship_types=[],
+        patterns=[],
+        constraints=[
+            ExtractedConstraintType(
+                type="UNIQUENESS",
+                node_type="Person",
+                property_name="name",
+            ),
+            ExtractedConstraintType(
+                type="EXISTENCE",
+                node_type="Person",
+                property_name="name",
+                relationship_type="",
+            ),
+        ],
+    )
+    gs = GraphSchema.from_extraction_output(dto)
+    assert len(gs.constraints) == 2

--- a/tests/unit/experimental/components/test_graph_schema_extraction_contract.py
+++ b/tests/unit/experimental/components/test_graph_schema_extraction_contract.py
@@ -35,8 +35,10 @@ from neo4j_graphrag.experimental.components.schema import (
 
 
 def test_extracted_property_type_field_names_match_property_type() -> None:
-    """Extraction wire format must stay in sync with :class:`PropertyType` for mapped fields."""
-    assert set(ExtractedPropertyType.model_fields) == set(PropertyType.model_fields)
+    """Extraction wire format matches :class:`PropertyType` except deprecated ``required`` (use EXISTENCE)."""
+    assert set(ExtractedPropertyType.model_fields) == set(PropertyType.model_fields) - {
+        "required"
+    }
 
 
 def test_extracted_property_type_uses_same_type_annotation_as_property_type() -> None:

--- a/tests/unit/experimental/components/test_graph_schema_extraction_contract.py
+++ b/tests/unit/experimental/components/test_graph_schema_extraction_contract.py
@@ -21,12 +21,14 @@ If these fail after a refactor, update the extraction models **and** conversion 
 from __future__ import annotations
 
 from neo4j_graphrag.experimental.components.graph_schema_extraction import (
+    ExtractedConstraintType,
     ExtractedNodeType,
     ExtractedPropertyType,
     ExtractedRelationshipType,
     GraphSchemaExtractionOutput,
 )
 from neo4j_graphrag.experimental.components.schema import (
+    ConstraintType,
     GraphSchema,
     NodeType,
     PropertyType,
@@ -73,6 +75,17 @@ def test_graph_schema_extraction_output_root_keys_match_validate_payload() -> No
         "patterns",
         "constraints",
     }
+
+
+def test_extracted_constraint_type_aligns_with_runtime_constraint_type() -> None:
+    """Wire model avoids nullable ``relationship_type``; maps to :class:`ConstraintType` after conversion."""
+    wire_keys = set(ExtractedConstraintType.model_fields)
+    runtime_keys = set(ConstraintType.model_fields)
+    assert wire_keys == runtime_keys
+    assert (
+        ExtractedConstraintType.model_fields["type"].annotation
+        != ConstraintType.model_fields["type"].annotation
+    )
 
 
 def test_graph_schema_model_fields_contain_extraction_superset() -> None:

--- a/tests/unit/experimental/components/test_property_type_deprecation.py
+++ b/tests/unit/experimental/components/test_property_type_deprecation.py
@@ -19,7 +19,14 @@ from __future__ import annotations
 
 import pytest
 
-from neo4j_graphrag.experimental.components.schema import GraphSchema, PropertyType
+from neo4j_graphrag.experimental.components.schema import (
+    ConstraintType,
+    GraphConstraintType,
+    GraphSchema,
+    NodeType,
+    PropertyType,
+    RelationshipType,
+)
 
 
 def test_property_type_required_field_emits_deprecation_on_access() -> None:
@@ -48,3 +55,58 @@ def test_legacy_required_true_in_json_becomes_existence_constraint() -> None:
         c.type == "EXISTENCE" and c.node_type == "Person" and c.property_name == "name"
         for c in schema.constraints
     )
+
+
+def test_programmatic_node_type_required_migrates_to_existence() -> None:
+    """``GraphSchema(node_types=(NodeType(..., required=True),))`` migrates like dict input."""
+    nt = NodeType(
+        label="Person",
+        properties=[PropertyType(name="name", type="STRING", required=True)],
+    )
+    schema = GraphSchema(node_types=(nt,))
+    assert schema.existence_property_names_for_node("Person") == {"name"}
+    assert len(schema.constraints) == 1
+    assert schema.constraints[0].type == GraphConstraintType.EXISTENCE
+    assert schema.constraints[0].node_type == "Person"
+    assert schema.constraints[0].property_name == "name"
+
+
+def test_programmatic_relationship_type_required_migrates_to_existence() -> None:
+    """``RelationshipType`` with ``PropertyType(required=True)`` migrates to relationship-scoped EXISTENCE."""
+    person = NodeType(
+        label="Person",
+        properties=[PropertyType(name="id", type="STRING")],
+    )
+    knows = RelationshipType(
+        label="KNOWS",
+        properties=[
+            PropertyType(name="since", type="LOCAL_DATETIME", required=True),
+        ],
+    )
+    schema = GraphSchema(node_types=(person,), relationship_types=(knows,))
+    assert schema.existence_property_names_for_relationship("KNOWS") == {"since"}
+    assert any(
+        c.type == GraphConstraintType.EXISTENCE
+        and c.relationship_type == "KNOWS"
+        and c.property_name == "since"
+        for c in schema.constraints
+    )
+
+
+def test_programmatic_required_deduped_when_existence_constraint_already_present() -> (
+    None
+):
+    """Pre-existing EXISTENCE constraint does not duplicate when ``required=True`` on instances."""
+    nt = NodeType(
+        label="Person",
+        properties=[PropertyType(name="name", type="STRING", required=True)],
+    )
+    existing = ConstraintType(
+        type=GraphConstraintType.EXISTENCE,
+        node_type="Person",
+        property_name="name",
+        relationship_type=None,
+    )
+    schema = GraphSchema(node_types=(nt,), constraints=(existing,))
+    assert len(schema.constraints) == 1
+    assert schema.existence_property_names_for_node("Person") == {"name"}

--- a/tests/unit/experimental/components/test_property_type_deprecation.py
+++ b/tests/unit/experimental/components/test_property_type_deprecation.py
@@ -1,0 +1,50 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Explicit coverage for :class:`PropertyType` ``required`` deprecation (see EXISTENCE constraints)."""
+
+from __future__ import annotations
+
+import pytest
+
+from neo4j_graphrag.experimental.components.schema import GraphSchema, PropertyType
+
+
+def test_property_type_required_field_emits_deprecation_on_access() -> None:
+    """Reading ``.required`` on a model instance should warn (Pydantic deprecated field)."""
+    prop = PropertyType(name="x", type="STRING", required=True)
+    with pytest.warns(DeprecationWarning, match="EXISTENCE"):
+        assert prop.required is True
+
+
+def test_legacy_required_true_in_json_becomes_existence_constraint() -> None:
+    """Loading JSON with ``required: true`` migrates to EXISTENCE (avoid asserting ``.required``; any read warns)."""
+    schema = GraphSchema.model_validate(
+        {
+            "node_types": [
+                {
+                    "label": "Person",
+                    "properties": [
+                        {"name": "name", "type": "STRING", "required": True},
+                    ],
+                }
+            ],
+        }
+    )
+    assert schema.existence_property_names_for_node("Person") == {"name"}
+    assert any(
+        c.type == "EXISTENCE" and c.node_type == "Person" and c.property_name == "name"
+        for c in schema.constraints
+    )

--- a/tests/unit/experimental/components/test_schema.py
+++ b/tests/unit/experimental/components/test_schema.py
@@ -28,6 +28,7 @@ from neo4j_graphrag.experimental.components.schema import (
     PropertyType,
     RelationshipType,
     ConstraintType,
+    GraphConstraintType,
     SchemaFromTextExtractor,
     GraphSchema,
     SchemaFromExistingGraphExtractor,
@@ -174,7 +175,7 @@ def test_relationship_type_additional_properties_default() -> None:
 
 def test_constraint_type_initialization() -> None:
     constraint = ConstraintType(
-        type="UNIQUENESS", node_type="Person", property_name="name"
+        type=GraphConstraintType.UNIQUENESS, node_type="Person", property_name="name"
     )
     assert constraint.type == "UNIQUENESS"
     assert constraint.node_type == "Person"
@@ -183,11 +184,11 @@ def test_constraint_type_initialization() -> None:
 
 def test_constraint_type_is_frozen() -> None:
     constraint = ConstraintType(
-        type="UNIQUENESS", node_type="Person", property_name="name"
+        type=GraphConstraintType.UNIQUENESS, node_type="Person", property_name="name"
     )
 
     with pytest.raises(ValidationError):
-        constraint.type = "UNIQUENESS"
+        constraint.type = GraphConstraintType.UNIQUENESS
 
     with pytest.raises(ValidationError):
         constraint.node_type = "Organization"
@@ -446,7 +447,11 @@ def patterns_with_invalid_entity() -> tuple[Pattern, ...]:
 @pytest.fixture
 def valid_constraints() -> tuple[ConstraintType, ...]:
     return (
-        ConstraintType(type="UNIQUENESS", node_type="PERSON", property_name="name"),
+        ConstraintType(
+            type=GraphConstraintType.UNIQUENESS,
+            node_type="PERSON",
+            property_name="name",
+        ),
     )
 
 
@@ -1896,12 +1901,12 @@ def test_graph_schema_from_extraction_output() -> None:
         patterns=[],
         constraints=[
             ConstraintType(
-                type="UNIQUENESS",
+                type=GraphConstraintType.UNIQUENESS,
                 node_type="Person",
                 property_name="name",
             ),
             ConstraintType(
-                type="EXISTENCE",
+                type=GraphConstraintType.EXISTENCE,
                 node_type="Person",
                 property_name="name",
                 relationship_type=None,

--- a/tests/unit/experimental/components/test_schema.py
+++ b/tests/unit/experimental/components/test_schema.py
@@ -41,7 +41,8 @@ from neo4j_graphrag.generation import PromptTemplate
 from neo4j_graphrag.llm.types import LLMResponse
 from neo4j_graphrag.utils.file_handler import FileFormat
 
-# PropertyType.required is deprecated; tests still assert migration behavior via .required.
+# Most tests below read ``PropertyType.required`` to assert migration; silence only that
+# deprecation. Explicit warning behavior is covered in ``test_property_type_deprecation.py``.
 pytestmark = pytest.mark.filterwarnings(
     "ignore:Use GraphSchema.constraints with type EXISTENCE:DeprecationWarning"
 )

--- a/tests/unit/experimental/components/test_schema.py
+++ b/tests/unit/experimental/components/test_schema.py
@@ -1881,8 +1881,25 @@ def test_graph_schema_extraction_output_json_schema_lean_root() -> None:
     assert "additional_patterns" not in dumped
 
 
+def test_graph_schema_extraction_constraint_schema_avoids_null_type_for_vertex() -> (
+    None
+):
+    """Vertex AI maps JSON Schema to protobuf and rejects ``type: \"null\"`` (e.g. ``Optional``)."""
+    from neo4j_graphrag.experimental.components.graph_schema_extraction import (
+        GraphSchemaExtractionOutput,
+    )
+
+    raw = GraphSchemaExtractionOutput.model_json_schema()
+    ect = (raw.get("$defs") or {}).get("ExtractedConstraintType")
+    assert ect is not None
+    rel_schema = (ect.get("properties") or {}).get("relationship_type", {})
+    assert "anyOf" not in rel_schema
+    assert '"type": "null"' not in json.dumps(rel_schema)
+
+
 def test_graph_schema_from_extraction_output() -> None:
     from neo4j_graphrag.experimental.components.graph_schema_extraction import (
+        ExtractedConstraintType,
         ExtractedNodeType,
         ExtractedPropertyType,
         GraphSchemaExtractionOutput,
@@ -1900,16 +1917,16 @@ def test_graph_schema_from_extraction_output() -> None:
         relationship_types=[],
         patterns=[],
         constraints=[
-            ConstraintType(
-                type=GraphConstraintType.UNIQUENESS,
+            ExtractedConstraintType(
+                type="UNIQUENESS",
                 node_type="Person",
                 property_name="name",
             ),
-            ConstraintType(
-                type=GraphConstraintType.EXISTENCE,
+            ExtractedConstraintType(
+                type="EXISTENCE",
                 node_type="Person",
                 property_name="name",
-                relationship_type=None,
+                relationship_type="",
             ),
         ],
     )

--- a/tests/unit/experimental/components/test_schema.py
+++ b/tests/unit/experimental/components/test_schema.py
@@ -41,6 +41,11 @@ from neo4j_graphrag.generation import PromptTemplate
 from neo4j_graphrag.llm.types import LLMResponse
 from neo4j_graphrag.utils.file_handler import FileFormat
 
+# PropertyType.required is deprecated; tests still assert migration behavior via .required.
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:Use GraphSchema.constraints with type EXISTENCE:DeprecationWarning"
+)
+
 
 def test_node_type_initialization_from_string() -> None:
     node_type = NodeType.model_validate("Label")
@@ -1622,127 +1627,6 @@ def test_filter_properties_required_field_missing(
     assert "required" not in result[0]["properties"][0]
 
 
-def test_enforce_required_for_constraint_properties_sets_required_true(
-    schema_from_text: SchemaFromTextExtractor,
-) -> None:
-    node_types: list[dict[str, Any]] = [
-        {
-            "label": "Person",
-            "properties": [
-                {"name": "name", "type": "STRING", "required": False},
-                {"name": "email", "type": "STRING", "required": False},
-            ],
-        }
-    ]
-    constraints = [
-        {"type": "UNIQUENESS", "node_type": "Person", "property_name": "name"}
-    ]
-
-    schema_from_text._enforce_required_for_constraint_properties(
-        node_types, constraints
-    )
-
-    # name should now be required=true
-    assert node_types[0]["properties"][0]["required"] is True
-    # email should remain required=false
-    assert node_types[0]["properties"][1]["required"] is False
-
-
-def test_enforce_required_for_constraint_properties_already_true(
-    schema_from_text: SchemaFromTextExtractor,
-) -> None:
-    node_types: list[dict[str, Any]] = [
-        {
-            "label": "Person",
-            "properties": [
-                {"name": "name", "type": "STRING", "required": True},
-            ],
-        }
-    ]
-    constraints = [
-        {"type": "UNIQUENESS", "node_type": "Person", "property_name": "name"}
-    ]
-
-    schema_from_text._enforce_required_for_constraint_properties(
-        node_types, constraints
-    )
-
-    assert node_types[0]["properties"][0]["required"] is True
-
-
-def test_enforce_required_for_constraint_properties_missing_required_field(
-    schema_from_text: SchemaFromTextExtractor,
-) -> None:
-    node_types: list[dict[str, Any]] = [
-        {
-            "label": "Person",
-            "properties": [
-                {"name": "name", "type": "STRING"},  # No required field
-            ],
-        }
-    ]
-    constraints = [
-        {"type": "UNIQUENESS", "node_type": "Person", "property_name": "name"}
-    ]
-
-    schema_from_text._enforce_required_for_constraint_properties(
-        node_types, constraints
-    )
-
-    assert node_types[0]["properties"][0]["required"] is True
-
-
-def test_enforce_required_for_constraint_properties_no_constraints(
-    schema_from_text: SchemaFromTextExtractor,
-) -> None:
-    node_types: list[dict[str, Any]] = [
-        {
-            "label": "Person",
-            "properties": [
-                {"name": "name", "type": "STRING", "required": False},
-            ],
-        }
-    ]
-    constraints: list[dict[str, Any]] = []
-
-    schema_from_text._enforce_required_for_constraint_properties(
-        node_types, constraints
-    )
-
-    assert node_types[0]["properties"][0]["required"] is False
-
-
-def test_enforce_required_for_constraint_properties_skips_unconstrained_nodes(
-    schema_from_text: SchemaFromTextExtractor,
-) -> None:
-    node_types: list[dict[str, Any]] = [
-        {
-            "label": "Person",
-            "properties": [
-                {"name": "name", "type": "STRING", "required": False},
-            ],
-        },
-        {
-            "label": "Company",
-            "properties": [
-                {"name": "name", "type": "STRING", "required": False},
-            ],
-        },
-    ]
-    constraints = [
-        {"type": "UNIQUENESS", "node_type": "Person", "property_name": "name"}
-    ]
-
-    schema_from_text._enforce_required_for_constraint_properties(
-        node_types, constraints
-    )
-
-    # Person.name should be required=true
-    assert node_types[0]["properties"][0]["required"] is True
-    # Company.name should remain required=false (no constraint on Company)
-    assert node_types[1]["properties"][0]["required"] is False
-
-
 @pytest.mark.asyncio
 async def test_schema_from_text_with_required_properties(
     schema_from_text: SchemaFromTextExtractor,
@@ -1758,12 +1642,13 @@ async def test_schema_from_text_with_required_properties(
     person = schema.node_type_from_label("Person")
     assert person is not None
 
-    # Check required properties
+    # Legacy required:true migrates to EXISTENCE; flags are cleared on PropertyType
+    assert schema.existence_property_names_for_node("Person") == {"name"}
     name_prop = next((p for p in person.properties if p.name == "name"), None)
     email_prop = next((p for p in person.properties if p.name == "email"), None)
     phone_prop = next((p for p in person.properties if p.name == "phone"), None)
 
-    assert name_prop is not None and name_prop.required is True
+    assert name_prop is not None and name_prop.required is False
     assert email_prop is not None and email_prop.required is False
     assert phone_prop is not None and phone_prop.required is False
 
@@ -1783,13 +1668,12 @@ async def test_schema_from_text_sanitizes_string_required_values(
     person = schema.node_type_from_label("Person")
     assert person is not None
 
-    # true and yes should become True
+    assert schema.existence_property_names_for_node("Person") == {"name", "email"}
     name_prop = next((p for p in person.properties if p.name == "name"), None)
     email_prop = next((p for p in person.properties if p.name == "email"), None)
-    assert name_prop is not None and name_prop.required is True
-    assert email_prop is not None and email_prop.required is True
+    assert name_prop is not None and name_prop.required is False
+    assert email_prop is not None and email_prop.required is False
 
-    # false and no should become False
     phone_prop = next((p for p in person.properties if p.name == "phone"), None)
     address_prop = next((p for p in person.properties if p.name == "address"), None)
     assert phone_prop is not None and phone_prop.required is False
@@ -1815,7 +1699,7 @@ async def test_schema_from_text_handles_missing_required_field(
 
 
 @pytest.mark.asyncio
-async def test_schema_from_text_enforces_required_for_constrained_properties(
+async def test_schema_from_text_uniqueness_does_not_force_required_property(
     schema_from_text: SchemaFromTextExtractor,
     mock_llm: AsyncMock,
 ) -> None:
@@ -1847,10 +1731,10 @@ async def test_schema_from_text_enforces_required_for_constrained_properties(
     name_prop = next((p for p in person.properties if p.name == "name"), None)
     email_prop = next((p for p in person.properties if p.name == "email"), None)
 
-    # name should be auto-fixed to required=true
-    assert name_prop is not None and name_prop.required is True
-    # email should remain required=false
+    assert name_prop is not None and name_prop.required is False
     assert email_prop is not None and email_prop.required is False
+    assert schema.existence_property_names_for_node("Person") == set()
+    assert schema.constraints[0].type == "UNIQUENESS"
 
 
 @pytest.mark.asyncio
@@ -1903,7 +1787,12 @@ async def test_schema_from_existing_graph(mock_get_structured_schema: Mock) -> N
     person_node_type = schema.node_type_from_label("Person")
     assert person_node_type is not None
     id_person_property = [p for p in person_node_type.properties if p.name == "id"][0]
-    assert id_person_property.required is True
+    assert id_person_property.required is False
+    assert schema.existence_property_names_for_node("Person") == {"id"}
+    assert any(
+        c.type == "EXISTENCE" and c.node_type == "Person" and c.property_name == "id"
+        for c in schema.constraints
+    )
     assert person_node_type.additional_properties is False
     city_node_type = schema.node_type_from_label("City")
     assert city_node_type is not None
@@ -1998,7 +1887,7 @@ def test_graph_schema_from_extraction_output() -> None:
             ExtractedNodeType(
                 label="Person",
                 properties=[
-                    ExtractedPropertyType(name="name", type="STRING", required=True)
+                    ExtractedPropertyType(name="name", type="STRING"),
                 ],
             )
         ],
@@ -2009,13 +1898,20 @@ def test_graph_schema_from_extraction_output() -> None:
                 type="UNIQUENESS",
                 node_type="Person",
                 property_name="name",
-            )
+            ),
+            ConstraintType(
+                type="EXISTENCE",
+                node_type="Person",
+                property_name="name",
+                relationship_type=None,
+            ),
         ],
     )
     gs = GraphSchema.from_extraction_output(dto)
     assert gs.node_types[0].label == "Person"
-    assert gs.node_types[0].properties[0].required is True
-    assert gs.constraints[0].property_name == "name"
+    assert gs.node_types[0].properties[0].required is False
+    assert gs.existence_property_names_for_node("Person") == {"name"}
+    assert {c.property_name for c in gs.constraints} == {"name"}
     assert gs.additional_node_types is False
 
 

--- a/tests/unit/experimental/components/test_schema.py
+++ b/tests/unit/experimental/components/test_schema.py
@@ -379,13 +379,15 @@ def test_schema_constraint_validation_missing_property_name() -> None:
 
 @pytest.fixture
 def valid_node_types() -> tuple[NodeType, ...]:
+    # required=False so tuples match GraphSchema after validation (legacy required=True
+    # is migrated to EXISTENCE and cleared).
     return (
         NodeType(
             label="PERSON",
             description="An individual human being.",
             properties=[
                 PropertyType(name="birth date", type="ZONED_DATETIME"),
-                PropertyType(name="name", type="STRING", required=True),
+                PropertyType(name="name", type="STRING", required=False),
             ],
             additional_properties=False,
         ),
@@ -411,7 +413,7 @@ def valid_relationship_types() -> tuple[RelationshipType, ...]:
             label="EMPLOYED_BY",
             description="Indicates employment relationship.",
             properties=[
-                PropertyType(name="start_time", type="LOCAL_DATETIME", required=True),
+                PropertyType(name="start_time", type="LOCAL_DATETIME", required=False),
                 PropertyType(name="end_time", type="LOCAL_DATETIME"),
             ],
             additional_properties=False,

--- a/tests/unit/experimental/components/test_schema.py
+++ b/tests/unit/experimental/components/test_schema.py
@@ -1507,132 +1507,6 @@ def test_clean_json_content_plain_json(
     assert cleaned == '{"node_types": [{"label": "Person"}]}'
 
 
-def test_filter_properties_required_field_valid_true(
-    schema_from_text: SchemaFromTextExtractor,
-) -> None:
-    node_types = [
-        {
-            "label": "Person",
-            "properties": [{"name": "name", "type": "STRING", "required": True}],
-        }
-    ]
-    result = schema_from_text._filter_properties_required_field(node_types)
-    assert result[0]["properties"][0]["required"] is True
-
-
-def test_filter_properties_required_field_valid_false(
-    schema_from_text: SchemaFromTextExtractor,
-) -> None:
-    node_types = [
-        {
-            "label": "Person",
-            "properties": [{"name": "name", "type": "STRING", "required": False}],
-        }
-    ]
-    result = schema_from_text._filter_properties_required_field(node_types)
-    assert result[0]["properties"][0]["required"] is False
-
-
-def test_filter_properties_required_field_string(
-    schema_from_text: SchemaFromTextExtractor,
-) -> None:
-    node_types = [
-        {
-            "label": "Person",
-            "properties": [
-                {"name": "prop1", "type": "STRING", "required": "true"},
-                {"name": "prop2", "type": "STRING", "required": "yes"},
-                {"name": "prop3", "type": "STRING", "required": "1"},
-                {"name": "prop4", "type": "STRING", "required": "TRUE"},
-            ],
-        }
-    ]
-    result = schema_from_text._filter_properties_required_field(node_types)
-    for prop in result[0]["properties"]:
-        assert prop["required"] is True
-    node_types = [
-        {
-            "label": "Person",
-            "properties": [
-                {"name": "prop1", "type": "STRING", "required": "false"},
-                {"name": "prop2", "type": "STRING", "required": "no"},
-                {"name": "prop3", "type": "STRING", "required": "0"},
-                {"name": "prop4", "type": "STRING", "required": "FALSE"},
-            ],
-        }
-    ]
-    result = schema_from_text._filter_properties_required_field(node_types)
-    for prop in result[0]["properties"]:
-        assert prop["required"] is False
-
-
-def test_filter_properties_required_field_invalid_string(
-    schema_from_text: SchemaFromTextExtractor,
-) -> None:
-    node_types = [
-        {
-            "label": "Person",
-            "properties": [
-                {"name": "name", "type": "STRING", "required": "mandatory"},
-                {"name": "email", "type": "STRING", "required": "always"},
-            ],
-        }
-    ]
-    result = schema_from_text._filter_properties_required_field(node_types)
-
-    assert "required" not in result[0]["properties"][0]
-    assert "required" not in result[0]["properties"][1]
-
-
-def test_filter_properties_required_field_int_values(
-    schema_from_text: SchemaFromTextExtractor,
-) -> None:
-    """Test that int values like 1 and 0 are converted to True/False."""
-    node_types = [
-        {
-            "label": "Person",
-            "properties": [
-                {"name": "prop1", "type": "STRING", "required": 1},
-                {"name": "prop2", "type": "STRING", "required": 0},
-            ],
-        }
-    ]
-    result = schema_from_text._filter_properties_required_field(node_types)
-    assert result[0]["properties"][0]["required"] is True
-    assert result[0]["properties"][1]["required"] is False
-
-
-def test_filter_properties_required_field_invalid_type(
-    schema_from_text: SchemaFromTextExtractor,
-) -> None:
-    """Test that unrecognized types like list and dict are removed."""
-    node_types = [
-        {
-            "label": "Person",
-            "properties": [
-                {"name": "prop1", "type": "STRING", "required": []},
-                {"name": "prop2", "type": "STRING", "required": {"value": True}},
-            ],
-        }
-    ]
-    result = schema_from_text._filter_properties_required_field(node_types)
-    for prop in result[0]["properties"]:
-        assert "required" not in prop
-
-
-def test_filter_properties_required_field_missing(
-    schema_from_text: SchemaFromTextExtractor,
-) -> None:
-    node_types = [
-        {
-            "label": "Person",
-            "properties": [{"name": "name", "type": "STRING"}],
-        }
-    ]
-    result = schema_from_text._filter_properties_required_field(node_types)
-    assert "required" not in result[0]["properties"][0]
-
-
 @pytest.mark.asyncio
 async def test_schema_from_text_with_required_properties(
     schema_from_text: SchemaFromTextExtractor,
@@ -1660,11 +1534,18 @@ async def test_schema_from_text_with_required_properties(
 
 
 @pytest.mark.asyncio
-async def test_schema_from_text_sanitizes_string_required_values(
+async def test_schema_from_text_string_required_coerced_without_existence_migration(
     schema_from_text: SchemaFromTextExtractor,
     mock_llm: AsyncMock,
     schema_json_with_string_required_values: str,
 ) -> None:
+    """LLMs may emit string truthiness for ``required``; Pydantic coerces it on ``PropertyType``.
+
+    Migration of legacy ``required`` to ``EXISTENCE`` constraints only runs when the raw
+    property dict has ``required is True`` (JSON boolean). String values such as ``\"true\"``
+    are not migrated; add ``ConstraintType`` rows with type ``EXISTENCE`` on ``GraphSchema``
+    if you need existence semantics for that case.
+    """
     mock_llm.ainvoke.return_value = LLMResponse(
         content=schema_json_with_string_required_values
     )
@@ -1674,16 +1555,20 @@ async def test_schema_from_text_sanitizes_string_required_values(
     person = schema.node_type_from_label("Person")
     assert person is not None
 
-    assert schema.existence_property_names_for_node("Person") == {"name", "email"}
+    assert schema.existence_property_names_for_node("Person") == set()
     name_prop = next((p for p in person.properties if p.name == "name"), None)
     email_prop = next((p for p in person.properties if p.name == "email"), None)
-    assert name_prop is not None and name_prop.required is False
-    assert email_prop is not None and email_prop.required is False
+    assert name_prop is not None
+    assert email_prop is not None
+    assert name_prop.model_dump().get("required") is True
+    assert email_prop.model_dump().get("required") is True
 
     phone_prop = next((p for p in person.properties if p.name == "phone"), None)
     address_prop = next((p for p in person.properties if p.name == "address"), None)
-    assert phone_prop is not None and phone_prop.required is False
-    assert address_prop is not None and address_prop.required is False
+    assert phone_prop is not None
+    assert address_prop is not None
+    assert phone_prop.model_dump().get("required") is False
+    assert address_prop.model_dump().get("required") is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description

## Summary

Aligns the KG schema model with how **Neo4j** separates concerns: **`required` (existence)** and **UNIQUENESS** are different constraint concepts and should not be represented the same way on node/relationship properties. This change makes **`GraphSchema`** express that distinction explicitly—**`EXISTENCE`** constraints for mandatory properties, **`UNIQUENESS`** for unique keys—and deprecates **`PropertyType.required`** with migration on load.

Structured schema extraction is also updated so **Vertex AI** can consume the response JSON Schema (wire-only constraint types without nullable fields that break protobuf conversion).

## Why

Previously, **`required`** lived on individual properties while **UNIQUENESS** lived in **`constraints`**, and the two were easy to conflate in prompts, extraction, and pruning. Neo4j treats **property existence** and **uniqueness** as separate constraint kinds; mirroring that in the library removes ambiguity and avoids implying that uniqueness enforces presence (or vice versa).

## What changed

### Runtime schema (`GraphSchema` / `ConstraintType`)

- Introduces **`GraphConstraintType`**: **`UNIQUENESS`** (node properties only in this API) and **`EXISTENCE`** (node **or** relationship property).
- **`PropertyType.required`** is deprecated; loading a schema migrates legacy `required` flags into **`EXISTENCE`** constraints where appropriate.
- **Graph pruning**, **schema visualization**, and **schema-from-existing-graph** flows updated to use **EXISTENCE** (and no longer treat uniqueness as a stand-in for required).

### Schema-from-text structured output (OpenAI / Vertex)

- **`GraphSchemaExtractionOutput.constraints`** use **`ExtractedConstraintType`**: plain string fields and **`relationship_type: ""`** instead of **`Optional` / null**, so generated JSON Schema stays compatible with Vertex’s protobuf parser.
- **`wire_extraction_constraints_for_graph_schema`** maps wire values (`""` / legacy `null`) to **`None`** for runtime **`ConstraintType`**.
- **`SchemaExtractionTemplate`** examples updated to use **`""`** instead of **`null`** where a constraint is not relationship-scoped.

### Tests & docs

- Unit/contract tests for extraction, constraints, pruning, and deprecation; **CHANGELOG** (`## Next`) updated.

## Type of Change
- [x] New feature (more like new syntax)
- [ ] Bug fix
- [x] Breaking change (but not really since we're only deprecating)
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Medium

## How Has This Been Tested?
- [x] Unit tests
- [x] E2E tests
- [x] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] Unit tests have been updated
- [x] E2E tests have been updated
- [x] Examples have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [x] CHANGELOG.md updated if appropriate
