### PR TITLE
Add token usage tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `LLMUsage` model (`request_tokens`, `response_tokens`, `total_tokens`) added to `neo4j_graphrag.llm`; `LLMResponse` now carries an optional `usage: LLMUsage` field populated by all built-in LLM implementations (OpenAI, AzureOpenAI, Anthropic, Bedrock, Cohere, MistralAI, Ollama, VertexAI).
 - Experimental: `GraphSchemaExtractionOutput`, `ExtractedNodeType`, `ExtractedRelationshipType`, and `ExtractedPropertyType` in `neo4j_graphrag.experimental.components.graph_schema_extraction` for schema-from-text LLM structured output; `Neo4jPropertyTypeName` type alias on `PropertyType`; `GraphSchema.from_extraction_output` and `validate_extraction_dict_to_graph_schema`; `make_strict_json_schema_for_structured_output` in `neo4j_graphrag.utils.json_schema_structured_output`.
 - Experimental KG schemas: `GraphConstraintType` (`UNIQUENESS`, `EXISTENCE`) and extended `ConstraintType` so `EXISTENCE` can target a node property or a relationship property; graph pruning and schema visualization respect `EXISTENCE` constraints.
 - Experimental: `GraphConstraintType.KEY` (Neo4j NODE KEY / RELATIONSHIP KEY, single property) on `GraphSchema.constraints`; pruning treats KEY like EXISTENCE for mandatory (non-null) properties. UNIQUENESS and KEY cannot target the same node property. Helpers: `key_property_names_for_node`, `key_property_names_for_relationship`, `uniqueness_property_names_for_node`, `mandatory_property_names_for_node`, `mandatory_property_names_for_relationship`.

--- a/docs/source/types.rst
+++ b/docs/source/types.rst
@@ -22,6 +22,12 @@ RetrieverResultItem
 .. autoclass:: neo4j_graphrag.types.RetrieverResultItem
 
 
+LLMUsage
+========
+
+.. autoclass:: neo4j_graphrag.llm.types.LLMUsage
+
+
 LLMResponse
 ===========
 

--- a/src/neo4j_graphrag/llm/__init__.py
+++ b/src/neo4j_graphrag/llm/__init__.py
@@ -22,7 +22,7 @@ from .cohere_llm import CohereLLM
 from .mistralai_llm import MistralAILLM
 from .ollama_llm import OllamaLLM
 from .openai_llm import AzureOpenAILLM, OpenAILLM
-from .types import LLMResponse
+from .types import LLMResponse, LLMUsage
 from .vertexai_llm import VertexAILLM
 
 __all__ = [
@@ -30,6 +30,7 @@ __all__ = [
     "BedrockLLM",
     "CohereLLM",
     "LLMResponse",
+    "LLMUsage",
     "LLMBase",
     "LLMInterface",
     "LLMInterfaceV2",

--- a/src/neo4j_graphrag/llm/anthropic_llm.py
+++ b/src/neo4j_graphrag/llm/anthropic_llm.py
@@ -31,6 +31,7 @@ from neo4j_graphrag.llm.base import LLMBase
 from neo4j_graphrag.llm.types import (
     BaseMessage,
     LLMResponse,
+    LLMUsage,
     MessageList,
     UserMessage,
 )
@@ -170,7 +171,12 @@ class AnthropicLLM(LLMBase):
                 text = response_content[0].text
             else:
                 raise LLMGenerationError("LLM returned empty response.")
-            return LLMResponse(content=text)
+            usage = LLMUsage(
+                request_tokens=response.usage.input_tokens,
+                response_tokens=response.usage.output_tokens,
+                total_tokens=response.usage.input_tokens + response.usage.output_tokens,
+            )
+            return LLMResponse(content=text, usage=usage)
         except self.anthropic.APIError as e:
             raise LLMGenerationError(e)
 
@@ -199,7 +205,12 @@ class AnthropicLLM(LLMBase):
                 text = response_content[0].text
             else:
                 raise LLMGenerationError("LLM returned empty response.")
-            return LLMResponse(content=text)
+            usage = LLMUsage(
+                request_tokens=response.usage.input_tokens,
+                response_tokens=response.usage.output_tokens,
+                total_tokens=response.usage.input_tokens + response.usage.output_tokens,
+            )
+            return LLMResponse(content=text, usage=usage)
         except self.anthropic.APIError as e:
             raise LLMGenerationError(e)
 
@@ -236,7 +247,12 @@ class AnthropicLLM(LLMBase):
                 text = response_content[0].text
             else:
                 raise LLMGenerationError("LLM returned empty response.")
-            return LLMResponse(content=text)
+            usage = LLMUsage(
+                request_tokens=response.usage.input_tokens,
+                response_tokens=response.usage.output_tokens,
+                total_tokens=response.usage.input_tokens + response.usage.output_tokens,
+            )
+            return LLMResponse(content=text, usage=usage)
         except self.anthropic.APIError as e:
             raise LLMGenerationError(e)
 
@@ -274,7 +290,12 @@ class AnthropicLLM(LLMBase):
                 text = response_content[0].text
             else:
                 raise LLMGenerationError("LLM returned empty response.")
-            return LLMResponse(content=text)
+            usage = LLMUsage(
+                request_tokens=response.usage.input_tokens,
+                response_tokens=response.usage.output_tokens,
+                total_tokens=response.usage.input_tokens + response.usage.output_tokens,
+            )
+            return LLMResponse(content=text, usage=usage)
         except self.anthropic.APIError as e:
             raise LLMGenerationError(e)
 

--- a/src/neo4j_graphrag/llm/bedrock_llm.py
+++ b/src/neo4j_graphrag/llm/bedrock_llm.py
@@ -38,6 +38,7 @@ from neo4j_graphrag.llm.base import LLMInterface, LLMInterfaceV2
 from neo4j_graphrag.llm.types import (
     BaseMessage,
     LLMResponse,
+    LLMUsage,
     MessageList,
     ToolCall,
     ToolCallResponse,
@@ -366,7 +367,15 @@ class BedrockLLM(LLMInterface, LLMInterfaceV2):
         text_parts = [block["text"] for block in content_blocks if "text" in block]
         if not text_parts:
             raise LLMGenerationError("LLM returned empty response.")
-        return LLMResponse(content="".join(text_parts))
+        usage = None
+        raw_usage = response.get("usage", {})
+        if raw_usage:
+            usage = LLMUsage(
+                request_tokens=raw_usage.get("inputTokens", 0),
+                response_tokens=raw_usage.get("outputTokens", 0),
+                total_tokens=raw_usage.get("totalTokens", 0),
+            )
+        return LLMResponse(content="".join(text_parts), usage=usage)
 
     def _get_tool_config(
         self, tools: Optional[Sequence[Tool]]

--- a/src/neo4j_graphrag/llm/bedrock_llm.py
+++ b/src/neo4j_graphrag/llm/bedrock_llm.py
@@ -371,9 +371,9 @@ class BedrockLLM(LLMInterface, LLMInterfaceV2):
         raw_usage = response.get("usage", {})
         if raw_usage:
             usage = LLMUsage(
-                request_tokens=raw_usage.get("inputTokens", 0),
-                response_tokens=raw_usage.get("outputTokens", 0),
-                total_tokens=raw_usage.get("totalTokens", 0),
+                request_tokens=raw_usage.get("inputTokens"),
+                response_tokens=raw_usage.get("outputTokens"),
+                total_tokens=raw_usage.get("totalTokens"),
             )
         return LLMResponse(content="".join(text_parts), usage=usage)
 

--- a/src/neo4j_graphrag/llm/cohere_llm.py
+++ b/src/neo4j_graphrag/llm/cohere_llm.py
@@ -177,12 +177,12 @@ class CohereLLM(LLMBase):
             raise LLMGenerationError(e)
         usage = None
         if res.usage and res.usage.tokens:
-            input_tokens = int(res.usage.tokens.input_tokens or 0)
-            output_tokens = int(res.usage.tokens.output_tokens or 0)
+            input_tokens = int(res.usage.tokens.input_tokens) if res.usage.tokens.input_tokens is not None else None
+            output_tokens = int(res.usage.tokens.output_tokens) if res.usage.tokens.output_tokens is not None else None
             usage = LLMUsage(
                 request_tokens=input_tokens,
                 response_tokens=output_tokens,
-                total_tokens=input_tokens + output_tokens,
+                total_tokens=(input_tokens + output_tokens) if (input_tokens is not None and output_tokens is not None) else None,
             )
         return LLMResponse(
             content=self._extract_text_content(res.message.content), usage=usage
@@ -219,12 +219,12 @@ class CohereLLM(LLMBase):
 
         usage = None
         if res.usage and res.usage.tokens:
-            input_tokens = int(res.usage.tokens.input_tokens or 0)
-            output_tokens = int(res.usage.tokens.output_tokens or 0)
+            input_tokens = int(res.usage.tokens.input_tokens) if res.usage.tokens.input_tokens is not None else None
+            output_tokens = int(res.usage.tokens.output_tokens) if res.usage.tokens.output_tokens is not None else None
             usage = LLMUsage(
                 request_tokens=input_tokens,
                 response_tokens=output_tokens,
-                total_tokens=input_tokens + output_tokens,
+                total_tokens=(input_tokens + output_tokens) if (input_tokens is not None and output_tokens is not None) else None,
             )
         return LLMResponse(
             content=(
@@ -265,12 +265,12 @@ class CohereLLM(LLMBase):
             raise LLMGenerationError(e)
         usage = None
         if res.usage and res.usage.tokens:
-            input_tokens = int(res.usage.tokens.input_tokens or 0)
-            output_tokens = int(res.usage.tokens.output_tokens or 0)
+            input_tokens = int(res.usage.tokens.input_tokens) if res.usage.tokens.input_tokens is not None else None
+            output_tokens = int(res.usage.tokens.output_tokens) if res.usage.tokens.output_tokens is not None else None
             usage = LLMUsage(
                 request_tokens=input_tokens,
                 response_tokens=output_tokens,
-                total_tokens=input_tokens + output_tokens,
+                total_tokens=(input_tokens + output_tokens) if (input_tokens is not None and output_tokens is not None) else None,
             )
         return LLMResponse(
             content=self._extract_text_content(res.message.content), usage=usage
@@ -297,12 +297,12 @@ class CohereLLM(LLMBase):
             raise LLMGenerationError("Error calling cohere") from e
         usage = None
         if res.usage and res.usage.tokens:
-            input_tokens = int(res.usage.tokens.input_tokens or 0)
-            output_tokens = int(res.usage.tokens.output_tokens or 0)
+            input_tokens = int(res.usage.tokens.input_tokens) if res.usage.tokens.input_tokens is not None else None
+            output_tokens = int(res.usage.tokens.output_tokens) if res.usage.tokens.output_tokens is not None else None
             usage = LLMUsage(
                 request_tokens=input_tokens,
                 response_tokens=output_tokens,
-                total_tokens=input_tokens + output_tokens,
+                total_tokens=(input_tokens + output_tokens) if (input_tokens is not None and output_tokens is not None) else None,
             )
         return LLMResponse(
             content=(

--- a/src/neo4j_graphrag/llm/cohere_llm.py
+++ b/src/neo4j_graphrag/llm/cohere_llm.py
@@ -177,12 +177,22 @@ class CohereLLM(LLMBase):
             raise LLMGenerationError(e)
         usage = None
         if res.usage and res.usage.tokens:
-            input_tokens = int(res.usage.tokens.input_tokens) if res.usage.tokens.input_tokens is not None else None
-            output_tokens = int(res.usage.tokens.output_tokens) if res.usage.tokens.output_tokens is not None else None
+            input_tokens = (
+                int(res.usage.tokens.input_tokens)
+                if res.usage.tokens.input_tokens is not None
+                else None
+            )
+            output_tokens = (
+                int(res.usage.tokens.output_tokens)
+                if res.usage.tokens.output_tokens is not None
+                else None
+            )
             usage = LLMUsage(
                 request_tokens=input_tokens,
                 response_tokens=output_tokens,
-                total_tokens=(input_tokens + output_tokens) if (input_tokens is not None and output_tokens is not None) else None,
+                total_tokens=(input_tokens + output_tokens)
+                if (input_tokens is not None and output_tokens is not None)
+                else None,
             )
         return LLMResponse(
             content=self._extract_text_content(res.message.content), usage=usage
@@ -219,12 +229,22 @@ class CohereLLM(LLMBase):
 
         usage = None
         if res.usage and res.usage.tokens:
-            input_tokens = int(res.usage.tokens.input_tokens) if res.usage.tokens.input_tokens is not None else None
-            output_tokens = int(res.usage.tokens.output_tokens) if res.usage.tokens.output_tokens is not None else None
+            input_tokens = (
+                int(res.usage.tokens.input_tokens)
+                if res.usage.tokens.input_tokens is not None
+                else None
+            )
+            output_tokens = (
+                int(res.usage.tokens.output_tokens)
+                if res.usage.tokens.output_tokens is not None
+                else None
+            )
             usage = LLMUsage(
                 request_tokens=input_tokens,
                 response_tokens=output_tokens,
-                total_tokens=(input_tokens + output_tokens) if (input_tokens is not None and output_tokens is not None) else None,
+                total_tokens=(input_tokens + output_tokens)
+                if (input_tokens is not None and output_tokens is not None)
+                else None,
             )
         return LLMResponse(
             content=(
@@ -265,12 +285,22 @@ class CohereLLM(LLMBase):
             raise LLMGenerationError(e)
         usage = None
         if res.usage and res.usage.tokens:
-            input_tokens = int(res.usage.tokens.input_tokens) if res.usage.tokens.input_tokens is not None else None
-            output_tokens = int(res.usage.tokens.output_tokens) if res.usage.tokens.output_tokens is not None else None
+            input_tokens = (
+                int(res.usage.tokens.input_tokens)
+                if res.usage.tokens.input_tokens is not None
+                else None
+            )
+            output_tokens = (
+                int(res.usage.tokens.output_tokens)
+                if res.usage.tokens.output_tokens is not None
+                else None
+            )
             usage = LLMUsage(
                 request_tokens=input_tokens,
                 response_tokens=output_tokens,
-                total_tokens=(input_tokens + output_tokens) if (input_tokens is not None and output_tokens is not None) else None,
+                total_tokens=(input_tokens + output_tokens)
+                if (input_tokens is not None and output_tokens is not None)
+                else None,
             )
         return LLMResponse(
             content=self._extract_text_content(res.message.content), usage=usage
@@ -297,12 +327,22 @@ class CohereLLM(LLMBase):
             raise LLMGenerationError("Error calling cohere") from e
         usage = None
         if res.usage and res.usage.tokens:
-            input_tokens = int(res.usage.tokens.input_tokens) if res.usage.tokens.input_tokens is not None else None
-            output_tokens = int(res.usage.tokens.output_tokens) if res.usage.tokens.output_tokens is not None else None
+            input_tokens = (
+                int(res.usage.tokens.input_tokens)
+                if res.usage.tokens.input_tokens is not None
+                else None
+            )
+            output_tokens = (
+                int(res.usage.tokens.output_tokens)
+                if res.usage.tokens.output_tokens is not None
+                else None
+            )
             usage = LLMUsage(
                 request_tokens=input_tokens,
                 response_tokens=output_tokens,
-                total_tokens=(input_tokens + output_tokens) if (input_tokens is not None and output_tokens is not None) else None,
+                total_tokens=(input_tokens + output_tokens)
+                if (input_tokens is not None and output_tokens is not None)
+                else None,
             )
         return LLMResponse(
             content=(

--- a/src/neo4j_graphrag/llm/cohere_llm.py
+++ b/src/neo4j_graphrag/llm/cohere_llm.py
@@ -36,6 +36,7 @@ from neo4j_graphrag.llm.base import LLMBase
 from neo4j_graphrag.llm.types import (
     BaseMessage,
     LLMResponse,
+    LLMUsage,
     MessageList,
     SystemMessage,
     UserMessage,
@@ -174,7 +175,16 @@ class CohereLLM(LLMBase):
             )
         except self.cohere_api_error as e:
             raise LLMGenerationError(e)
-        return LLMResponse(content=self._extract_text_content(res.message.content))
+        usage = None
+        if res.usage and res.usage.tokens:
+            input_tokens = int(res.usage.tokens.input_tokens or 0)
+            output_tokens = int(res.usage.tokens.output_tokens or 0)
+            usage = LLMUsage(
+                request_tokens=input_tokens,
+                response_tokens=output_tokens,
+                total_tokens=input_tokens + output_tokens,
+            )
+        return LLMResponse(content=self._extract_text_content(res.message.content), usage=usage)
 
     @rate_limit_handler_decorator
     def __invoke_v2(
@@ -205,12 +215,22 @@ class CohereLLM(LLMBase):
         except self.cohere_api_error as e:
             raise LLMGenerationError("Error calling cohere") from e
 
+        usage = None
+        if res.usage and res.usage.tokens:
+            input_tokens = int(res.usage.tokens.input_tokens or 0)
+            output_tokens = int(res.usage.tokens.output_tokens or 0)
+            usage = LLMUsage(
+                request_tokens=input_tokens,
+                response_tokens=output_tokens,
+                total_tokens=input_tokens + output_tokens,
+            )
         return LLMResponse(
             content=(
                 res.message.content[0].text
                 if res.message.content and hasattr(res.message.content[0], "text")
                 else ""
             ),
+            usage=usage,
         )
 
     @async_rate_limit_handler_decorator
@@ -241,7 +261,16 @@ class CohereLLM(LLMBase):
             )
         except self.cohere_api_error as e:
             raise LLMGenerationError(e)
-        return LLMResponse(content=self._extract_text_content(res.message.content))
+        usage = None
+        if res.usage and res.usage.tokens:
+            input_tokens = int(res.usage.tokens.input_tokens or 0)
+            output_tokens = int(res.usage.tokens.output_tokens or 0)
+            usage = LLMUsage(
+                request_tokens=input_tokens,
+                response_tokens=output_tokens,
+                total_tokens=input_tokens + output_tokens,
+            )
+        return LLMResponse(content=self._extract_text_content(res.message.content), usage=usage)
 
     @async_rate_limit_handler_decorator
     async def __ainvoke_v2(
@@ -262,12 +291,22 @@ class CohereLLM(LLMBase):
             )
         except self.cohere_api_error as e:
             raise LLMGenerationError("Error calling cohere") from e
+        usage = None
+        if res.usage and res.usage.tokens:
+            input_tokens = int(res.usage.tokens.input_tokens or 0)
+            output_tokens = int(res.usage.tokens.output_tokens or 0)
+            usage = LLMUsage(
+                request_tokens=input_tokens,
+                response_tokens=output_tokens,
+                total_tokens=input_tokens + output_tokens,
+            )
         return LLMResponse(
             content=(
                 res.message.content[0].text
                 if res.message.content and hasattr(res.message.content[0], "text")
                 else ""
             ),
+            usage=usage,
         )
 
     # subsdiary methods

--- a/src/neo4j_graphrag/llm/cohere_llm.py
+++ b/src/neo4j_graphrag/llm/cohere_llm.py
@@ -184,7 +184,9 @@ class CohereLLM(LLMBase):
                 response_tokens=output_tokens,
                 total_tokens=input_tokens + output_tokens,
             )
-        return LLMResponse(content=self._extract_text_content(res.message.content), usage=usage)
+        return LLMResponse(
+            content=self._extract_text_content(res.message.content), usage=usage
+        )
 
     @rate_limit_handler_decorator
     def __invoke_v2(
@@ -270,7 +272,9 @@ class CohereLLM(LLMBase):
                 response_tokens=output_tokens,
                 total_tokens=input_tokens + output_tokens,
             )
-        return LLMResponse(content=self._extract_text_content(res.message.content), usage=usage)
+        return LLMResponse(
+            content=self._extract_text_content(res.message.content), usage=usage
+        )
 
     @async_rate_limit_handler_decorator
     async def __ainvoke_v2(

--- a/src/neo4j_graphrag/llm/mistralai_llm.py
+++ b/src/neo4j_graphrag/llm/mistralai_llm.py
@@ -24,6 +24,7 @@ from neo4j_graphrag.llm.base import LLMBase
 from neo4j_graphrag.llm.types import (
     BaseMessage,
     LLMResponse,
+    LLMUsage,
     MessageList,
     SystemMessage,
     UserMessage,
@@ -157,11 +158,18 @@ class MistralAILLM(LLMBase):
                 **self.model_params,
             )
             content: str = ""
+            usage = None
             if response and response.choices:
                 possible_content = response.choices[0].message.content
                 if isinstance(possible_content, str):
                     content = possible_content
-            return LLMResponse(content=content)
+            if response and response.usage:
+                usage = LLMUsage(
+                    request_tokens=response.usage.prompt_tokens or 0,
+                    response_tokens=response.usage.completion_tokens or 0,
+                    total_tokens=response.usage.total_tokens or 0,
+                )
+            return LLMResponse(content=content, usage=usage)
         except SDKError as e:
             raise LLMGenerationError(e)
 
@@ -195,11 +203,18 @@ class MistralAILLM(LLMBase):
                 model=self.model_name, messages=messages, **self.model_params, **kwargs
             )
             content: str = ""
+            usage = None
             if response and response.choices:
                 possible_content = response.choices[0].message.content
                 if isinstance(possible_content, str):
                     content = possible_content
-            return LLMResponse(content=content)
+            if response and response.usage:
+                usage = LLMUsage(
+                    request_tokens=response.usage.prompt_tokens or 0,
+                    response_tokens=response.usage.completion_tokens or 0,
+                    total_tokens=response.usage.total_tokens or 0,
+                )
+            return LLMResponse(content=content, usage=usage)
         except SDKError as e:
             raise LLMGenerationError(e)
 
@@ -235,11 +250,18 @@ class MistralAILLM(LLMBase):
                 **self.model_params,
             )
             content: str = ""
+            usage = None
             if response and response.choices:
                 possible_content = response.choices[0].message.content
                 if isinstance(possible_content, str):
                     content = possible_content
-            return LLMResponse(content=content)
+            if response and response.usage:
+                usage = LLMUsage(
+                    request_tokens=response.usage.prompt_tokens or 0,
+                    response_tokens=response.usage.completion_tokens or 0,
+                    total_tokens=response.usage.total_tokens or 0,
+                )
+            return LLMResponse(content=content, usage=usage)
         except SDKError as e:
             raise LLMGenerationError(e)
 
@@ -276,11 +298,18 @@ class MistralAILLM(LLMBase):
                 **kwargs,
             )
             content: str = ""
+            usage = None
             if response and response.choices:
                 possible_content = response.choices[0].message.content
                 if isinstance(possible_content, str):
                     content = possible_content
-            return LLMResponse(content=content)
+            if response and response.usage:
+                usage = LLMUsage(
+                    request_tokens=response.usage.prompt_tokens or 0,
+                    response_tokens=response.usage.completion_tokens or 0,
+                    total_tokens=response.usage.total_tokens or 0,
+                )
+            return LLMResponse(content=content, usage=usage)
         except SDKError as e:
             raise LLMGenerationError(e)
 

--- a/src/neo4j_graphrag/llm/mistralai_llm.py
+++ b/src/neo4j_graphrag/llm/mistralai_llm.py
@@ -165,9 +165,9 @@ class MistralAILLM(LLMBase):
                     content = possible_content
             if response and response.usage:
                 usage = LLMUsage(
-                    request_tokens=response.usage.prompt_tokens or 0,
-                    response_tokens=response.usage.completion_tokens or 0,
-                    total_tokens=response.usage.total_tokens or 0,
+                    request_tokens=response.usage.prompt_tokens,
+                    response_tokens=response.usage.completion_tokens,
+                    total_tokens=response.usage.total_tokens,
                 )
             return LLMResponse(content=content, usage=usage)
         except SDKError as e:
@@ -210,9 +210,9 @@ class MistralAILLM(LLMBase):
                     content = possible_content
             if response and response.usage:
                 usage = LLMUsage(
-                    request_tokens=response.usage.prompt_tokens or 0,
-                    response_tokens=response.usage.completion_tokens or 0,
-                    total_tokens=response.usage.total_tokens or 0,
+                    request_tokens=response.usage.prompt_tokens,
+                    response_tokens=response.usage.completion_tokens,
+                    total_tokens=response.usage.total_tokens,
                 )
             return LLMResponse(content=content, usage=usage)
         except SDKError as e:
@@ -257,9 +257,9 @@ class MistralAILLM(LLMBase):
                     content = possible_content
             if response and response.usage:
                 usage = LLMUsage(
-                    request_tokens=response.usage.prompt_tokens or 0,
-                    response_tokens=response.usage.completion_tokens or 0,
-                    total_tokens=response.usage.total_tokens or 0,
+                    request_tokens=response.usage.prompt_tokens,
+                    response_tokens=response.usage.completion_tokens,
+                    total_tokens=response.usage.total_tokens,
                 )
             return LLMResponse(content=content, usage=usage)
         except SDKError as e:
@@ -305,9 +305,9 @@ class MistralAILLM(LLMBase):
                     content = possible_content
             if response and response.usage:
                 usage = LLMUsage(
-                    request_tokens=response.usage.prompt_tokens or 0,
-                    response_tokens=response.usage.completion_tokens or 0,
-                    total_tokens=response.usage.total_tokens or 0,
+                    request_tokens=response.usage.prompt_tokens,
+                    response_tokens=response.usage.completion_tokens,
+                    total_tokens=response.usage.total_tokens,
                 )
             return LLMResponse(content=content, usage=usage)
         except SDKError as e:

--- a/src/neo4j_graphrag/llm/ollama_llm.py
+++ b/src/neo4j_graphrag/llm/ollama_llm.py
@@ -52,6 +52,7 @@ from .base import LLMBase
 from .types import (
     BaseMessage,
     LLMResponse,
+    LLMUsage,
     MessageList,
     SystemMessage,
     ToolCall,
@@ -169,7 +170,16 @@ class OllamaLLM(LLMBase):
                 **self.model_params,
             )
             content = response.message.content or ""
-            return LLMResponse(content=content)
+            usage = None
+            if response.prompt_eval_count is not None or response.eval_count is not None:
+                request_tokens = response.prompt_eval_count or 0
+                response_tokens = response.eval_count or 0
+                usage = LLMUsage(
+                    request_tokens=request_tokens,
+                    response_tokens=response_tokens,
+                    total_tokens=request_tokens + response_tokens,
+                )
+            return LLMResponse(content=content, usage=usage)
         except self.ollama.ResponseError as e:
             raise LLMGenerationError(e)
 
@@ -201,7 +211,16 @@ class OllamaLLM(LLMBase):
                 **kwargs,
             )
             content = response.message.content or ""
-            return LLMResponse(content=content)
+            usage = None
+            if response.prompt_eval_count is not None or response.eval_count is not None:
+                request_tokens = response.prompt_eval_count or 0
+                response_tokens = response.eval_count or 0
+                usage = LLMUsage(
+                    request_tokens=request_tokens,
+                    response_tokens=response_tokens,
+                    total_tokens=request_tokens + response_tokens,
+                )
+            return LLMResponse(content=content, usage=usage)
         except self.ollama.ResponseError as e:
             raise LLMGenerationError(e)
 
@@ -236,7 +255,16 @@ class OllamaLLM(LLMBase):
                 options=self.model_params,
             )
             content = response.message.content or ""
-            return LLMResponse(content=content)
+            usage = None
+            if response.prompt_eval_count is not None or response.eval_count is not None:
+                request_tokens = response.prompt_eval_count or 0
+                response_tokens = response.eval_count or 0
+                usage = LLMUsage(
+                    request_tokens=request_tokens,
+                    response_tokens=response_tokens,
+                    total_tokens=request_tokens + response_tokens,
+                )
+            return LLMResponse(content=content, usage=usage)
         except self.ollama.ResponseError as e:
             raise LLMGenerationError(e)
 
@@ -272,7 +300,16 @@ class OllamaLLM(LLMBase):
                 options=params,
             )
             content = response.message.content or ""
-            return LLMResponse(content=content)
+            usage = None
+            if response.prompt_eval_count is not None or response.eval_count is not None:
+                request_tokens = response.prompt_eval_count or 0
+                response_tokens = response.eval_count or 0
+                usage = LLMUsage(
+                    request_tokens=request_tokens,
+                    response_tokens=response_tokens,
+                    total_tokens=request_tokens + response_tokens,
+                )
+            return LLMResponse(content=content, usage=usage)
         except self.ollama.ResponseError as e:
             raise LLMGenerationError(e)
 

--- a/src/neo4j_graphrag/llm/ollama_llm.py
+++ b/src/neo4j_graphrag/llm/ollama_llm.py
@@ -180,7 +180,9 @@ class OllamaLLM(LLMBase):
                 usage = LLMUsage(
                     request_tokens=request_tokens,
                     response_tokens=response_tokens,
-                    total_tokens=(request_tokens + response_tokens) if (request_tokens is not None and response_tokens is not None) else None,
+                    total_tokens=(request_tokens + response_tokens)
+                    if (request_tokens is not None and response_tokens is not None)
+                    else None,
                 )
             return LLMResponse(content=content, usage=usage)
         except self.ollama.ResponseError as e:
@@ -224,7 +226,9 @@ class OllamaLLM(LLMBase):
                 usage = LLMUsage(
                     request_tokens=request_tokens,
                     response_tokens=response_tokens,
-                    total_tokens=(request_tokens + response_tokens) if (request_tokens is not None and response_tokens is not None) else None,
+                    total_tokens=(request_tokens + response_tokens)
+                    if (request_tokens is not None and response_tokens is not None)
+                    else None,
                 )
             return LLMResponse(content=content, usage=usage)
         except self.ollama.ResponseError as e:
@@ -271,7 +275,9 @@ class OllamaLLM(LLMBase):
                 usage = LLMUsage(
                     request_tokens=request_tokens,
                     response_tokens=response_tokens,
-                    total_tokens=(request_tokens + response_tokens) if (request_tokens is not None and response_tokens is not None) else None,
+                    total_tokens=(request_tokens + response_tokens)
+                    if (request_tokens is not None and response_tokens is not None)
+                    else None,
                 )
             return LLMResponse(content=content, usage=usage)
         except self.ollama.ResponseError as e:
@@ -319,7 +325,9 @@ class OllamaLLM(LLMBase):
                 usage = LLMUsage(
                     request_tokens=request_tokens,
                     response_tokens=response_tokens,
-                    total_tokens=(request_tokens + response_tokens) if (request_tokens is not None and response_tokens is not None) else None,
+                    total_tokens=(request_tokens + response_tokens)
+                    if (request_tokens is not None and response_tokens is not None)
+                    else None,
                 )
             return LLMResponse(content=content, usage=usage)
         except self.ollama.ResponseError as e:

--- a/src/neo4j_graphrag/llm/ollama_llm.py
+++ b/src/neo4j_graphrag/llm/ollama_llm.py
@@ -171,7 +171,10 @@ class OllamaLLM(LLMBase):
             )
             content = response.message.content or ""
             usage = None
-            if response.prompt_eval_count is not None or response.eval_count is not None:
+            if (
+                response.prompt_eval_count is not None
+                or response.eval_count is not None
+            ):
                 request_tokens = response.prompt_eval_count or 0
                 response_tokens = response.eval_count or 0
                 usage = LLMUsage(
@@ -212,7 +215,10 @@ class OllamaLLM(LLMBase):
             )
             content = response.message.content or ""
             usage = None
-            if response.prompt_eval_count is not None or response.eval_count is not None:
+            if (
+                response.prompt_eval_count is not None
+                or response.eval_count is not None
+            ):
                 request_tokens = response.prompt_eval_count or 0
                 response_tokens = response.eval_count or 0
                 usage = LLMUsage(
@@ -256,7 +262,10 @@ class OllamaLLM(LLMBase):
             )
             content = response.message.content or ""
             usage = None
-            if response.prompt_eval_count is not None or response.eval_count is not None:
+            if (
+                response.prompt_eval_count is not None
+                or response.eval_count is not None
+            ):
                 request_tokens = response.prompt_eval_count or 0
                 response_tokens = response.eval_count or 0
                 usage = LLMUsage(
@@ -301,7 +310,10 @@ class OllamaLLM(LLMBase):
             )
             content = response.message.content or ""
             usage = None
-            if response.prompt_eval_count is not None or response.eval_count is not None:
+            if (
+                response.prompt_eval_count is not None
+                or response.eval_count is not None
+            ):
                 request_tokens = response.prompt_eval_count or 0
                 response_tokens = response.eval_count or 0
                 usage = LLMUsage(

--- a/src/neo4j_graphrag/llm/ollama_llm.py
+++ b/src/neo4j_graphrag/llm/ollama_llm.py
@@ -175,12 +175,12 @@ class OllamaLLM(LLMBase):
                 response.prompt_eval_count is not None
                 or response.eval_count is not None
             ):
-                request_tokens = response.prompt_eval_count or 0
-                response_tokens = response.eval_count or 0
+                request_tokens = response.prompt_eval_count
+                response_tokens = response.eval_count
                 usage = LLMUsage(
                     request_tokens=request_tokens,
                     response_tokens=response_tokens,
-                    total_tokens=request_tokens + response_tokens,
+                    total_tokens=(request_tokens + response_tokens) if (request_tokens is not None and response_tokens is not None) else None,
                 )
             return LLMResponse(content=content, usage=usage)
         except self.ollama.ResponseError as e:
@@ -219,12 +219,12 @@ class OllamaLLM(LLMBase):
                 response.prompt_eval_count is not None
                 or response.eval_count is not None
             ):
-                request_tokens = response.prompt_eval_count or 0
-                response_tokens = response.eval_count or 0
+                request_tokens = response.prompt_eval_count
+                response_tokens = response.eval_count
                 usage = LLMUsage(
                     request_tokens=request_tokens,
                     response_tokens=response_tokens,
-                    total_tokens=request_tokens + response_tokens,
+                    total_tokens=(request_tokens + response_tokens) if (request_tokens is not None and response_tokens is not None) else None,
                 )
             return LLMResponse(content=content, usage=usage)
         except self.ollama.ResponseError as e:
@@ -266,12 +266,12 @@ class OllamaLLM(LLMBase):
                 response.prompt_eval_count is not None
                 or response.eval_count is not None
             ):
-                request_tokens = response.prompt_eval_count or 0
-                response_tokens = response.eval_count or 0
+                request_tokens = response.prompt_eval_count
+                response_tokens = response.eval_count
                 usage = LLMUsage(
                     request_tokens=request_tokens,
                     response_tokens=response_tokens,
-                    total_tokens=request_tokens + response_tokens,
+                    total_tokens=(request_tokens + response_tokens) if (request_tokens is not None and response_tokens is not None) else None,
                 )
             return LLMResponse(content=content, usage=usage)
         except self.ollama.ResponseError as e:
@@ -314,12 +314,12 @@ class OllamaLLM(LLMBase):
                 response.prompt_eval_count is not None
                 or response.eval_count is not None
             ):
-                request_tokens = response.prompt_eval_count or 0
-                response_tokens = response.eval_count or 0
+                request_tokens = response.prompt_eval_count
+                response_tokens = response.eval_count
                 usage = LLMUsage(
                     request_tokens=request_tokens,
                     response_tokens=response_tokens,
-                    total_tokens=request_tokens + response_tokens,
+                    total_tokens=(request_tokens + response_tokens) if (request_tokens is not None and response_tokens is not None) else None,
                 )
             return LLMResponse(content=content, usage=usage)
         except self.ollama.ResponseError as e:

--- a/src/neo4j_graphrag/llm/openai_llm.py
+++ b/src/neo4j_graphrag/llm/openai_llm.py
@@ -54,6 +54,7 @@ from .base import LLMBase
 from .types import (
     BaseMessage,
     LLMResponse,
+    LLMUsage,
     MessageList,
     SystemMessage,
     ToolCall,
@@ -302,7 +303,14 @@ class BaseOpenAILLM(LLMBase, abc.ABC):
             )
 
             content = response.choices[0].message.content or ""
-            return LLMResponse(content=content)
+            usage = None
+            if response.usage:
+                usage = LLMUsage(
+                    request_tokens=response.usage.prompt_tokens,
+                    response_tokens=response.usage.completion_tokens,
+                    total_tokens=response.usage.total_tokens,
+                )
+            return LLMResponse(content=content, usage=usage)
         except self.openai.OpenAIError as e:
             raise LLMGenerationError(e)
 
@@ -337,7 +345,14 @@ class BaseOpenAILLM(LLMBase, abc.ABC):
                 **self.model_params,
             )
             content = response.choices[0].message.content or ""
-            return LLMResponse(content=content)
+            usage = None
+            if response.usage:
+                usage = LLMUsage(
+                    request_tokens=response.usage.prompt_tokens,
+                    response_tokens=response.usage.completion_tokens,
+                    total_tokens=response.usage.total_tokens,
+                )
+            return LLMResponse(content=content, usage=usage)
         except self.openai.OpenAIError as e:
             raise LLMGenerationError(e)
 
@@ -447,7 +462,14 @@ class BaseOpenAILLM(LLMBase, abc.ABC):
                 **self.model_params,
             )
             content = response.choices[0].message.content or ""
-            return LLMResponse(content=content)
+            usage = None
+            if response.usage:
+                usage = LLMUsage(
+                    request_tokens=response.usage.prompt_tokens,
+                    response_tokens=response.usage.completion_tokens,
+                    total_tokens=response.usage.total_tokens,
+                )
+            return LLMResponse(content=content, usage=usage)
         except self.openai.OpenAIError as e:
             raise LLMGenerationError(e)
 
@@ -513,7 +535,14 @@ class BaseOpenAILLM(LLMBase, abc.ABC):
             )
 
             content = response.choices[0].message.content or ""
-            return LLMResponse(content=content)
+            usage = None
+            if response.usage:
+                usage = LLMUsage(
+                    request_tokens=response.usage.prompt_tokens,
+                    response_tokens=response.usage.completion_tokens,
+                    total_tokens=response.usage.total_tokens,
+                )
+            return LLMResponse(content=content, usage=usage)
         except self.openai.OpenAIError as e:
             raise LLMGenerationError(e)
 

--- a/src/neo4j_graphrag/llm/types.py
+++ b/src/neo4j_graphrag/llm/types.py
@@ -21,14 +21,17 @@ class LLMUsage(BaseModel):
     """Token usage statistics returned by an LLM call.
 
     Attributes:
-        request_tokens (int): Number of tokens in the prompt/request. Defaults to 0.
-        response_tokens (int): Number of tokens in the completion/response. Defaults to 0.
-        total_tokens (int): Total tokens consumed by the call. Defaults to 0.
+        request_tokens (Optional[int]): Number of tokens in the prompt/request.
+            ``None`` when not reported by the provider.
+        response_tokens (Optional[int]): Number of tokens in the completion/response.
+            ``None`` when not reported by the provider.
+        total_tokens (Optional[int]): Total tokens consumed by the call.
+            ``None`` when not reported by the provider.
     """
 
-    request_tokens: int = 0
-    response_tokens: int = 0
-    total_tokens: int = 0
+    request_tokens: Optional[int] = None
+    response_tokens: Optional[int] = None
+    total_tokens: Optional[int] = None
 
 
 class LLMResponse(BaseModel):

--- a/src/neo4j_graphrag/llm/types.py
+++ b/src/neo4j_graphrag/llm/types.py
@@ -18,12 +18,27 @@ def __getattr__(name: str) -> Any:
 
 
 class LLMUsage(BaseModel):
+    """Token usage statistics returned by an LLM call.
+
+    Attributes:
+        request_tokens (int): Number of tokens in the prompt/request. Defaults to 0.
+        response_tokens (int): Number of tokens in the completion/response. Defaults to 0.
+        total_tokens (int): Total tokens consumed by the call. Defaults to 0.
+    """
+
     request_tokens: int = 0
     response_tokens: int = 0
     total_tokens: int = 0
 
 
 class LLMResponse(BaseModel):
+    """Response returned by an LLM invocation.
+
+    Attributes:
+        content (str): The text content of the LLM response.
+        usage (Optional[LLMUsage]): Token usage statistics for the call, if provided by the LLM.
+    """
+
     content: str
     usage: Optional[LLMUsage] = None
 

--- a/src/neo4j_graphrag/llm/types.py
+++ b/src/neo4j_graphrag/llm/types.py
@@ -17,8 +17,15 @@ def __getattr__(name: str) -> Any:
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
+class LLMUsage(BaseModel):
+    request_tokens: int = 0
+    response_tokens: int = 0
+    total_tokens: int = 0
+
+
 class LLMResponse(BaseModel):
     content: str
+    usage: Optional[LLMUsage] = None
 
 
 class BaseMessage(BaseModel):

--- a/src/neo4j_graphrag/llm/vertexai_llm.py
+++ b/src/neo4j_graphrag/llm/vertexai_llm.py
@@ -28,6 +28,7 @@ from neo4j_graphrag.llm.base import LLMBase
 from neo4j_graphrag.llm.types import (
     BaseMessage,
     LLMResponse,
+    LLMUsage,
     MessageList,
     ToolCall,
     ToolCallResponse,
@@ -589,6 +590,12 @@ class VertexAILLM(LLMBase):
         )
 
     def _parse_content_response(self, response: GenerationResponse) -> LLMResponse:
-        return LLMResponse(
-            content=response.text,
-        )
+        usage = None
+        metadata = response.usage_metadata
+        if metadata:
+            usage = LLMUsage(
+                request_tokens=metadata.prompt_token_count,
+                response_tokens=metadata.candidates_token_count,
+                total_tokens=metadata.total_token_count,
+            )
+        return LLMResponse(content=response.text, usage=usage)

--- a/tests/unit/llm/test_base_llm.py
+++ b/tests/unit/llm/test_base_llm.py
@@ -16,13 +16,58 @@ import warnings
 from typing import Any, List, Optional, Type, Union
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from neo4j_graphrag.llm.base import LLMBase
-from neo4j_graphrag.llm.types import LLMResponse
+from neo4j_graphrag.llm.types import LLMResponse, LLMUsage
 from neo4j_graphrag.message_history import MessageHistory
 from neo4j_graphrag.types import LLMMessage
 from neo4j_graphrag.utils.rate_limit import NoOpRateLimitHandler
+
+# ---------------------------------------------------------------------------
+# LLMUsage
+# ---------------------------------------------------------------------------
+
+
+def test_llm_usage_defaults_to_zero() -> None:
+    usage = LLMUsage()
+    assert usage.request_tokens == 0
+    assert usage.response_tokens == 0
+    assert usage.total_tokens == 0
+
+
+def test_llm_usage_accepts_explicit_values() -> None:
+    usage = LLMUsage(request_tokens=10, response_tokens=20, total_tokens=30)
+    assert usage.request_tokens == 10
+    assert usage.response_tokens == 20
+    assert usage.total_tokens == 30
+
+
+def test_llm_usage_partial_values_keep_other_defaults() -> None:
+    usage = LLMUsage(request_tokens=5)
+    assert usage.request_tokens == 5
+    assert usage.response_tokens == 0
+    assert usage.total_tokens == 0
+
+
+def test_llm_usage_rejects_non_integer_tokens() -> None:
+    with pytest.raises(ValidationError):
+        LLMUsage(request_tokens="bad")  # type: ignore[arg-type]
+
+
+def test_llm_response_usage_is_none_by_default() -> None:
+    response = LLMResponse(content="hello")
+    assert response.usage is None
+
+
+def test_llm_response_carries_usage() -> None:
+    usage = LLMUsage(request_tokens=3, response_tokens=7, total_tokens=10)
+    response = LLMResponse(content="hi", usage=usage)
+    assert response.usage is not None
+    assert response.usage.request_tokens == 3
+    assert response.usage.response_tokens == 7
+    assert response.usage.total_tokens == 10
+
 
 # ---------------------------------------------------------------------------
 # Minimal concrete subclass used across tests

--- a/tests/unit/llm/test_base_llm.py
+++ b/tests/unit/llm/test_base_llm.py
@@ -29,11 +29,11 @@ from neo4j_graphrag.utils.rate_limit import NoOpRateLimitHandler
 # ---------------------------------------------------------------------------
 
 
-def test_llm_usage_defaults_to_zero() -> None:
+def test_llm_usage_defaults_to_none() -> None:
     usage = LLMUsage()
-    assert usage.request_tokens == 0
-    assert usage.response_tokens == 0
-    assert usage.total_tokens == 0
+    assert usage.request_tokens is None
+    assert usage.response_tokens is None
+    assert usage.total_tokens is None
 
 
 def test_llm_usage_accepts_explicit_values() -> None:
@@ -46,8 +46,8 @@ def test_llm_usage_accepts_explicit_values() -> None:
 def test_llm_usage_partial_values_keep_other_defaults() -> None:
     usage = LLMUsage(request_tokens=5)
     assert usage.request_tokens == 5
-    assert usage.response_tokens == 0
-    assert usage.total_tokens == 0
+    assert usage.response_tokens is None
+    assert usage.total_tokens is None
 
 
 def test_llm_usage_rejects_non_integer_tokens() -> None:

--- a/tests/unit/llm/test_vertexai_llm.py
+++ b/tests/unit/llm/test_vertexai_llm.py
@@ -65,6 +65,7 @@ def test_vertexai_invoke_happy_path(GenerativeModelMock: MagicMock) -> None:
     input_text = "may thy knife chip and shatter"
     mock_response = Mock()
     mock_response.text = "Return text"
+    mock_response.usage_metadata = None
     mock_model = GenerativeModelMock.return_value
     mock_model.generate_content.return_value = mock_response
     model_params = {"temperature": 0.5}
@@ -94,6 +95,7 @@ def test_vertexai_invoke_with_system_instruction(
     input_text = "may thy knife chip and shatter"
     mock_response = Mock()
     mock_response.text = "Return text"
+    mock_response.usage_metadata = None
     mock_model = GenerativeModelMock.return_value
     mock_model.generate_content.return_value = mock_response
 
@@ -121,6 +123,7 @@ def test_vertexai_invoke_with_message_history_and_system_instruction(
     model_name = "gemini-1.5-flash-001"
     mock_response = Mock()
     mock_response.text = "Return text"
+    mock_response.usage_metadata = None
     mock_model = GenerativeModelMock.return_value
     mock_model.generate_content.return_value = mock_response
     model_params = {"temperature": 0.5}
@@ -348,6 +351,7 @@ def test_vertexai_invoke_v2_happy_path(GenerativeModelMock: MagicMock) -> None:
     ]
     mock_response = Mock()
     mock_response.text = "Paris is the capital of France."
+    mock_response.usage_metadata = None
     mock_model = GenerativeModelMock.return_value
     mock_model.generate_content.return_value = mock_response
 
@@ -381,6 +385,7 @@ def test_vertexai_invoke_v2_with_conversation_history(
     ]
     mock_response = Mock()
     mock_response.text = "Berlin is the capital of Germany."
+    mock_response.usage_metadata = None
     mock_model = GenerativeModelMock.return_value
     mock_model.generate_content.return_value = mock_response
 
@@ -412,6 +417,7 @@ def test_vertexai_invoke_v2_no_system_message(GenerativeModelMock: MagicMock) ->
     ]
     mock_response = Mock()
     mock_response.text = "I'm doing well, thank you!"
+    mock_response.usage_metadata = None
     mock_model = GenerativeModelMock.return_value
     mock_model.generate_content.return_value = mock_response
 
@@ -515,6 +521,7 @@ def test_vertexai_invoke_v2_with_pydantic_response_format(
     ]
     mock_response = Mock()
     mock_response.text = '{"name": "John", "age": 30}'
+    mock_response.usage_metadata = None
     mock_model = GenerativeModelMock.return_value
     mock_model.generate_content.return_value = mock_response
 
@@ -540,6 +547,7 @@ def test_vertexai_invoke_v2_with_json_schema_response_format(
     ]
     mock_response = Mock()
     mock_response.text = '{"result": "success"}'
+    mock_response.usage_metadata = None
     mock_model = GenerativeModelMock.return_value
     mock_model.generate_content.return_value = mock_response
 
@@ -609,6 +617,7 @@ def test_vertexai_invoke_v2_rate_limit_handler_called(
     messages: List[LLMMessage] = [{"role": "user", "content": "Hello"}]
     mock_response = Mock()
     mock_response.text = "Hi there!"
+    mock_response.usage_metadata = None
     mock_model = GenerativeModelMock.return_value
     mock_model.generate_content.return_value = mock_response
 


### PR DESCRIPTION
# Description

This pull request enhances the LLM response handling across all supported providers by adding token usage tracking. The `LLMResponse` objects returned by each LLM now include an optional `usage` field that provides detailed token counts for requests and responses. This enables better monitoring and analysis of LLM costs and performance.
* Introduced the `LLMUsage` type and updated imports and `__all__` in `src/neo4j_graphrag/llm/__init__.py` to expose it across the package.
* Updated all LLM provider modules (`anthropic_llm.py`, `bedrock_llm.py`, `cohere_llm.py`, `mistralai_llm.py`, `ollama_llm.py`, `openai_llm.py`) to extract token usage information from their respective API responses and include it in the `LLMResponse` via the new `usage` parameter. 
* Ensured that all synchronous and asynchronous invocation methods for each provider now consistently attach usage data to the response, or `None` if unavailable, paving the way for uniform downstream handling and analytics. 

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: low

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [x] CHANGELOG.md updated if appropriate
