### PR TITLE
fix: test embedding float32 followup (GENKGB-1065)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 
 ### Fixed
 
-- Fixed `Neo4jGraphParquetFormatter` uses an explicit PyArrow schema (with embeddings typed as `float32`) derived from the union of all row keys.
+- Fixed `Neo4jGraphParquetFormatter` uses an explicit PyArrow schema (with embeddings typed as `float32`) derived from the union of all row keys. Integer embedding vectors (e.g. all-zero or one-hot) are now also cast to `float32`. Note: columns where only empty lists were observed are typed as `list<null>`, which may not be supported by all downstream consumers (e.g. DuckDB, Spark).
 
 ## 1.14.1
 

--- a/src/neo4j_graphrag/experimental/components/parquet_formatter.py
+++ b/src/neo4j_graphrag/experimental/components/parquet_formatter.py
@@ -539,14 +539,19 @@ class Neo4jGraphParquetFormatter:
                     elif k not in sample and v is not None:
                         sample[k] = v
 
-            fields: list[Any] = []
+            fields: list[pa.Field] = []
             for k in all_keys:
                 if k in sample:
                     t: Any = pa.infer_type([sample[k]])
-                    if pa.types.is_list(t) and pa.types.is_floating(t.value_type):
+                    if pa.types.is_list(t) and (
+                        pa.types.is_floating(t.value_type)
+                        or pa.types.is_integer(t.value_type)
+                    ):
                         t = pa.list_(pa.float32())
                 elif k in has_empty_list:
                     # Only empty lists seen — use list<null> so [] values round-trip correctly.
+                    # Note: list<null> is a known limitation; some consumers (DuckDB, Spark)
+                    # may not handle this type well.
                     t = pa.list_(pa.null())
                 else:
                     t = pa.null()

--- a/tests/unit/experimental/components/test_kg_writer.py
+++ b/tests/unit/experimental/components/test_kg_writer.py
@@ -1111,8 +1111,8 @@ def test_format_parquet_all_rows_empty_list_embedding_does_not_crash() -> None:
     assert "embedding" in table.column_names
     for row in table.to_pylist():
         assert (
-            row["embedding"] == [] or row["embedding"] is None
-        ), f"Expected empty list or null for embedding, got {row['embedding']}"
+            row["embedding"] == []
+        ), f"Expected empty list for embedding, got {row['embedding']}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**Post-review fixes for Neo4jGraphParquetFormatter** - Follow-up to #500

This PR contains the post-review improvements suggested on https://github.com/neo4j/neo4j-graphrag-python/pull/500. 

**Changes:**
- Cast integer embedding vectors (e.g. all-zero or one-hot) to float32, not just float ones                                                                        
- Document the list<null> limitation for empty-list-only columns (known issue with DuckDB/Spark)                                                                    
- Fix test assertion to match the updated behaviour  