### PR TITLE
Add warning to `upsert_vectors` + fix errors in doc generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added `close` and `aclose` methods to `LLMBase` to gracefully close resources.
 
+### Changed
+
+- Make clear in documentation that `upsert_vectors` is not for production.
+
 
 ## 1.15.0
 
@@ -24,6 +28,7 @@
 ### Fixed
 
 - `NodeType`: a node type defined without a `properties` key (e.g. `{"label": "Person"}` or `{"label": "Person", "description": "..."}`) now automatically gets a default `name: STRING` property and `additional_properties=True`, preventing a `ValidationError` from the `min_length=1` constraint. This matches the existing behaviour for string input. Auto-addition is skipped when `properties` is explicitly provided (including as an empty list) or when `additional_properties` is explicitly set to `False`.
+- Fixed `Neo4jGraphParquetFormatter` uses an explicit PyArrow schema (with embeddings typed as `float32`) derived from the union of all row keys. Integer embedding vectors (e.g. all-zero or one-hot) are now also cast to `float32`. Note: columns where only empty lists were observed are typed as `list<null>`, which may not be supported by all downstream consumers (e.g. DuckDB, Spark).
 
 ### Changed
 
@@ -35,9 +40,6 @@
 - SimpleKG pipeline (experimental): the `from_pdf` parameter is deprecated in favor of `from_file` (PDF and Markdown inputs). `from_pdf` still works but emits a deprecation warning and will be removed in a future version.
 - Data loaders (experimental): the `PdfDocument` type name is deprecated in favor of `LoadedDocument`; `PdfDocument` remains available as a backward-compatible alias with a deprecation warning.
 
-### Fixed
-
-- Fixed `Neo4jGraphParquetFormatter` uses an explicit PyArrow schema (with embeddings typed as `float32`) derived from the union of all row keys. Integer embedding vectors (e.g. all-zero or one-hot) are now also cast to `float32`. Note: columns where only empty lists were observed are typed as `list<null>`, which may not be supported by all downstream consumers (e.g. DuckDB, Spark).
 
 ## 1.14.1
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -187,15 +187,12 @@ RetrieverInterface
     :members:
 
 
-.. _vectorretriever:
-
 VectorRetriever
 ===============
 
 .. autoclass:: neo4j_graphrag.retrievers.VectorRetriever
     :members: search
 
-.. _vectorcypherretriever:
 
 VectorCypherRetriever
 =====================
@@ -204,8 +201,6 @@ VectorCypherRetriever
     :members: search
 
 
-.. _hybridretriever:
-
 HybridRetriever
 ===============
 
@@ -213,15 +208,12 @@ HybridRetriever
     :members: search
 
 
-.. _hybridcypherretriever:
-
 HybridCypherRetriever
 =====================
 
 .. autoclass:: neo4j_graphrag.retrievers.HybridCypherRetriever
     :members: search
 
-.. _text2cypherretriever:
 
 Text2CypherRetriever
 =====================
@@ -229,7 +221,6 @@ Text2CypherRetriever
 .. autoclass:: neo4j_graphrag.retrievers.Text2CypherRetriever
     :members: search
 
-.. _toolsretriever:
 
 ToolsRetriever
 ==============
@@ -245,8 +236,6 @@ External Retrievers
 This section includes retrievers that integrate with databases external to Neo4j.
 
 
-.. _weaviateneo4jretriever:
-
 WeaviateNeo4jRetriever
 ======================
 
@@ -254,15 +243,12 @@ WeaviateNeo4jRetriever
     :members: search
 
 
-.. _pineconeneo4jretriever:
-
 PineconeNeo4jRetriever
 ======================
 
 .. autoclass:: neo4j_graphrag.retrievers.external.pinecone.pinecone.PineconeNeo4jRetriever
     :members: search
 
-.. _qdrantneo4jretriever:
 
 QdrantNeo4jRetriever
 ====================

--- a/docs/source/user_guide_rag.rst
+++ b/docs/source/user_guide_rag.rst
@@ -377,6 +377,7 @@ VertexAI Structured Output
 ---------------------------
 
 VertexAI uses `GenerationConfig` with `response_mime_type` and `response_schema` internally when `response_format` is passed to `invoke()`. Both Pydantic models and JSON schemas are supported. **Important**: Additional `GenerationConfig` parameters (e.g., `temperature`, `max_output_tokens`) can be passed as kwargs to `invoke()`.
+
 .. code:: python
 
     from pydantic import BaseModel, ConfigDict
@@ -385,7 +386,6 @@ VertexAI uses `GenerationConfig` with `response_mime_type` and `response_schema`
 
     class Person(BaseModel):
         model_config = ConfigDict(extra="forbid")
-
         name: str
         age: int
 
@@ -393,6 +393,7 @@ VertexAI uses `GenerationConfig` with `response_mime_type` and `response_schema`
     messages = [LLMMessage(role="user", content="Extract: John is 30.")]
     response = llm.invoke(messages, response_format=Person, temperature=0)
     person = Person.model_validate_json(response.content)
+
 
 Rate Limit Handling
 ===================

--- a/docs/source/user_guide_rag.rst
+++ b/docs/source/user_guide_rag.rst
@@ -331,7 +331,6 @@ Structured output enables LLMs to return responses conforming to a predefined sc
 
     class Person(BaseModel):
         model_config = ConfigDict(extra="forbid")  # Required for OpenAI structured output
-        
         name: str
         age: int
         occupation: str
@@ -353,7 +352,7 @@ Structured output enables LLMs to return responses conforming to a predefined sc
 OpenAI Structured Output
 -------------------------
 
-OpenAI supports Pydantic models, JSON schemas, and JSON object mode. **Important**: Pydantic models must include `ConfigDict(extra="forbid")` to generate schemas with `additionalProperties: false`, which is required by OpenAI's strict mode. 
+OpenAI supports Pydantic models, JSON schemas, and JSON object mode. **Important**: Pydantic models must include `ConfigDict(extra="forbid")` to generate schemas with `additionalProperties: false`, which is required by OpenAI's strict mode.
 
 .. code:: python
 
@@ -386,7 +385,7 @@ VertexAI uses `GenerationConfig` with `response_mime_type` and `response_schema`
 
     class Person(BaseModel):
         model_config = ConfigDict(extra="forbid")
-        
+
         name: str
         age: int
 
@@ -452,7 +451,7 @@ You can customize the rate limiting behavior by creating your own rate limit han
 
     class CustomRateLimitHandler(RateLimitHandler):
         """Implement your custom rate limiting strategy."""
-        # Implement required methods: handle_sync, handle_async 
+        # Implement required methods: handle_sync, handle_async
         # and optionally override is_retryable_exception and to_retryable_error
         # to classify additional exception types as retryable or convert them to retryable errors
         pass
@@ -1076,8 +1075,8 @@ See :ref:`text2cypherretriever`.
 
 .. _tools-retriever-user-guide:
 
-ToolsRetriever
---------------
+Tools Retriever
+---------------
 
 The ToolsRetriever uses an LLM to intelligently select and execute appropriate tools based on user queries. This retriever analyzes the user's question using an LLM to determine which tools from a provided set would be most helpful for retrieving relevant information. It can select multiple tools if necessary or none if no tools are appropriate for the query, then combines results from the executed tools with proper attribution. This is particularly useful when different types of information retrieval might be needed for complex queries.
 

--- a/src/neo4j_graphrag/experimental/components/kg_writer.py
+++ b/src/neo4j_graphrag/experimental/components/kg_writer.py
@@ -123,6 +123,7 @@ class KGWriterModel(DataModel):
     Attributes:
         status: Whether the write operation was successful ("SUCCESS" or "FAILURE").
         metadata: Optional dict. When status is SUCCESS, contains at least:
+
             - "statistics": dict with node_count, relationship_count, nodes_per_label,
               rel_per_type, input_files_count, input_files_total_size_bytes.
             - "files": list of file descriptors with file_path, etc. (ParquetWriter).

--- a/src/neo4j_graphrag/indexes.py
+++ b/src/neo4j_graphrag/indexes.py
@@ -260,6 +260,13 @@ def upsert_vectors(
     This method constructs a Cypher query and executes it to upsert
     (insert or update) embeddings on a set of nodes or relationships.
 
+    .. warning::
+
+        This function depends on Neo4j's internal element IDs, which are unsafe to use
+        outside of a transaction. It is intended solely as a helper for low-load
+        databases and must not be used in production environments, where element IDs
+        may be reassigned or overwritten by concurrent transactions.
+
     Example:
 
     .. code-block:: python

--- a/src/neo4j_graphrag/llm/ollama_llm.py
+++ b/src/neo4j_graphrag/llm/ollama_llm.py
@@ -372,16 +372,20 @@ class OllamaLLM(LLMBase):
     ) -> ToolCallResponse:
         """Sends a text input to the LLM with tool definitions
         and retrieves a tool call response.
+
         Args:
             input (str): Text sent to the LLM.
             tools (List[Tool]): List of Tools for the LLM to choose from.
             message_history (Optional[Union[List[LLMMessage], MessageHistory]]): A collection previous messages,
                 with each message having a specific role assigned.
             system_instruction (Optional[str]): An option to override the llm system message for this invocation.
+
         Returns:
             ToolCallResponse: The response from the LLM containing a tool call.
+
         Raises:
             LLMGenerationError: If anything goes wrong.
+
         """
         try:
             if isinstance(message_history, MessageHistory):
@@ -429,14 +433,17 @@ class OllamaLLM(LLMBase):
     ) -> ToolCallResponse:
         """Sends a text input to the LLM with tool definitions
         and retrieves a tool call response.
+
         Args:
             input (str): Text sent to the LLM.
             tools (List[Tool]): List of Tools for the LLM to choose from.
             message_history (Optional[Union[List[LLMMessage], MessageHistory]]): A collection previous messages,
                 with each message having a specific role assigned.
             system_instruction (Optional[str]): An option to override the llm system message for this invocation.
+
         Returns:
             ToolCallResponse: The response from the LLM containing a tool call.
+
         Raises:
             LLMGenerationError: If anything goes wrong.
         """


### PR DESCRIPTION
# Description

Just wanted to add a warning in `upsert_vectors` and ended up fixing the documentation generation which was throwing a bunch of errors.

https://github.com/neo4j/neo4j-graphrag-python/issues/385


## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation update
- [ ] Project configuration change

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High
>
>

Complexity:

## How Has This Been Tested?
- [ ] Unit tests
- [ ] E2E tests
- [x] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [ ] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
