### PR TITLE
Use GraphSchema type instead of dict in ParquetWriter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Make clear in documentation that `upsert_vectors` is not for production.
+- Use typed `GraphSchema` instead of `dict[str, Any]` for improved type safety.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Changed
 
 - Make clear in documentation that `upsert_vectors` is not for production.
-- Use typed `GraphSchema` instead of `dict[str, Any]` for improved type safety.
+- Use typed `GraphSchema` instead of `dict[str, Any]` for improved type safety in `ParquetWriter` and `KGWriter`.
 
 ### Fixed
 

--- a/src/neo4j_graphrag/experimental/components/kg_writer.py
+++ b/src/neo4j_graphrag/experimental/components/kg_writer.py
@@ -38,6 +38,7 @@ from neo4j_graphrag.experimental.components.types import (
     Neo4jNode,
     Neo4jRelationship,
 )
+from neo4j_graphrag.experimental.components.schema import GraphSchema
 from neo4j_graphrag.experimental.pipeline.component import Component, DataModel
 from neo4j_graphrag.neo4j_queries import (
     upsert_node_query,
@@ -359,7 +360,7 @@ class ParquetWriter(KGWriter):
         self,
         graph: Neo4jGraph,
         lexical_graph_config: LexicalGraphConfig = LexicalGraphConfig(),
-        schema: Optional[dict[str, Any]] = None,
+        schema: Optional[GraphSchema] = None,
     ) -> KGWriterModel:
         """Write the knowledge graph to Parquet files via Neo4jGraphParquetFormatter.
 
@@ -367,7 +368,7 @@ class ParquetWriter(KGWriter):
             graph (Neo4jGraph): The knowledge graph to write.
             lexical_graph_config (LexicalGraphConfig): Used by the formatter for
                 lexical graph labels (e.g. __Entity__) and key properties.
-            schema (Optional[dict[str, Any]]): Optional GraphSchema as a dictionary for
+            schema (Optional[GraphSchema]): Optional GraphSchema for
                 UNIQUENESS, KEY, and EXISTENCE constraints. Drives Parquet column metadata
                 (``is_unique`` vs ``is_primary_key``). If not provided, node files use ``__id__``
                 as the only primary-key column.

--- a/src/neo4j_graphrag/experimental/components/parquet_formatter.py
+++ b/src/neo4j_graphrag/experimental/components/parquet_formatter.py
@@ -22,7 +22,6 @@ sanitized for filesystem and Neo4j import compatibility (safe characters:
 from __future__ import annotations
 
 import logging
-from tkinter import constants
 import unicodedata
 import warnings
 from collections import defaultdict
@@ -30,7 +29,11 @@ from dataclasses import dataclass, field
 from io import BytesIO
 from typing import Any, DefaultDict, Optional
 
-from neo4j_graphrag.experimental.components.schema import ConstraintType, GraphConstraintType, GraphSchema
+from neo4j_graphrag.experimental.components.schema import (
+    ConstraintType,
+    GraphConstraintType,
+    GraphSchema,
+)
 from neo4j_graphrag.experimental.components.types import (
     LexicalGraphConfig,
     Neo4jGraph,
@@ -87,14 +90,8 @@ def _constraint_relationship_type_unset(constraint: ConstraintType) -> bool:
 
 
 def _resolve_constraint_property_names(constraint: ConstraintType) -> list[str]:
-    """Resolve property names from a constraint dict (``property_names`` or ``property_name``)."""
-    # ConstraintType has property_names as a list
-    if constraint.property_names:
-        return list(constraint.property_names)
-    # Backward if property_name exists
-    if hasattr(constraint, 'property_name') and constraint.property_name:
-        return [constraint.property_name]
-    return []
+    """Resolve property names from a ConstraintType (always populated via model validator)."""
+    return list(constraint.property_names)
 
 
 def get_uniqueness_property_names_for_node_type(

--- a/src/neo4j_graphrag/experimental/components/parquet_formatter.py
+++ b/src/neo4j_graphrag/experimental/components/parquet_formatter.py
@@ -89,11 +89,6 @@ def _constraint_relationship_type_unset(constraint: ConstraintType) -> bool:
     return rt is None or (isinstance(rt, str) and rt.strip() == "")
 
 
-def _resolve_constraint_property_names(constraint: ConstraintType) -> list[str]:
-    """Resolve property names from a ConstraintType (always populated via model validator)."""
-    return list(constraint.property_names)
-
-
 def get_uniqueness_property_names_for_node_type(
     schema: Optional[GraphSchema], node_label: str
 ) -> list[str]:
@@ -106,7 +101,7 @@ def get_uniqueness_property_names_for_node_type(
             continue
         if constraint.node_type != node_label:
             continue
-        out.extend(_resolve_constraint_property_names(constraint))
+        out.extend(constraint.property_names)
     return out
 
 
@@ -124,7 +119,7 @@ def get_key_property_names_for_node_type(
             continue
         if not _constraint_relationship_type_unset(constraint):
             continue
-        out.extend(_resolve_constraint_property_names(constraint))
+        out.extend(constraint.property_names)
     return out
 
 
@@ -145,9 +140,7 @@ def get_key_constraints_for_node_type(
             continue
         if not _constraint_relationship_type_unset(constraint):
             continue
-        props = _resolve_constraint_property_names(constraint)
-        if props:
-            out.append(tuple(props))
+        out.append(constraint.property_names)
     return out
 
 
@@ -176,9 +169,7 @@ def get_uniqueness_constraints_for_node_type(
             continue
         if constraint.node_type != node_label:
             continue
-        props = _resolve_constraint_property_names(constraint)
-        if props:
-            out.append(tuple(props))
+        out.append(constraint.property_names)
     return out
 
 

--- a/src/neo4j_graphrag/experimental/components/parquet_formatter.py
+++ b/src/neo4j_graphrag/experimental/components/parquet_formatter.py
@@ -22,6 +22,7 @@ sanitized for filesystem and Neo4j import compatibility (safe characters:
 from __future__ import annotations
 
 import logging
+from tkinter import constants
 import unicodedata
 import warnings
 from collections import defaultdict
@@ -29,6 +30,7 @@ from dataclasses import dataclass, field
 from io import BytesIO
 from typing import Any, DefaultDict, Optional
 
+from neo4j_graphrag.experimental.components.schema import ConstraintType, GraphConstraintType, GraphSchema
 from neo4j_graphrag.experimental.components.types import (
     LexicalGraphConfig,
     Neo4jGraph,
@@ -79,47 +81,49 @@ def sanitize_parquet_filestem(name: str) -> str:
     return result
 
 
-def _constraint_relationship_type_unset(constraint: dict[str, Any]) -> bool:
-    rt = constraint.get("relationship_type")
+def _constraint_relationship_type_unset(constraint: ConstraintType) -> bool:
+    rt = constraint.relationship_type
     return rt is None or (isinstance(rt, str) and rt.strip() == "")
 
 
-def _resolve_constraint_property_names(constraint: dict[str, Any]) -> list[str]:
+def _resolve_constraint_property_names(constraint: ConstraintType) -> list[str]:
     """Resolve property names from a constraint dict (``property_names`` or ``property_name``)."""
-    pns = constraint.get("property_names") or ()
-    if pns:
-        return list(pns)
-    pn = constraint.get("property_name", "")
-    return [pn] if pn else []
+    # ConstraintType has property_names as a list
+    if constraint.property_names:
+        return list(constraint.property_names)
+    # Backward if property_name exists
+    if hasattr(constraint, 'property_name') and constraint.property_name:
+        return [constraint.property_name]
+    return []
 
 
 def get_uniqueness_property_names_for_node_type(
-    schema: Optional[dict[str, Any]], node_label: str
+    schema: Optional[GraphSchema], node_label: str
 ) -> list[str]:
     """Property names with a UNIQUENESS constraint for this node label (flat, order as in schema)."""
     if not schema:
         return []
     out: list[str] = []
-    for constraint in schema.get("constraints", ()) or ():
-        if constraint.get("type") != "UNIQUENESS":
+    for constraint in schema.constraints:
+        if constraint.type != GraphConstraintType.UNIQUENESS:
             continue
-        if constraint.get("node_type", "") != node_label:
+        if constraint.node_type != node_label:
             continue
         out.extend(_resolve_constraint_property_names(constraint))
     return out
 
 
 def get_key_property_names_for_node_type(
-    schema: Optional[dict[str, Any]], node_label: str
+    schema: Optional[GraphSchema], node_label: str
 ) -> list[str]:
     """Property names with a KEY constraint (node scope) for this node label (flat)."""
     if not schema:
         return []
     out: list[str] = []
-    for constraint in schema.get("constraints", ()) or ():
-        if constraint.get("type") != "KEY":
+    for constraint in schema.constraints:
+        if constraint.type != GraphConstraintType.KEY:
             continue
-        if constraint.get("node_type", "") != node_label:
+        if constraint.node_type != node_label:
             continue
         if not _constraint_relationship_type_unset(constraint):
             continue
@@ -128,7 +132,7 @@ def get_key_property_names_for_node_type(
 
 
 def get_key_constraints_for_node_type(
-    schema: Optional[dict[str, Any]], node_label: str
+    schema: Optional[GraphSchema], node_label: str
 ) -> list[tuple[str, ...]]:
     """KEY constraints for a node label, preserving composite grouping.
 
@@ -137,10 +141,10 @@ def get_key_constraints_for_node_type(
     if not schema:
         return []
     out: list[tuple[str, ...]] = []
-    for constraint in schema.get("constraints", ()) or ():
-        if constraint.get("type") != "KEY":
+    for constraint in schema.constraints:
+        if constraint.type != GraphConstraintType.KEY:
             continue
-        if constraint.get("node_type", "") != node_label:
+        if constraint.node_type != node_label:
             continue
         if not _constraint_relationship_type_unset(constraint):
             continue
@@ -161,7 +165,7 @@ def _first_single_property_key_name_from_groups(
 
 
 def get_uniqueness_constraints_for_node_type(
-    schema: Optional[dict[str, Any]], node_label: str
+    schema: Optional[GraphSchema], node_label: str
 ) -> list[tuple[str, ...]]:
     """UNIQUENESS constraints for a node label, preserving composite grouping.
 
@@ -170,10 +174,10 @@ def get_uniqueness_constraints_for_node_type(
     if not schema:
         return []
     out: list[tuple[str, ...]] = []
-    for constraint in schema.get("constraints", ()) or ():
-        if constraint.get("type") != "UNIQUENESS":
+    for constraint in schema.constraints:
+        if constraint.type != GraphConstraintType.UNIQUENESS:
             continue
-        if constraint.get("node_type", "") != node_label:
+        if constraint.node_type != node_label:
             continue
         props = _resolve_constraint_property_names(constraint)
         if props:
@@ -182,7 +186,7 @@ def get_uniqueness_constraints_for_node_type(
 
 
 def enrich_key_constraints_for_node_type(
-    schema: Optional[dict[str, Any]], node_label: str
+    schema: Optional[GraphSchema], node_label: str
 ) -> list[tuple[str, ...]]:
     """KEY constraint groups for export metadata, ensuring a single-property KEY exists.
 
@@ -207,7 +211,7 @@ def flatten_key_constraint_property_names(
 
 
 def get_relationship_join_key_property_name(
-    schema: Optional[dict[str, Any]], node_label: str
+    schema: Optional[GraphSchema], node_label: str
 ) -> str:
     """Property used in relationship Parquet ``from``/``to`` and endpoint metadata.
 
@@ -223,7 +227,7 @@ def get_relationship_join_key_property_name(
 
 
 def get_primary_key_column_names_for_node_type(
-    schema: Optional[dict[str, Any]], node_label: str
+    schema: Optional[GraphSchema], node_label: str
 ) -> list[str]:
     """Column names flagged as primary key: enriched KEY properties (see enrich_key_constraints)."""
     return flatten_key_constraint_property_names(
@@ -232,7 +236,7 @@ def get_primary_key_column_names_for_node_type(
 
 
 def get_unique_properties_for_node_type(
-    schema: Optional[dict[str, Any]], node_label: str
+    schema: Optional[GraphSchema], node_label: str
 ) -> list[str]:
     """Deprecated synonym for :func:`get_primary_key_column_names_for_node_type`.
 
@@ -310,7 +314,7 @@ class TypeInfo:
 class Neo4jGraphParquetFormatter:
     """Formats Neo4j graph data into Parquet format."""
 
-    def __init__(self, schema: Optional[dict[str, Any]] = None) -> None:
+    def __init__(self, schema: Optional[GraphSchema] = None) -> None:
         self.schema = schema
 
     @staticmethod

--- a/tests/unit/experimental/components/test_kg_writer.py
+++ b/tests/unit/experimental/components/test_kg_writer.py
@@ -36,6 +36,7 @@ from neo4j_graphrag.experimental.components.kg_writer import (
     ParquetWriter,
     batched,
 )
+from neo4j_graphrag.experimental.components.schema import GraphSchema
 from neo4j_graphrag.experimental.components.types import (
     LexicalGraphConfig,
     Neo4jGraph,
@@ -741,7 +742,9 @@ async def test_parquet_writer_relationship_joins_on_single_property_key() -> Non
             start_node_id="n1", end_node_id="n2", type="KNOWS", properties={}
         )
         graph = Neo4jGraph(nodes=[n1, n2], relationships=[rel])
-        result = await writer.run(graph=graph, schema=schema_dict)
+        result = await writer.run(
+            graph=graph, schema=GraphSchema.model_validate(schema_dict)
+        )
         assert result.status == "SUCCESS"
         assert result.metadata is not None
         rel_file = next(f for f in result.metadata["files"] if not f["is_node"])
@@ -790,7 +793,9 @@ async def test_parquet_writer_columns_uniqueness_sets_is_unique() -> None:
             properties={"email": "a@b.c", "name": "Alice"},
         )
         graph = Neo4jGraph(nodes=[node], relationships=[])
-        result = await writer.run(graph=graph, schema=schema_dict)
+        result = await writer.run(
+            graph=graph, schema=GraphSchema.model_validate(schema_dict)
+        )
         assert result.status == "SUCCESS"
         assert result.metadata is not None
         node_file = next(f for f in result.metadata["files"] if f["is_node"])
@@ -841,7 +846,9 @@ async def test_parquet_writer_columns_key_sets_is_primary_key() -> None:
             properties={"email": "a@b.c", "name": "Alice"},
         )
         graph = Neo4jGraph(nodes=[node], relationships=[])
-        result = await writer.run(graph=graph, schema=schema_dict)
+        result = await writer.run(
+            graph=graph, schema=GraphSchema.model_validate(schema_dict)
+        )
         assert result.status == "SUCCESS"
         assert result.metadata is not None
         node_file = next(f for f in result.metadata["files"] if f["is_node"])
@@ -889,7 +896,9 @@ async def test_parquet_writer_composite_key_constraint() -> None:
             properties={"firstname": "John", "surname": "Smith", "age": 42},
         )
         graph = Neo4jGraph(nodes=[node], relationships=[])
-        result = await writer.run(graph=graph, schema=schema_dict)
+        result = await writer.run(
+            graph=graph, schema=GraphSchema.model_validate(schema_dict)
+        )
         assert result.status == "SUCCESS"
         assert result.metadata is not None
         node_file = next(f for f in result.metadata["files"] if f["is_node"])
@@ -946,7 +955,9 @@ async def test_parquet_writer_composite_uniqueness_constraint() -> None:
             properties={"title": "Neo4j in Action", "year": 2024, "isbn": "123"},
         )
         graph = Neo4jGraph(nodes=[node], relationships=[])
-        result = await writer.run(graph=graph, schema=schema_dict)
+        result = await writer.run(
+            graph=graph, schema=GraphSchema.model_validate(schema_dict)
+        )
         assert result.status == "SUCCESS"
         assert result.metadata is not None
         node_file = next(f for f in result.metadata["files"] if f["is_node"])


### PR DESCRIPTION
# Description

This PR refactors `ParquetWriter` and `parquet_formatter` to use `GraphSchema` objects instead of `dict[str, Any]`, improving type safety and code clarity.


## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [x] Project configuration change

## Complexity

Complexity: Low

## How Has This Been Tested?
- [x] Unit tests
- [x] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [x] CHANGELOG.md updated if appropriate
