### PR TITLE
Include EXISTENCE constraints in metadata emitted by ParquetWriter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added `close` and `aclose` methods to `LLMBase` to gracefully close resources.
+- Experimental: `ParquetWriter` node file `constraints` metadata now includes `EXISTENCE` constraints from `GraphSchema` (alongside existing `KEY` and `UNIQUENESS` entries).
 
 ### Changed
 

--- a/src/neo4j_graphrag/experimental/components/kg_writer.py
+++ b/src/neo4j_graphrag/experimental/components/kg_writer.py
@@ -131,10 +131,12 @@ class KGWriterModel(DataModel):
               Each file entry includes ``columns``: a list of dicts with ``name``, ``type``,
               ``is_primary_key``, and ``is_unique`` (KEY / synthetic ``__id__`` / ``from``/``to``
               vs UNIQUENESS constraints per :class:`~neo4j_graphrag.experimental.components.schema.GraphSchema`).
-              Node files include a ``constraints`` list with at least one single-property ``KEY``
-              (``__id__`` is injected when the schema has none). Relationship files include
-              ``start_node_primary_keys`` / ``end_node_primary_keys`` as a one-element list:
-              the first single-property schema ``KEY`` for that label, or ``__id__``.
+              Node files include a ``constraints`` list with ``KEY``, ``UNIQUENESS``, and node-scoped
+              ``EXISTENCE`` entries (grouped ``properties`` lists), plus at least one single-property
+              ``KEY`` (``__id__`` is injected when the schema has none). Relationship files do not
+              include a ``constraints`` list; they include ``start_node_primary_keys`` /
+              ``end_node_primary_keys`` as a one-element list: the first single-property schema
+              ``KEY`` for that label, or ``__id__``.
     """
 
     status: Literal["SUCCESS", "FAILURE"]
@@ -370,8 +372,9 @@ class ParquetWriter(KGWriter):
                 lexical graph labels (e.g. __Entity__) and key properties.
             schema (Optional[GraphSchema]): Optional GraphSchema for
                 UNIQUENESS, KEY, and EXISTENCE constraints. Drives Parquet column metadata
-                (``is_unique`` vs ``is_primary_key``). If not provided, node files use ``__id__``
-                as the only primary-key column.
+                (``is_unique`` vs ``is_primary_key`` from KEY/UNIQUENESS only). Node-scoped
+                EXISTENCE constraints appear in each node file's ``constraints`` metadata.
+                If not provided, node files use ``__id__`` as the only primary-key column.
         """
         try:
             formatter = Neo4jGraphParquetFormatter(schema=schema)
@@ -421,6 +424,10 @@ class ParquetWriter(KGWriter):
                 for props in meta.uniqueness_constraints or []:
                     constraints_meta.append(
                         {"type": "UNIQUENESS", "properties": list(props)}
+                    )
+                for props in meta.existence_constraints or []:
+                    constraints_meta.append(
+                        {"type": "EXISTENCE", "properties": list(props)}
                     )
                 file_entry: dict[str, Any] = {
                     "name": name,

--- a/src/neo4j_graphrag/experimental/components/parquet_formatter.py
+++ b/src/neo4j_graphrag/experimental/components/parquet_formatter.py
@@ -173,6 +173,24 @@ def get_uniqueness_constraints_for_node_type(
     return out
 
 
+def get_existence_constraints_for_node_type(
+    schema: Optional[GraphSchema], node_label: str
+) -> list[tuple[str, ...]]:
+    """EXISTENCE constraints for a node label (each tuple has exactly one property)."""
+    if not schema:
+        return []
+    out: list[tuple[str, ...]] = []
+    for constraint in schema.constraints:
+        if constraint.type != GraphConstraintType.EXISTENCE:
+            continue
+        if constraint.node_type != node_label:
+            continue
+        if not _constraint_relationship_type_unset(constraint):
+            continue
+        out.append(constraint.property_names)
+    return out
+
+
 def enrich_key_constraints_for_node_type(
     schema: Optional[GraphSchema], node_label: str
 ) -> list[tuple[str, ...]]:
@@ -269,6 +287,7 @@ class FileMetadata:
     # Grouped constraint metadata (preserves composite grouping)
     key_constraints: Optional[list[tuple[str, ...]]] = None
     uniqueness_constraints: Optional[list[tuple[str, ...]]] = None
+    existence_constraints: Optional[list[tuple[str, ...]]] = None
 
 
 @dataclass
@@ -723,6 +742,9 @@ class Neo4jGraphParquetFormatter:
                     ),
                     key_constraints=enriched_keys,
                     uniqueness_constraints=get_uniqueness_constraints_for_node_type(
+                        self.schema, label
+                    ),
+                    existence_constraints=get_existence_constraints_for_node_type(
                         self.schema, label
                     ),
                 )

--- a/tests/unit/experimental/components/test_kg_writer.py
+++ b/tests/unit/experimental/components/test_kg_writer.py
@@ -977,6 +977,133 @@ async def test_parquet_writer_composite_uniqueness_constraint() -> None:
 
 
 @pytest.mark.asyncio
+async def test_parquet_writer_existence_constraint_in_metadata() -> None:
+    """Node-scoped EXISTENCE appears in structured constraints; synthetic KEY on __id__ remains."""
+    pytest.importorskip("pyarrow")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = Path(tmpdir)
+        dest = _LocalParquetDestination(out)
+        writer = ParquetWriter(
+            nodes_dest=dest,
+            relationships_dest=dest,
+            collision_handler=FilenameCollisionHandler(),
+        )
+        schema_dict: dict[str, Any] = {
+            "node_types": [
+                {
+                    "label": "Person",
+                    "properties": [
+                        {"name": "name", "type": "STRING"},
+                        {"name": "email", "type": "STRING"},
+                    ],
+                }
+            ],
+            "constraints": [
+                {
+                    "type": "EXISTENCE",
+                    "node_type": "Person",
+                    "property_names": ["name"],
+                    "relationship_type": None,
+                }
+            ],
+        }
+        node = Neo4jNode(
+            id="n1",
+            label="Person",
+            properties={"name": "Alice", "email": "a@b.c"},
+        )
+        graph = Neo4jGraph(nodes=[node], relationships=[])
+        result = await writer.run(
+            graph=graph, schema=GraphSchema.model_validate(schema_dict)
+        )
+        assert result.status == "SUCCESS"
+        assert result.metadata is not None
+        node_file = next(f for f in result.metadata["files"] if f["is_node"])
+        existence_cs = [c for c in node_file["constraints"] if c["type"] == "EXISTENCE"]
+        assert existence_cs == [{"type": "EXISTENCE", "properties": ["name"]}]
+        key_cs = [c for c in node_file["constraints"] if c["type"] == "KEY"]
+        assert key_cs == [{"type": "KEY", "properties": [INTERNAL_ID_PROPERTY]}]
+        cols = {c["name"]: c for c in node_file["columns"]}
+        assert cols["name"]["is_primary_key"] is False
+        assert cols["name"]["is_unique"] is False
+
+
+@pytest.mark.asyncio
+async def test_parquet_writer_key_uniqueness_existence_constraints_metadata() -> None:
+    """KEY, UNIQUENESS, and EXISTENCE all appear in constraints; EXISTENCE does not alter column flags."""
+    pytest.importorskip("pyarrow")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = Path(tmpdir)
+        dest = _LocalParquetDestination(out)
+        writer = ParquetWriter(
+            nodes_dest=dest,
+            relationships_dest=dest,
+            collision_handler=FilenameCollisionHandler(),
+        )
+        schema_dict: dict[str, Any] = {
+            "node_types": [
+                {
+                    "label": "Person",
+                    "properties": [
+                        {"name": "email", "type": "STRING"},
+                        {"name": "external_id", "type": "STRING"},
+                        {"name": "name", "type": "STRING"},
+                    ],
+                }
+            ],
+            "constraints": [
+                {
+                    "type": "KEY",
+                    "node_type": "Person",
+                    "property_names": ["email"],
+                    "relationship_type": None,
+                },
+                {
+                    "type": "UNIQUENESS",
+                    "node_type": "Person",
+                    "property_names": ["external_id"],
+                    "relationship_type": None,
+                },
+                {
+                    "type": "EXISTENCE",
+                    "node_type": "Person",
+                    "property_names": ["name"],
+                    "relationship_type": None,
+                },
+            ],
+        }
+        node = Neo4jNode(
+            id="n1",
+            label="Person",
+            properties={
+                "email": "a@b.c",
+                "external_id": "ext-1",
+                "name": "Alice",
+            },
+        )
+        graph = Neo4jGraph(nodes=[node], relationships=[])
+        result = await writer.run(
+            graph=graph, schema=GraphSchema.model_validate(schema_dict)
+        )
+        assert result.status == "SUCCESS"
+        assert result.metadata is not None
+        node_file = next(f for f in result.metadata["files"] if f["is_node"])
+        cs = node_file["constraints"]
+        assert {"type": "KEY", "properties": ["email"]} in cs
+        assert {"type": "UNIQUENESS", "properties": ["external_id"]} in cs
+        assert {"type": "EXISTENCE", "properties": ["name"]} in cs
+        cols = {c["name"]: c for c in node_file["columns"]}
+        assert cols["email"]["is_primary_key"] is True
+        assert cols["email"]["is_unique"] is False
+        assert cols["external_id"]["is_primary_key"] is False
+        assert cols["external_id"]["is_unique"] is True
+        assert cols["name"]["is_primary_key"] is False
+        assert cols["name"]["is_unique"] is False
+
+
+@pytest.mark.asyncio
 async def test_parquet_writer_run_empty_graph() -> None:
     """ParquetWriter accepts an empty graph and writes no files."""
     pytest.importorskip("pyarrow")


### PR DESCRIPTION
# Description

## Summary

Extends experimental `ParquetWriter` success metadata so each **node** Parquet file’s `files[].constraints` list includes **`EXISTENCE`** entries derived from `GraphSchema`, in addition to existing **`KEY`** and **`UNIQUENESS`** entries.


## Changes

- **`Neo4jGraphParquetFormatter`**: `get_existence_constraints_for_node_type()`, `FileMetadata.existence_constraints`, populated for node files only.
- **`ParquetWriter`**: emits `{"type": "EXISTENCE", "properties": [...]}` alongside KEY/UNIQUENESS; docstrings updated (`KGWriterModel`, `ParquetWriter.run`).
- **Tests**: existence-only schema + mixed KEY / UNIQUENESS / EXISTENCE on one label.
- **CHANGELOG**: note under `## Next` → Added.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Low

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
- [x] CHANGELOG.md updated if appropriate
