### PR TITLE
Remove relationship types from uniqueness constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Experimental: `wire_extraction_constraints_for_graph_schema` now nulls out `relationship_type` whenever `type == "UNIQUENESS"`, preventing a `validate_constraint_shape` `ValueError` when an LLM emits a stray `relationship_type` alongside a UNIQUENESS constraint (only node-level UNIQUENESS is supported).
+- Experimental: `wire_extraction_constraints_for_graph_schema` now removes `relationship_type` whenever `type == "UNIQUENESS"`, preventing a `validate_constraint_shape` `ValueError` when an LLM emits a stray `relationship_type` alongside a UNIQUENESS constraint (only node-level UNIQUENESS is supported).
 
 ## 1.16.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+### Fixed
+
+- Experimental: `wire_extraction_constraints_for_graph_schema` now nulls out `relationship_type` whenever `type == "UNIQUENESS"`, preventing a `validate_constraint_shape` `ValueError` when an LLM emits a stray `relationship_type` alongside a UNIQUENESS constraint (only node-level UNIQUENESS is supported).
+
 ## 1.16.0
 
 ### Added

--- a/src/neo4j_graphrag/experimental/components/graph_schema_extraction.py
+++ b/src/neo4j_graphrag/experimental/components/graph_schema_extraction.py
@@ -91,12 +91,15 @@ def wire_extraction_constraints_for_graph_schema(
     """Map extraction constraint dicts to values compatible with :class:`~neo4j_graphrag.experimental.components.schema.ConstraintType`.
 
     Empty ``relationship_type`` (the wire \"unset\" sentinel) becomes ``None`` for runtime validation.
+    UNIQUENESS constraints always have ``relationship_type`` nulled out, since only node-level UNIQUENESS is supported.
     """
     out: list[dict[str, Any]] = []
     for c in constraints:
         d = dict(c)
         rt = d.get("relationship_type")
-        if rt is None or (isinstance(rt, str) and rt.strip() == ""):
+        if d.get("type") == "UNIQUENESS":
+            d["relationship_type"] = None
+        elif rt is None or (isinstance(rt, str) and rt.strip() == ""):
             d["relationship_type"] = None
         out.append(d)
     return out

--- a/src/neo4j_graphrag/experimental/components/graph_schema_extraction.py
+++ b/src/neo4j_graphrag/experimental/components/graph_schema_extraction.py
@@ -91,16 +91,17 @@ def wire_extraction_constraints_for_graph_schema(
     """Map extraction constraint dicts to values compatible with :class:`~neo4j_graphrag.experimental.components.schema.ConstraintType`.
 
     Empty ``relationship_type`` (the wire \"unset\" sentinel) becomes ``None`` for runtime validation.
-    UNIQUENESS constraints always have ``relationship_type`` nulled out, since only node-level UNIQUENESS is supported.
+    UNIQUENESS constraints have ``relationship_type`` removed entirely, since only node-level UNIQUENESS is supported.
     """
     out: list[dict[str, Any]] = []
     for c in constraints:
         d = dict(c)
-        rt = d.get("relationship_type")
         if d.get("type") == "UNIQUENESS":
-            d["relationship_type"] = None
-        elif rt is None or (isinstance(rt, str) and rt.strip() == ""):
-            d["relationship_type"] = None
+            d.pop("relationship_type", None)
+        else:
+            rt = d.get("relationship_type")
+            if rt is None or (isinstance(rt, str) and rt.strip() == ""):
+                d["relationship_type"] = None
         out.append(d)
     return out
 

--- a/src/neo4j_graphrag/experimental/components/graph_schema_extraction.py
+++ b/src/neo4j_graphrag/experimental/components/graph_schema_extraction.py
@@ -90,8 +90,10 @@ def wire_extraction_constraints_for_graph_schema(
 ) -> list[dict[str, Any]]:
     """Map extraction constraint dicts to values compatible with :class:`~neo4j_graphrag.experimental.components.schema.ConstraintType`.
 
-    Empty ``relationship_type`` (the wire \"unset\" sentinel) becomes ``None`` for runtime validation.
-    UNIQUENESS constraints have ``relationship_type`` removed entirely, since only node-level UNIQUENESS is supported.
+    The empty-string ``relationship_type`` wire sentinel (and any missing or ``None`` value) is removed,
+    so that :class:`~neo4j_graphrag.experimental.components.schema.ConstraintType` falls back to its
+    default. UNIQUENESS constraints also have ``relationship_type`` removed regardless of value, since
+    only node-level UNIQUENESS is supported.
     """
     out: list[dict[str, Any]] = []
     for c in constraints:
@@ -101,7 +103,7 @@ def wire_extraction_constraints_for_graph_schema(
         else:
             rt = d.get("relationship_type")
             if rt is None or (isinstance(rt, str) and rt.strip() == ""):
-                d["relationship_type"] = None
+                d.pop("relationship_type", None)
         out.append(d)
     return out
 

--- a/src/neo4j_graphrag/experimental/components/graph_schema_extraction.py
+++ b/src/neo4j_graphrag/experimental/components/graph_schema_extraction.py
@@ -98,12 +98,15 @@ def wire_extraction_constraints_for_graph_schema(
     out: list[dict[str, Any]] = []
     for c in constraints:
         d = dict(c)
-        if d.get("type") == "UNIQUENESS":
+
+        rt = d.get("relationship_type")
+
+        if (
+            d.get("type") == "UNIQUENESS"
+            or rt is None
+            or (isinstance(rt, str) and rt.strip() == "")
+        ):
             d.pop("relationship_type", None)
-        else:
-            rt = d.get("relationship_type")
-            if rt is None or (isinstance(rt, str) and rt.strip() == ""):
-                d.pop("relationship_type", None)
         out.append(d)
     return out
 

--- a/tests/unit/experimental/components/test_graph_schema_extraction.py
+++ b/tests/unit/experimental/components/test_graph_schema_extraction.py
@@ -56,7 +56,9 @@ def test_wire_extraction_constraints_drops_relationship_type_for_uniqueness() ->
         assert "relationship_type" not in entry
 
 
-def test_wire_extraction_constraints_empty_relationship_type_becomes_none_for_non_uniqueness() -> None:
+def test_wire_extraction_constraints_empty_relationship_type_becomes_none_for_non_uniqueness() -> (
+    None
+):
     """For non-UNIQUENESS constraints, empty/null ``relationship_type`` becomes ``None``."""
     out = wire_extraction_constraints_for_graph_schema(
         [

--- a/tests/unit/experimental/components/test_graph_schema_extraction.py
+++ b/tests/unit/experimental/components/test_graph_schema_extraction.py
@@ -28,8 +28,8 @@ from neo4j_graphrag.experimental.components.graph_schema_extraction import (
 from neo4j_graphrag.experimental.components.schema import GraphSchema, Pattern
 
 
-def test_wire_extraction_constraints_empty_and_null_become_none() -> None:
-    """Maps ``\"\"`` and legacy ``null`` to ``None`` for :class:`ConstraintType`."""
+def test_wire_extraction_constraints_drops_relationship_type_for_uniqueness() -> None:
+    """UNIQUENESS constraints always have ``relationship_type`` removed entirely, regardless of its emitted value."""
     out = wire_extraction_constraints_for_graph_schema(
         [
             {
@@ -44,25 +44,38 @@ def test_wire_extraction_constraints_empty_and_null_become_none() -> None:
                 "property_names": ["id"],
                 "relationship_type": None,
             },
-        ]
-    )
-    assert out[0]["relationship_type"] is None
-    assert out[1]["relationship_type"] is None
-
-
-def test_wire_extraction_constraints_nulls_relationship_type_for_uniqueness() -> None:
-    """UNIQUENESS constraints always have ``relationship_type`` nulled out, even when the LLM emits a non-empty value."""
-    out = wire_extraction_constraints_for_graph_schema(
-        [
             {
                 "type": "UNIQUENESS",
-                "node_type": "Person",
-                "property_names": ["id"],
+                "node_type": "Book",
+                "property_names": ["isbn"],
                 "relationship_type": "KNOWS",
             },
         ]
     )
+    for entry in out:
+        assert "relationship_type" not in entry
+
+
+def test_wire_extraction_constraints_empty_relationship_type_becomes_none_for_non_uniqueness() -> None:
+    """For non-UNIQUENESS constraints, empty/null ``relationship_type`` becomes ``None``."""
+    out = wire_extraction_constraints_for_graph_schema(
+        [
+            {
+                "type": "EXISTENCE",
+                "node_type": "Person",
+                "property_names": ["name"],
+                "relationship_type": "",
+            },
+            {
+                "type": "KEY",
+                "node_type": "Person",
+                "property_names": ["id"],
+                "relationship_type": None,
+            },
+        ]
+    )
     assert out[0]["relationship_type"] is None
+    assert out[1]["relationship_type"] is None
 
 
 def test_wire_extraction_constraints_preserves_relationship_scoped_existence() -> None:

--- a/tests/unit/experimental/components/test_graph_schema_extraction.py
+++ b/tests/unit/experimental/components/test_graph_schema_extraction.py
@@ -17,9 +17,6 @@
 
 from __future__ import annotations
 
-import pytest
-
-from neo4j_graphrag.exceptions import SchemaExtractionError
 from neo4j_graphrag.experimental.components.graph_schema_extraction import (
     ExtractedConstraintType,
     ExtractedNodeType,
@@ -53,6 +50,21 @@ def test_wire_extraction_constraints_empty_and_null_become_none() -> None:
     assert out[1]["relationship_type"] is None
 
 
+def test_wire_extraction_constraints_nulls_relationship_type_for_uniqueness() -> None:
+    """UNIQUENESS constraints always have ``relationship_type`` nulled out, even when the LLM emits a non-empty value."""
+    out = wire_extraction_constraints_for_graph_schema(
+        [
+            {
+                "type": "UNIQUENESS",
+                "node_type": "Person",
+                "property_names": ["id"],
+                "relationship_type": "KNOWS",
+            },
+        ]
+    )
+    assert out[0]["relationship_type"] is None
+
+
 def test_wire_extraction_constraints_preserves_relationship_scoped_existence() -> None:
     out = wire_extraction_constraints_for_graph_schema(
         [
@@ -67,8 +79,8 @@ def test_wire_extraction_constraints_preserves_relationship_scoped_existence() -
     assert out[0]["relationship_type"] == "KNOWS"
 
 
-def test_uniqueness_with_relationship_type_fails_at_graph_schema_validation() -> None:
-    """If a bad constraint survives extraction filters, :class:`ConstraintType` rejects it."""
+def test_uniqueness_with_relationship_type_is_sanitized_by_wire_conversion() -> None:
+    """A stray ``relationship_type`` on a UNIQUENESS constraint is nulled out before runtime validation."""
     dto = GraphSchemaExtractionOutput(
         node_types=[
             ExtractedNodeType(
@@ -87,8 +99,10 @@ def test_uniqueness_with_relationship_type_fails_at_graph_schema_validation() ->
             ),
         ],
     )
-    with pytest.raises(SchemaExtractionError):
-        GraphSchema.from_extraction_output(dto)
+    gs = GraphSchema.from_extraction_output(dto)
+    assert len(gs.constraints) == 1
+    assert gs.constraints[0].relationship_type is None
+    assert gs.constraints[0].node_type == "Person"
 
 
 def test_invalid_constraints_dropped_by_extraction_filters_without_error() -> None:

--- a/tests/unit/experimental/components/test_graph_schema_extraction.py
+++ b/tests/unit/experimental/components/test_graph_schema_extraction.py
@@ -56,10 +56,10 @@ def test_wire_extraction_constraints_drops_relationship_type_for_uniqueness() ->
         assert "relationship_type" not in entry
 
 
-def test_wire_extraction_constraints_empty_relationship_type_becomes_none_for_non_uniqueness() -> (
+def test_wire_extraction_constraints_drops_empty_relationship_type_for_non_uniqueness() -> (
     None
 ):
-    """For non-UNIQUENESS constraints, empty/null ``relationship_type`` becomes ``None``."""
+    """For non-UNIQUENESS constraints, empty/null ``relationship_type`` is removed so the runtime default applies."""
     out = wire_extraction_constraints_for_graph_schema(
         [
             {
@@ -76,8 +76,8 @@ def test_wire_extraction_constraints_empty_relationship_type_becomes_none_for_no
             },
         ]
     )
-    assert out[0]["relationship_type"] is None
-    assert out[1]["relationship_type"] is None
+    assert "relationship_type" not in out[0]
+    assert "relationship_type" not in out[1]
 
 
 def test_wire_extraction_constraints_preserves_relationship_scoped_existence() -> None:


### PR DESCRIPTION
# Description

This pull request fixes an issue in the experimental graph schema extraction logic where a `relationship_type` field could be incorrectly included in UNIQUENESS constraints, which only support node-level uniqueness. The update ensures that any `relationship_type` is removed from UNIQUENESS constraints before validation, preventing runtime errors. The tests have been updated and expanded to verify this behavior and to clarify how empty or null `relationship_type` values are handled for other constraint types.

* The `wire_extraction_constraints_for_graph_schema` function now removes the `relationship_type` field from any constraint where `type == "UNIQUENESS"`, regardless of its value, ensuring only node-level UNIQUENESS is supported and preventing validation errors.
* For non-UNIQUENESS constraints, empty-string or null `relationship_type` values are now removed entirely, so the runtime default applies.
* Added and updated tests to verify that `relationship_type` is always removed from UNIQUENESS constraints, and that empty or null values are handled correctly for other types. 
* Updated the docstring for `wire_extraction_constraints_for_graph_schema` to reflect the new handling of `relationship_type`.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: low

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [x] CHANGELOG.md updated if appropriate
