### PR TITLE
Improve unit-test coverage for the async tool-calling paths in `OpenAILLM` and `OllamaLLM`

### DIFF
--- a/tests/unit/llm/test_ollama_llm.py
+++ b/tests/unit/llm/test_ollama_llm.py
@@ -651,6 +651,81 @@ def test_ollama_llm_invoke_with_tools_error(mock_import: Mock, test_tool: Tool) 
         llm.invoke_with_tools("my text", tools)
 
 
+@pytest.mark.asyncio
+@patch("builtins.__import__")
+async def test_ollama_llm_ainvoke_with_tools_happy_path(
+    mock_import: Mock, test_tool: Tool
+) -> None:
+    mock_ollama = get_mock_ollama()
+    mock_import.return_value = mock_ollama
+
+    mock_function = MagicMock()
+    mock_function.name = "test_tool"
+    mock_function.arguments = {"param1": "value1"}
+
+    mock_tool_call = MagicMock()
+    mock_tool_call.function = mock_function
+
+    async def mock_chat_async(*_args: Any, **_kwargs: Any) -> MagicMock:
+        return MagicMock(
+            message=MagicMock(
+                content="ollama tool response", tool_calls=[mock_tool_call]
+            )
+        )
+
+    mock_ollama.AsyncClient.return_value.chat = mock_chat_async
+
+    llm = OllamaLLM(model_name="gpt", model_params={"options": {"temperature": 0}})
+    res = await llm.ainvoke_with_tools("my text", [test_tool])
+
+    assert isinstance(res, ToolCallResponse)
+    assert len(res.tool_calls) == 1
+    assert res.tool_calls[0].name == "test_tool"
+    assert res.tool_calls[0].arguments == {"param1": "value1"}
+    assert res.content == "ollama tool response"
+
+
+@pytest.mark.asyncio
+@patch("builtins.__import__")
+async def test_ollama_llm_ainvoke_with_tools_no_tool_calls(
+    mock_import: Mock, test_tool: Tool
+) -> None:
+    """When the model returns no tool_calls, content is returned with empty tool_calls."""
+    mock_ollama = get_mock_ollama()
+    mock_import.return_value = mock_ollama
+
+    async def mock_chat_async(*_args: Any, **_kwargs: Any) -> MagicMock:
+        return MagicMock(message=MagicMock(content="plain content", tool_calls=[]))
+
+    mock_ollama.AsyncClient.return_value.chat = mock_chat_async
+
+    llm = OllamaLLM(model_name="gpt", model_params={"options": {"temperature": 0}})
+    res = await llm.ainvoke_with_tools("my text", [test_tool])
+
+    assert isinstance(res, ToolCallResponse)
+    assert res.tool_calls == []
+    assert res.content == "plain content"
+
+
+@pytest.mark.asyncio
+@patch("builtins.__import__")
+async def test_ollama_llm_ainvoke_with_tools_error(
+    mock_import: Mock, test_tool: Tool
+) -> None:
+    """ResponseError from the async client surfaces as LLMGenerationError."""
+    mock_ollama = get_mock_ollama()
+    mock_import.return_value = mock_ollama
+
+    async def mock_chat_async_error(*_args: Any, **_kwargs: Any) -> None:
+        raise ollama.ResponseError("async tool error")
+
+    mock_ollama.AsyncClient.return_value.chat = mock_chat_async_error
+
+    llm = OllamaLLM(model_name="gpt", model_params={"options": {"temperature": 0}})
+    with pytest.raises(LLMGenerationError):
+        await llm.ainvoke_with_tools("my text", [test_tool])
+
+
 class _TestModelForOllama(BaseModel):
     """Test model for structured output tests."""
 

--- a/tests/unit/llm/test_openai_llm.py
+++ b/tests/unit/llm/test_openai_llm.py
@@ -465,6 +465,124 @@ async def test_openai_llm_ainvoke_happy_path(mock_import: Mock) -> None:
     assert response.content == "Return text"
 
 
+@pytest.mark.asyncio
+@patch("builtins.__import__")
+@patch("json.loads")
+async def test_openai_llm_ainvoke_with_tools_happy_path(
+    mock_json_loads: Mock,
+    mock_import: Mock,
+    test_tool: Tool,
+) -> None:
+    mock_json_loads.return_value = {"param1": "value1"}
+
+    mock_openai = get_mock_openai()
+    mock_import.return_value = mock_openai
+
+    mock_function = MagicMock()
+    mock_function.name = "test_tool"
+    mock_function.arguments = '{"param1": "value1"}'
+
+    mock_tool_call = MagicMock()
+    mock_tool_call.function = mock_function
+
+    async def async_create(*args: Any, **kwargs: Any) -> MagicMock:
+        return MagicMock(
+            choices=[
+                MagicMock(
+                    message=MagicMock(
+                        content="openai tool response", tool_calls=[mock_tool_call]
+                    )
+                )
+            ],
+        )
+
+    mock_openai.AsyncOpenAI.return_value.chat.completions.create = async_create
+
+    llm = OpenAILLM(api_key="my key", model_name="gpt")
+    res = await llm.ainvoke_with_tools("my text", [test_tool])
+
+    assert isinstance(res, ToolCallResponse)
+    assert len(res.tool_calls) == 1
+    assert res.tool_calls[0].name == "test_tool"
+    assert res.tool_calls[0].arguments == {"param1": "value1"}
+    assert res.content == "openai tool response"
+
+
+@pytest.mark.asyncio
+@patch("builtins.__import__")
+async def test_openai_llm_ainvoke_with_tools_no_tool_calls(
+    mock_import: Mock, test_tool: Tool
+) -> None:
+    """When the model returns no tool_calls, content is returned as a regular response."""
+    mock_openai = get_mock_openai()
+    mock_import.return_value = mock_openai
+
+    async def async_create(*args: Any, **kwargs: Any) -> MagicMock:
+        return MagicMock(
+            choices=[MagicMock(message=MagicMock(content="plain text", tool_calls=[]))],
+        )
+
+    mock_openai.AsyncOpenAI.return_value.chat.completions.create = async_create
+
+    llm = OpenAILLM(api_key="my key", model_name="gpt")
+    res = await llm.ainvoke_with_tools("my text", [test_tool])
+
+    assert isinstance(res, ToolCallResponse)
+    assert len(res.tool_calls) == 1
+    assert res.tool_calls[0].name == ""
+    assert res.tool_calls[0].arguments == {}
+    assert res.content == "plain text"
+
+
+@pytest.mark.asyncio
+@patch("builtins.__import__")
+async def test_openai_llm_ainvoke_with_tools_invalid_arguments(
+    mock_import: Mock, test_tool: Tool
+) -> None:
+    """Malformed JSON in tool_call arguments raises LLMGenerationError."""
+    mock_openai = get_mock_openai()
+    mock_import.return_value = mock_openai
+
+    mock_function = MagicMock()
+    mock_function.name = "test_tool"
+    mock_function.arguments = "not-json"
+
+    mock_tool_call = MagicMock()
+    mock_tool_call.function = mock_function
+
+    async def async_create(*args: Any, **kwargs: Any) -> MagicMock:
+        return MagicMock(
+            choices=[
+                MagicMock(message=MagicMock(content=None, tool_calls=[mock_tool_call]))
+            ],
+        )
+
+    mock_openai.AsyncOpenAI.return_value.chat.completions.create = async_create
+
+    llm = OpenAILLM(api_key="my key", model_name="gpt")
+    with pytest.raises(LLMGenerationError):
+        await llm.ainvoke_with_tools("my text", [test_tool])
+
+
+@pytest.mark.asyncio
+@patch("builtins.__import__")
+async def test_openai_llm_ainvoke_with_tools_error(
+    mock_import: Mock, test_tool: Tool
+) -> None:
+    """OpenAIError from the async client surfaces as LLMGenerationError."""
+    mock_openai = get_mock_openai()
+    mock_import.return_value = mock_openai
+
+    async def async_create(*args: Any, **kwargs: Any) -> MagicMock:
+        raise openai.OpenAIError("async test error")
+
+    mock_openai.AsyncOpenAI.return_value.chat.completions.create = async_create
+
+    llm = OpenAILLM(api_key="my key", model_name="gpt")
+    with pytest.raises(LLMGenerationError):
+        await llm.ainvoke_with_tools("my text", [test_tool])
+
+
 # LLM Interface V2 Tests
 
 


### PR DESCRIPTION
# Description

This pull request adds comprehensive asynchronous test coverage for the `ainvoke_with_tools` method in both the `OllamaLLM` and `OpenAILLM` classes. The new tests ensure correct handling of tool call responses, error propagation, and edge cases such as missing or malformed tool call arguments. This improves the reliability and robustness of the LLM integration by verifying expected behaviors under various scenarios.

* Added tests for successful tool call responses, cases with no tool calls, and error handling in the `ainvoke_with_tools` method of `OllamaLLM` (`test_ollama_llm_ainvoke_with_tools_happy_path`, `test_ollama_llm_ainvoke_with_tools_no_tool_calls`, `test_ollama_llm_ainvoke_with_tools_error`).
* Added tests for successful tool call responses, cases with no tool calls, malformed tool call arguments, and error handling in the `ainvoke_with_tools` method of `OpenAILLM` (`test_openai_llm_ainvoke_with_tools_happy_path`, `test_openai_llm_ainvoke_with_tools_no_tool_calls`, `test_openai_llm_ainvoke_with_tools_invalid_arguments`, `test_openai_llm_ainvoke_with_tools_error`).


## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: low

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
