### PR TITLE
Return vector indexes in the ParquetWriter results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Next
 
+### Added
+
+- Vector index for all nodes embedding properties in the ParquetWriter result metadata.
+
+
 ## 1.16.1
 
 ### Added

--- a/src/neo4j_graphrag/experimental/components/kg_writer.py
+++ b/src/neo4j_graphrag/experimental/components/kg_writer.py
@@ -439,6 +439,8 @@ class ParquetWriter(KGWriter):
                 }
                 if constraints_meta:
                     file_entry["constraints"] = constraints_meta
+                if meta.indexes:
+                    file_entry["indexes"] = meta.indexes
                 files.append(file_entry)
 
             base_rel = self.relationships_dest.output_path.rstrip("/")

--- a/src/neo4j_graphrag/experimental/components/kg_writer.py
+++ b/src/neo4j_graphrag/experimental/components/kg_writer.py
@@ -133,11 +133,18 @@ class KGWriterModel(DataModel):
               vs UNIQUENESS constraints per :class:`~neo4j_graphrag.experimental.components.schema.GraphSchema`).
               Node files include a ``constraints`` list with ``KEY``, ``UNIQUENESS``, and node-scoped
               ``EXISTENCE`` entries (grouped ``properties`` lists), plus at least one single-property
-              ``KEY`` (``__id__`` is injected when the schema has none). Relationship files include
-              a ``constraints`` list with ``KEY``, ``UNIQUENESS``, and relationship-scoped
-              ``EXISTENCE`` entries when the schema defines them (key absent when none exist), plus
-              ``start_node_primary_keys`` / ``end_node_primary_keys`` as a one-element list: the
-              first single-property schema ``KEY`` for that label, or ``__id__``.
+              ``KEY`` (``__id__`` is injected when the schema has none). Node files whose
+              source ``Neo4jNode.embedding_properties`` contain one or more keys also include
+              an ``indexes`` list: one ``VECTOR`` entry per embedding property
+              (``properties``: ``[name]``, ``dimensions``: inferred from the first non-empty
+              embedding or ``None`` if absent, ``similarity``: ``"cosine"``). This covers the
+              lexical-graph Chunk file (where the chunk embedder populates
+              ``embedding_properties``) as well as any entity-level embeddings.
+              Relationship files include a ``constraints`` list with ``KEY``, ``UNIQUENESS``,
+              and relationship-scoped ``EXISTENCE`` entries when the schema defines them
+              (key absent when none exist), plus ``start_node_primary_keys`` /
+              ``end_node_primary_keys`` as a one-element list: the first single-property schema
+              ``KEY`` for that label, or ``__id__``.
     """
 
     status: Literal["SUCCESS", "FAILURE"]

--- a/src/neo4j_graphrag/experimental/components/parquet_formatter.py
+++ b/src/neo4j_graphrag/experimental/components/parquet_formatter.py
@@ -821,7 +821,7 @@ class Neo4jGraphParquetFormatter:
             indexes_meta: Optional[list[dict[str, Any]]] = (
                 [
                     build_vector_index_for_property(name, dims_for_label[name])
-                    for name in sorted(dims_for_label)
+                    for name in dims_for_label
                 ]
                 if dims_for_label
                 else None

--- a/src/neo4j_graphrag/experimental/components/parquet_formatter.py
+++ b/src/neo4j_graphrag/experimental/components/parquet_formatter.py
@@ -173,6 +173,24 @@ def get_uniqueness_constraints_for_node_type(
     return out
 
 
+def build_vector_index_for_property(
+    embedding_property_name: str,
+    dimensions: Optional[int],
+) -> dict[str, Any]:
+    """Build a VECTOR index descriptor for an embedding property on a node file.
+
+    ``dimensions`` is the inferred embedding length, or ``None`` if no concrete
+    embedding has been seen — in which case the consumer decides whether to
+    materialize the index.
+    """
+    return {
+        "type": "VECTOR",
+        "properties": [embedding_property_name],
+        "dimensions": dimensions,
+        "similarity": "cosine",
+    }
+
+
 def get_existence_constraints_for_node_type(
     schema: Optional[GraphSchema], node_label: str
 ) -> list[tuple[str, ...]]:
@@ -336,6 +354,8 @@ class FileMetadata:
     key_constraints: Optional[list[tuple[str, ...]]] = None
     uniqueness_constraints: Optional[list[tuple[str, ...]]] = None
     existence_constraints: Optional[list[tuple[str, ...]]] = None
+    # Index metadata (e.g. VECTOR index on lexical-graph Chunk embedding)
+    indexes: Optional[list[dict[str, Any]]] = None
 
 
 @dataclass
@@ -493,15 +513,33 @@ class Neo4jGraphParquetFormatter:
         # Default fallback
         return TypeInfo(source_type="string", target_type="string", is_array=False)
 
-    def _nodes_to_rows(
+    def _process_nodes(
         self,
         nodes: list[Neo4jNode],
         lexical_graph_config: LexicalGraphConfig,
-    ) -> DefaultDict[str, list[dict[str, Any]]]:
-        """Convert Neo4jNode objects to row dictionaries."""
+    ) -> tuple[
+        DefaultDict[str, list[dict[str, Any]]],
+        dict[str, Neo4jNode],
+        DefaultDict[str, dict[str, Optional[int]]],
+    ]:
+        """Single-pass traversal of *nodes* producing every per-node derivation.
+
+        Returns:
+            label_to_rows: row dicts grouped by node label.
+            node_id_to_node: id → Neo4jNode lookup for relationship endpoint resolution.
+            label_to_embedding_dims: per label, per embedding property name, the
+                dimension inferred from the first non-empty embedding seen on a node;
+                ``None`` until a non-empty embedding appears.
+        """
         label_to_rows: DefaultDict[str, list[dict[str, Any]]] = defaultdict(list)
+        node_id_to_node: dict[str, Neo4jNode] = {}
+        label_to_embedding_dims: DefaultDict[str, dict[str, Optional[int]]] = (
+            defaultdict(dict)
+        )
 
         for node in nodes:
+            node_id_to_node[node.id] = node
+
             labels: list[str] = [node.label]
             if node.label not in lexical_graph_config.lexical_graph_node_labels:
                 labels.append("__Entity__")
@@ -510,15 +548,20 @@ class Neo4jGraphParquetFormatter:
                 INTERNAL_ID_PROPERTY: node.id,
                 "labels": labels,
             }
-
             if node.properties:
                 row.update(node.properties)
             if node.embedding_properties:
                 row.update(node.embedding_properties)
+                dims_for_label = label_to_embedding_dims[node.label]
+                for name, value in node.embedding_properties.items():
+                    if name not in dims_for_label:
+                        dims_for_label[name] = len(value) if value else None
+                    elif dims_for_label[name] is None and value:
+                        dims_for_label[name] = len(value)
 
             label_to_rows[node.label].append(row)
 
-        return label_to_rows
+        return label_to_rows, node_id_to_node, label_to_embedding_dims
 
     def _get_node_key_property_value(self, node: Neo4jNode) -> Any:
         """Get the join key value for relationship Parquet ``from``/``to`` columns.
@@ -748,10 +791,9 @@ class Neo4jGraphParquetFormatter:
             - List of FileMetadata objects with schema information
             - Statistics dictionary with 'nodes_per_label' and 'rel_per_type' counts
         """
-        label_to_rows: DefaultDict[str, list[dict[str, Any]]] = self._nodes_to_rows(
+        label_to_rows, node_id_to_node, label_to_embedding_dims = self._process_nodes(
             graph.nodes, lexical_graph_config
         )
-        node_id_to_node: dict[str, Neo4jNode] = {node.id: node for node in graph.nodes}
         type_to_rows: DefaultDict[tuple[str, str, str], list[dict[str, Any]]] = (
             self._relationships_to_rows(graph.relationships, node_id_to_node)
         )
@@ -775,6 +817,15 @@ class Neo4jGraphParquetFormatter:
                 labels_list.append("__Entity__")
 
             enriched_keys = enrich_key_constraints_for_node_type(self.schema, label)
+            dims_for_label = label_to_embedding_dims.get(label, {})
+            indexes_meta: Optional[list[dict[str, Any]]] = (
+                [
+                    build_vector_index_for_property(name, dims_for_label[name])
+                    for name in sorted(dims_for_label)
+                ]
+                if dims_for_label
+                else None
+            )
             file_metadata.append(
                 FileMetadata(
                     filename=filename,
@@ -795,6 +846,7 @@ class Neo4jGraphParquetFormatter:
                     existence_constraints=get_existence_constraints_for_node_type(
                         self.schema, label
                     ),
+                    indexes=indexes_meta,
                 )
             )
 

--- a/tests/unit/experimental/components/test_kg_writer.py
+++ b/tests/unit/experimental/components/test_kg_writer.py
@@ -1686,3 +1686,205 @@ def test_format_parquet_empty_list_before_float_embedding_does_not_crash() -> No
         or rows_by_id["node-1"]["embedding"] == []
     )
     assert rows_by_id["node-2"]["embedding"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Vector index emission for any node label with embedding_properties
+# ---------------------------------------------------------------------------
+
+
+def _indexes_for_label(file_metadata: list[Any], label: str) -> Any:
+    """Return the indexes list on the FileMetadata for *label* (or None)."""
+    meta = next(m for m in file_metadata if m.is_node and m.node_label == label)
+    return meta.indexes
+
+
+@pytest.mark.asyncio
+async def test_parquet_writer_chunk_file_emits_vector_index_in_metadata() -> None:
+    """End-to-end: ParquetWriter.run forwards the VECTOR index into KGWriterModel.metadata.
+
+    Single writer-level test that confirms the formatter→writer wiring; the rest of
+    the index-emission rules are exercised at the formatter level (no IO needed).
+    """
+    pytest.importorskip("pyarrow")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = Path(tmpdir)
+        dest = _LocalParquetDestination(out)
+        writer = ParquetWriter(
+            nodes_dest=dest,
+            relationships_dest=dest,
+            collision_handler=FilenameCollisionHandler(),
+        )
+
+        chunk = Neo4jNode(
+            id="c1",
+            label="Chunk",
+            properties={"text": "hello"},
+            embedding_properties={"embedding": [0.1, 0.2, 0.3, 0.4]},
+        )
+        graph = Neo4jGraph(nodes=[chunk], relationships=[])
+
+        result = await writer.run(graph=graph)
+
+    assert result.status == "SUCCESS"
+    assert result.metadata is not None
+    chunk_file = next(
+        f for f in result.metadata["files"] if f.get("name") == "Chunk"
+    )
+    assert chunk_file.get("indexes") == [
+        {
+            "type": "VECTOR",
+            "properties": ["embedding"],
+            "dimensions": 4,
+            "similarity": "cosine",
+        }
+    ]
+
+
+def test_formatter_emits_vector_index_for_any_label() -> None:
+    """Any node label with embedding_properties gets a VECTOR index entry."""
+    pytest.importorskip("pyarrow")
+
+    person = Neo4jNode(
+        id="p1",
+        label="Person",
+        properties={"name": "Alice"},
+        embedding_properties={"name_emb": [0.0] * 8},
+    )
+    graph = Neo4jGraph(nodes=[person], relationships=[])
+
+    _, file_metadata, _ = Neo4jGraphParquetFormatter().format_graph(
+        graph, LexicalGraphConfig()
+    )
+
+    assert _indexes_for_label(file_metadata, "Person") == [
+        {
+            "type": "VECTOR",
+            "properties": ["name_emb"],
+            "dimensions": 8,
+            "similarity": "cosine",
+        }
+    ]
+
+
+def test_formatter_emits_one_index_per_embedding_property() -> None:
+    """Multiple embedding_properties keys produce multiple VECTOR index entries, sorted by name."""
+    pytest.importorskip("pyarrow")
+
+    node = Neo4jNode(
+        id="n1",
+        label="Doc",
+        properties={"text": "hello"},
+        embedding_properties={
+            "text_emb": [0.1, 0.2, 0.3],
+            "title_emb": [0.0] * 5,
+        },
+    )
+    graph = Neo4jGraph(nodes=[node], relationships=[])
+
+    _, file_metadata, _ = Neo4jGraphParquetFormatter().format_graph(
+        graph, LexicalGraphConfig()
+    )
+
+    assert _indexes_for_label(file_metadata, "Doc") == [
+        {
+            "type": "VECTOR",
+            "properties": ["text_emb"],
+            "dimensions": 3,
+            "similarity": "cosine",
+        },
+        {
+            "type": "VECTOR",
+            "properties": ["title_emb"],
+            "dimensions": 5,
+            "similarity": "cosine",
+        },
+    ]
+
+
+def test_formatter_file_without_embeddings_has_no_indexes() -> None:
+    """Node files whose nodes carry no embedding_properties do not get an indexes entry."""
+    pytest.importorskip("pyarrow")
+
+    n1 = Neo4jNode(id="n1", label="Person", properties={"name": "Alice"})
+    n2 = Neo4jNode(id="n2", label="Person", properties={"name": "Bob"})
+    rel = Neo4jRelationship(
+        start_node_id="n1", end_node_id="n2", type="KNOWS", properties={}
+    )
+    graph = Neo4jGraph(nodes=[n1, n2], relationships=[rel])
+
+    _, file_metadata, _ = Neo4jGraphParquetFormatter().format_graph(
+        graph, LexicalGraphConfig()
+    )
+
+    for m in file_metadata:
+        assert m.indexes is None
+
+
+def test_formatter_indexes_emitted_for_multiple_labels() -> None:
+    """Each node label with embedding_properties gets its own vector index entries."""
+    pytest.importorskip("pyarrow")
+
+    chunk = Neo4jNode(
+        id="c1",
+        label="Chunk",
+        properties={"text": "hi"},
+        embedding_properties={"embedding": [0.1] * 4},
+    )
+    person = Neo4jNode(
+        id="p1",
+        label="Person",
+        properties={"name": "Alice"},
+        embedding_properties={"name_emb": [0.0] * 8},
+    )
+    graph = Neo4jGraph(nodes=[chunk, person], relationships=[])
+
+    _, file_metadata, _ = Neo4jGraphParquetFormatter().format_graph(
+        graph, LexicalGraphConfig()
+    )
+
+    assert _indexes_for_label(file_metadata, "Chunk") == [
+        {
+            "type": "VECTOR",
+            "properties": ["embedding"],
+            "dimensions": 4,
+            "similarity": "cosine",
+        }
+    ]
+    assert _indexes_for_label(file_metadata, "Person") == [
+        {
+            "type": "VECTOR",
+            "properties": ["name_emb"],
+            "dimensions": 8,
+            "similarity": "cosine",
+        }
+    ]
+
+
+def test_formatter_embedding_keys_unioned_across_nodes_of_same_label() -> None:
+    """Embedding keys are unioned across all nodes of a label; dimensions inferred from first non-empty."""
+    pytest.importorskip("pyarrow")
+
+    # First chunk has no embedding; second carries one.
+    n1 = Neo4jNode(id="c1", label="Chunk", properties={"text": "hi"})
+    n2 = Neo4jNode(
+        id="c2",
+        label="Chunk",
+        properties={"text": "bye"},
+        embedding_properties={"embedding": [0.1, 0.2, 0.3]},
+    )
+    graph = Neo4jGraph(nodes=[n1, n2], relationships=[])
+
+    _, file_metadata, _ = Neo4jGraphParquetFormatter().format_graph(
+        graph, LexicalGraphConfig()
+    )
+
+    assert _indexes_for_label(file_metadata, "Chunk") == [
+        {
+            "type": "VECTOR",
+            "properties": ["embedding"],
+            "dimensions": 3,
+            "similarity": "cosine",
+        }
+    ]

--- a/tests/unit/experimental/components/test_kg_writer.py
+++ b/tests/unit/experimental/components/test_kg_writer.py
@@ -1694,7 +1694,7 @@ def test_format_parquet_empty_list_before_float_embedding_does_not_crash() -> No
 
 
 def _indexes_for_label(file_metadata: list[Any], label: str) -> Any:
-    """Return the indexes list on the FileMetadata for *label* (or None)."""
+    """Return the indexes list on the formatter FileMetadata for *label* (or None)."""
     meta = next(m for m in file_metadata if m.is_node and m.node_label == label)
     return meta.indexes
 
@@ -1729,9 +1729,7 @@ async def test_parquet_writer_chunk_file_emits_vector_index_in_metadata() -> Non
 
     assert result.status == "SUCCESS"
     assert result.metadata is not None
-    chunk_file = next(
-        f for f in result.metadata["files"] if f.get("name") == "Chunk"
-    )
+    chunk_file = next(f for f in result.metadata["files"] if f.get("name") == "Chunk")
     assert chunk_file.get("indexes") == [
         {
             "type": "VECTOR",


### PR DESCRIPTION
# Description

Add `indexes` to be created to the ParquetWriter result metadata. All embedding properties for all nodes are taken into account (even if for now, we only have embeddings for `Chunk` nodes).

Note: relationship embedding properties are not handled in this PR on purpose, we do not have any requirement for it and we do not store relationships per type but per pattern, which adds complexity.


## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High
>
>

Complexity:

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [x] CHANGELOG.md updated if appropriate
