### PR TITLE
Add relationship-scope support for UNIQUENESS, EXISTENCE, and KEY constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Experimental: `EXISTENCE`, `KEY`, and `UNIQUENESS` constraints can now be scoped to relationship types in `GraphSchema`. `ConstraintType` accepts a `relationship_type` field (mutually exclusive with `node_type`); validation rejects schemas where both `UNIQUENESS` and `KEY` target the same relationship type and property set. `ParquetWriter` relationship file entries now include a `constraints` list when the schema defines any for that relationship type.
 - Experimental: `SchemaFromExistingGraphExtractor._extract_graph_constraints_from_metadata` now maps `NODE_PROPERTY_UNIQUENESS` and `RELATIONSHIP_PROPERTY_UNIQUENESS` rows from `SHOW CONSTRAINTS` to the corresponding node-scoped and relationship-scoped `UNIQUENESS` constraints in `GraphSchema`.
 
+### Fixed
+
+- Experimental: `GraphPruning` now drops relationships whose `KEY`- or `EXISTENCE`-constrained properties are null, matching the existing behaviour for nodes. Previously such relationships were logged as pruned but still passed through with empty properties.
+
 ## 1.16.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+### Added
+
+- Experimental: `EXISTENCE`, `KEY`, and `UNIQUENESS` constraints can now be scoped to relationship types in `GraphSchema`. `ConstraintType` accepts a `relationship_type` field (mutually exclusive with `node_type`); validation rejects schemas where both `UNIQUENESS` and `KEY` target the same relationship type and property set. `ParquetWriter` relationship file entries now include a `constraints` list when the schema defines any for that relationship type.
+
 ### Fixed
 
 - Experimental: `wire_extraction_constraints_for_graph_schema` now removes `relationship_type` whenever `type == "UNIQUENESS"`, preventing a `validate_constraint_shape` `ValueError` when an LLM emits a stray `relationship_type` alongside a UNIQUENESS constraint (only node-level UNIQUENESS is supported).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,7 @@
 ### Added
 
 - Experimental: `EXISTENCE`, `KEY`, and `UNIQUENESS` constraints can now be scoped to relationship types in `GraphSchema`. `ConstraintType` accepts a `relationship_type` field (mutually exclusive with `node_type`); validation rejects schemas where both `UNIQUENESS` and `KEY` target the same relationship type and property set. `ParquetWriter` relationship file entries now include a `constraints` list when the schema defines any for that relationship type.
-
-### Fixed
-
-- Experimental: `wire_extraction_constraints_for_graph_schema` now removes `relationship_type` whenever `type == "UNIQUENESS"`, preventing a `validate_constraint_shape` `ValueError` when an LLM emits a stray `relationship_type` alongside a UNIQUENESS constraint (only node-level UNIQUENESS is supported).
+- Experimental: `SchemaFromExistingGraphExtractor._extract_graph_constraints_from_metadata` now maps `NODE_PROPERTY_UNIQUENESS` and `RELATIONSHIP_PROPERTY_UNIQUENESS` rows from `SHOW CONSTRAINTS` to the corresponding node-scoped and relationship-scoped `UNIQUENESS` constraints in `GraphSchema`.
 
 ## 1.16.0
 

--- a/src/neo4j_graphrag/experimental/components/graph_pruning.py
+++ b/src/neo4j_graphrag/experimental/components/graph_pruning.py
@@ -340,6 +340,12 @@ class GraphPruning(Component):
                 pruning_stats,
                 prune_empty=False,
             )
+            if not filtered_props and schema.mandatory_property_names_for_relationship(
+                rel.type
+            ):
+                # _enforce_properties already logged this relationship as pruned
+                # (MISSING_REQUIRED_PROPERTY); honour that decision
+                return None
         else:
             filtered_props = rel.properties
 

--- a/src/neo4j_graphrag/experimental/components/graph_schema_extraction.py
+++ b/src/neo4j_graphrag/experimental/components/graph_schema_extraction.py
@@ -92,8 +92,8 @@ def wire_extraction_constraints_for_graph_schema(
 
     The empty-string ``relationship_type`` wire sentinel (and any missing or ``None`` value) is removed,
     so that :class:`~neo4j_graphrag.experimental.components.schema.ConstraintType` falls back to its
-    default. UNIQUENESS constraints also have ``relationship_type`` removed regardless of value, since
-    only node-level UNIQUENESS is supported.
+    default. All three constraint types (UNIQUENESS, EXISTENCE, KEY) support both node and relationship
+    scope; relationship_type is only removed when it is empty or None.
     """
     out: list[dict[str, Any]] = []
     for c in constraints:
@@ -101,11 +101,7 @@ def wire_extraction_constraints_for_graph_schema(
 
         rt = d.get("relationship_type")
 
-        if (
-            d.get("type") == "UNIQUENESS"
-            or rt is None
-            or (isinstance(rt, str) and rt.strip() == "")
-        ):
+        if rt is None or (isinstance(rt, str) and rt.strip() == ""):
             d.pop("relationship_type", None)
         out.append(d)
     return out

--- a/src/neo4j_graphrag/experimental/components/kg_writer.py
+++ b/src/neo4j_graphrag/experimental/components/kg_writer.py
@@ -133,10 +133,11 @@ class KGWriterModel(DataModel):
               vs UNIQUENESS constraints per :class:`~neo4j_graphrag.experimental.components.schema.GraphSchema`).
               Node files include a ``constraints`` list with ``KEY``, ``UNIQUENESS``, and node-scoped
               ``EXISTENCE`` entries (grouped ``properties`` lists), plus at least one single-property
-              ``KEY`` (``__id__`` is injected when the schema has none). Relationship files do not
-              include a ``constraints`` list; they include ``start_node_primary_keys`` /
-              ``end_node_primary_keys`` as a one-element list: the first single-property schema
-              ``KEY`` for that label, or ``__id__``.
+              ``KEY`` (``__id__`` is injected when the schema has none). Relationship files include
+              a ``constraints`` list with ``KEY``, ``UNIQUENESS``, and relationship-scoped
+              ``EXISTENCE`` entries when the schema defines them (key absent when none exist), plus
+              ``start_node_primary_keys`` / ``end_node_primary_keys`` as a one-element list: the
+              first single-property schema ``KEY`` for that label, or ``__id__``.
     """
 
     status: Literal["SUCCESS", "FAILURE"]
@@ -469,27 +470,35 @@ class ParquetWriter(KGWriter):
                     if unique_filename.endswith(".parquet")
                     else unique_filename
                 )
-                files.append(
-                    {
-                        "name": rel_name,
-                        "file_path": file_path,
-                        "columns": columns,
-                        "is_node": False,
-                        "relationship_type": meta.relationship_type,
-                        "start_node_source": start_node_source,
-                        "start_node_primary_keys": (
-                            meta.head_primary_key_property_names
-                            if meta.head_primary_key_property_names
-                            else [INTERNAL_ID_PROPERTY]
-                        ),
-                        "end_node_source": end_node_source,
-                        "end_node_primary_keys": (
-                            meta.tail_primary_key_property_names
-                            if meta.tail_primary_key_property_names
-                            else [INTERNAL_ID_PROPERTY]
-                        ),
-                    }
-                )
+                rel_constraints_meta: list[dict[str, Any]] = []
+                for props in meta.key_constraints or []:
+                    rel_constraints_meta.append({"type": "KEY", "properties": list(props)})
+                for props in meta.uniqueness_constraints or []:
+                    rel_constraints_meta.append({"type": "UNIQUENESS", "properties": list(props)})
+                for props in meta.existence_constraints or []:
+                    rel_constraints_meta.append({"type": "EXISTENCE", "properties": list(props)})
+                rel_entry: dict[str, Any] = {
+                    "name": rel_name,
+                    "file_path": file_path,
+                    "columns": columns,
+                    "is_node": False,
+                    "relationship_type": meta.relationship_type,
+                    "start_node_source": start_node_source,
+                    "start_node_primary_keys": (
+                        meta.head_primary_key_property_names
+                        if meta.head_primary_key_property_names
+                        else [INTERNAL_ID_PROPERTY]
+                    ),
+                    "end_node_source": end_node_source,
+                    "end_node_primary_keys": (
+                        meta.tail_primary_key_property_names
+                        if meta.tail_primary_key_property_names
+                        else [INTERNAL_ID_PROPERTY]
+                    ),
+                }
+                if rel_constraints_meta:
+                    rel_entry["constraints"] = rel_constraints_meta
+                files.append(rel_entry)
 
             logger.info(
                 "Wrote %d node files and %d relationship files",

--- a/src/neo4j_graphrag/experimental/components/kg_writer.py
+++ b/src/neo4j_graphrag/experimental/components/kg_writer.py
@@ -472,11 +472,17 @@ class ParquetWriter(KGWriter):
                 )
                 rel_constraints_meta: list[dict[str, Any]] = []
                 for props in meta.key_constraints or []:
-                    rel_constraints_meta.append({"type": "KEY", "properties": list(props)})
+                    rel_constraints_meta.append(
+                        {"type": "KEY", "properties": list(props)}
+                    )
                 for props in meta.uniqueness_constraints or []:
-                    rel_constraints_meta.append({"type": "UNIQUENESS", "properties": list(props)})
+                    rel_constraints_meta.append(
+                        {"type": "UNIQUENESS", "properties": list(props)}
+                    )
                 for props in meta.existence_constraints or []:
-                    rel_constraints_meta.append({"type": "EXISTENCE", "properties": list(props)})
+                    rel_constraints_meta.append(
+                        {"type": "EXISTENCE", "properties": list(props)}
+                    )
                 rel_entry: dict[str, Any] = {
                     "name": rel_name,
                     "file_path": file_path,

--- a/src/neo4j_graphrag/experimental/components/parquet_formatter.py
+++ b/src/neo4j_graphrag/experimental/components/parquet_formatter.py
@@ -191,6 +191,54 @@ def get_existence_constraints_for_node_type(
     return out
 
 
+def get_key_constraints_for_relationship_type(
+    schema: Optional[GraphSchema], rel_label: str
+) -> list[tuple[str, ...]]:
+    """KEY constraints for a relationship type, preserving composite grouping."""
+    if not schema:
+        return []
+    out: list[tuple[str, ...]] = []
+    for constraint in schema.constraints:
+        if constraint.type != GraphConstraintType.KEY:
+            continue
+        if constraint.relationship_type != rel_label:
+            continue
+        out.append(constraint.property_names)
+    return out
+
+
+def get_uniqueness_constraints_for_relationship_type(
+    schema: Optional[GraphSchema], rel_label: str
+) -> list[tuple[str, ...]]:
+    """UNIQUENESS constraints for a relationship type, preserving composite grouping."""
+    if not schema:
+        return []
+    out: list[tuple[str, ...]] = []
+    for constraint in schema.constraints:
+        if constraint.type != GraphConstraintType.UNIQUENESS:
+            continue
+        if constraint.relationship_type != rel_label:
+            continue
+        out.append(constraint.property_names)
+    return out
+
+
+def get_existence_constraints_for_relationship_type(
+    schema: Optional[GraphSchema], rel_label: str
+) -> list[tuple[str, ...]]:
+    """EXISTENCE constraints for a relationship type (each tuple has exactly one property)."""
+    if not schema:
+        return []
+    out: list[tuple[str, ...]] = []
+    for constraint in schema.constraints:
+        if constraint.type != GraphConstraintType.EXISTENCE:
+            continue
+        if constraint.relationship_type != rel_label:
+            continue
+        out.append(constraint.property_names)
+    return out
+
+
 def enrich_key_constraints_for_node_type(
     schema: Optional[GraphSchema], node_label: str
 ) -> list[tuple[str, ...]]:
@@ -783,6 +831,15 @@ class Neo4jGraphParquetFormatter:
                     ],
                     tail_uniqueness_property_names=get_uniqueness_property_names_for_node_type(
                         self.schema, tail_label
+                    ),
+                    key_constraints=get_key_constraints_for_relationship_type(
+                        self.schema, rtype
+                    ),
+                    uniqueness_constraints=get_uniqueness_constraints_for_relationship_type(
+                        self.schema, rtype
+                    ),
+                    existence_constraints=get_existence_constraints_for_relationship_type(
+                        self.schema, rtype
                     ),
                 )
             )

--- a/src/neo4j_graphrag/experimental/components/schema.py
+++ b/src/neo4j_graphrag/experimental/components/schema.py
@@ -336,7 +336,7 @@ class ConstraintType(BaseModel):
         return self
 
 
-def _validate_existence_or_key_property_defined(
+def _validate_constraint_property_defined(
     constraint: ConstraintType,
     *,
     node_type_index: dict[str, NodeType],
@@ -374,7 +374,7 @@ def _validate_existence_or_key_property_defined(
         for pn in constraint.property_names:
             if pn not in valid_property_names:
                 raise SchemaValidationError(
-                    f"{kind} constraint references undefined property "
+                    f"{kind.value} constraint references undefined property "
                     f"'{pn}' on relationship type '{rlabel}'. "
                     f"Valid properties: {valid_property_names}"
                 )
@@ -705,7 +705,7 @@ class GraphSchema(DataModel):
                 GraphConstraintType.EXISTENCE,
                 GraphConstraintType.KEY,
             ):
-                _validate_existence_or_key_property_defined(
+                _validate_constraint_property_defined(
                     constraint,
                     node_type_index=self._node_type_index,
                     relationship_type_index=self._relationship_type_index,
@@ -1722,7 +1722,7 @@ class SchemaFromExistingGraphExtractor(BaseSchemaBuilder):
     def _extract_graph_constraints_from_metadata(
         structured_schema: dict[str, Any],
     ) -> list[dict[str, Any]]:
-        """Build EXISTENCE / KEY constraint dicts from Neo4j ``SHOW CONSTRAINTS`` metadata."""
+        """Build EXISTENCE / KEY / UNIQUENESS constraint dicts from Neo4j ``SHOW CONSTRAINTS`` metadata."""
         schema_metadata = structured_schema.get("metadata", {})
         result: list[dict[str, Any]] = []
         seen: set[tuple[str, ...]] = set()
@@ -1786,6 +1786,34 @@ class SchemaFromExistingGraphExtractor(BaseSchemaBuilder):
                 result.append(
                     {
                         "type": GraphConstraintType.KEY.value,
+                        "node_type": "",
+                        "property_name": properties[0],
+                        "property_names": props_tuple,
+                        "relationship_type": lab,
+                    }
+                )
+            elif ctype == "NODE_PROPERTY_UNIQUENESS":
+                dedupe_key = ("UNIQUENESS", "NODE", lab, "", *props_tuple)
+                if dedupe_key in seen:
+                    continue
+                seen.add(dedupe_key)
+                result.append(
+                    {
+                        "type": GraphConstraintType.UNIQUENESS.value,
+                        "node_type": lab,
+                        "property_name": properties[0],
+                        "property_names": props_tuple,
+                        "relationship_type": None,
+                    }
+                )
+            elif ctype == "RELATIONSHIP_PROPERTY_UNIQUENESS":
+                dedupe_key = ("UNIQUENESS", "REL", "", lab, *props_tuple)
+                if dedupe_key in seen:
+                    continue
+                seen.add(dedupe_key)
+                result.append(
+                    {
+                        "type": GraphConstraintType.UNIQUENESS.value,
                         "node_type": "",
                         "property_name": properties[0],
                         "property_names": props_tuple,

--- a/src/neo4j_graphrag/experimental/components/schema.py
+++ b/src/neo4j_graphrag/experimental/components/schema.py
@@ -97,8 +97,8 @@ _DUNDER_RE = re.compile(r"^__|__$")
 class GraphConstraintType(str, enum.Enum):
     """Constraint kinds for :class:`ConstraintType`.
 
-    ``UNIQUENESS`` is for node properties only in this API.  Supports composite
-    (multi-property) constraints.  ``EXISTENCE`` marks a mandatory (non-null) node or
+    ``UNIQUENESS`` supports both node and relationship scope; composite (multi-property)
+    constraints are allowed.  ``EXISTENCE`` marks a mandatory (non-null) node or
     relationship property (single property only — Neo4j does not support composite
     existence).  ``KEY`` matches Neo4j NODE KEY / RELATIONSHIP KEY: mandatory and unique;
     supports composite (multi-property) constraints.
@@ -261,7 +261,7 @@ class ConstraintType(BaseModel):
     """
     Represents a schema-level constraint on a node or relationship property.
 
-    ``UNIQUENESS`` applies to node properties only. ``EXISTENCE`` and ``KEY`` use exactly one of
+    All three types (``UNIQUENESS``, ``EXISTENCE``, ``KEY``) use exactly one of
     ``node_type`` or ``relationship_type`` (non-empty), like Neo4j node vs relationship scope.
 
     ``UNIQUENESS`` and ``KEY`` support composite (multi-property) constraints via
@@ -282,7 +282,7 @@ class ConstraintType(BaseModel):
         ),
     )
     property_names: Tuple[str, ...] = Field(min_length=1)
-    node_type: str = ""
+    node_type: Optional[str] = None
     relationship_type: Optional[str] = None
 
     model_config = ConfigDict(
@@ -293,9 +293,12 @@ class ConstraintType(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def migrate_property_name_to_property_names(cls, data: Any) -> Any:
-        """Backward-compat migration: ``property_name`` → ``property_names``."""
+        """Backward-compat migration: ``property_name`` → ``property_names``; normalizes empty-string scope fields to ``None``."""
         if not isinstance(data, dict):
             return data
+        for field in ("node_type", "relationship_type"):
+            if field in data and (data[field] or "").strip() == "":
+                data[field] = None
         pn = data.get("property_name") or ""
         pns = data.get("property_names") or ()
         if isinstance(pns, str):
@@ -313,18 +316,8 @@ class ConstraintType(BaseModel):
 
     @model_validator(mode="after")
     def validate_constraint_shape(self) -> Self:
-        if self.type == GraphConstraintType.UNIQUENESS:
-            if not (self.node_type and self.node_type.strip()):
-                raise ValueError(
-                    "UNIQUENESS constraint requires a non-empty node_type; "
-                    "relationship uniqueness is not supported on GraphSchema constraints."
-                )
-            if self.relationship_type is not None and self.relationship_type.strip():
-                raise ValueError(
-                    "UNIQUENESS constraint must not set relationship_type; "
-                    "only node-level UNIQUENESS is supported."
-                )
-        elif self.type in (
+        if self.type in (
+            GraphConstraintType.UNIQUENESS,
             GraphConstraintType.EXISTENCE,
             GraphConstraintType.KEY,
         ):
@@ -348,7 +341,7 @@ def _validate_existence_or_key_property_defined(
     *,
     node_type_index: dict[str, NodeType],
     relationship_type_index: dict[str, RelationshipType],
-    kind: Literal["EXISTENCE", "KEY"],
+    kind: GraphConstraintType,
 ) -> None:
     """Raise SchemaValidationError if any property in the constraint is not declared on the entity."""
     has_node = bool(constraint.node_type and constraint.node_type.strip())
@@ -365,7 +358,7 @@ def _validate_existence_or_key_property_defined(
         for pn in constraint.property_names:
             if pn not in valid_property_names:
                 raise SchemaValidationError(
-                    f"{kind} constraint references undefined property "
+                    f"{kind.value} constraint references undefined property "
                     f"'{pn}' on node type '{constraint.node_type}'. "
                     f"Valid properties: {valid_property_names}"
                 )
@@ -707,32 +700,16 @@ class GraphSchema(DataModel):
             if isinstance(ctype, str):
                 ctype = GraphConstraintType(ctype)
 
-            if ctype == GraphConstraintType.UNIQUENESS:
-                if constraint.node_type not in self._node_type_index:
-                    raise SchemaValidationError(
-                        f"Constraint references undefined node type: {constraint.node_type}"
-                    )
-                node_type = self._node_type_index[constraint.node_type]
-                valid_property_names = {p.name for p in node_type.properties}
-                for pn in constraint.property_names:
-                    if pn not in valid_property_names:
-                        raise SchemaValidationError(
-                            f"Constraint references undefined property '{pn}' "
-                            f"on node type '{constraint.node_type}'. "
-                            f"Valid properties: {valid_property_names}"
-                        )
-            elif ctype in (
+            if ctype in (
+                GraphConstraintType.UNIQUENESS,
                 GraphConstraintType.EXISTENCE,
                 GraphConstraintType.KEY,
             ):
-                kind: Literal["EXISTENCE", "KEY"] = (
-                    "EXISTENCE" if ctype == GraphConstraintType.EXISTENCE else "KEY"
-                )
                 _validate_existence_or_key_property_defined(
                     constraint,
                     node_type_index=self._node_type_index,
                     relationship_type_index=self._relationship_type_index,
-                    kind=kind,
+                    kind=ctype,
                 )
         return self
 
@@ -741,25 +718,41 @@ class GraphSchema(DataModel):
         """Neo4j: property uniqueness and key constraints cannot share the same schema."""
         node_uniqueness: set[tuple[str, tuple[str, ...]]] = set()
         node_key: set[tuple[str, tuple[str, ...]]] = set()
+        rel_uniqueness: set[tuple[str, tuple[str, ...]]] = set()
+        rel_key: set[tuple[str, tuple[str, ...]]] = set()
         for c in self.constraints:
             ct = c.type
             if isinstance(ct, str):
                 ct = GraphConstraintType(ct)
+            has_node = bool(c.node_type and str(c.node_type).strip())
+            has_rel = bool(c.relationship_type and str(c.relationship_type).strip())
             if ct == GraphConstraintType.UNIQUENESS:
-                node_uniqueness.add((c.node_type, c.property_names))
+                if has_node:
+                    assert c.node_type is not None
+                    node_uniqueness.add((c.node_type, c.property_names))
+                elif has_rel:
+                    assert c.relationship_type is not None
+                    rel_uniqueness.add((c.relationship_type, c.property_names))
             elif ct == GraphConstraintType.KEY:
-                if (
-                    c.node_type
-                    and str(c.node_type).strip()
-                    and not (c.relationship_type and str(c.relationship_type).strip())
-                ):
+                if has_node:
+                    assert c.node_type is not None
                     node_key.add((c.node_type, c.property_names))
-        overlap = node_uniqueness & node_key
-        if overlap:
-            nt, pns = next(iter(overlap))
+                elif has_rel:
+                    assert c.relationship_type is not None
+                    rel_key.add((c.relationship_type, c.property_names))
+        node_overlap = node_uniqueness & node_key
+        if node_overlap:
+            nt, pns = next(iter(node_overlap))
             raise SchemaValidationError(
                 f"UNIQUENESS and KEY constraints cannot apply to the same node type "
                 f"and properties ({nt!r}, {pns!r})."
+            )
+        rel_overlap = rel_uniqueness & rel_key
+        if rel_overlap:
+            rt, pns = next(iter(rel_overlap))
+            raise SchemaValidationError(
+                f"UNIQUENESS and KEY constraints cannot apply to the same relationship type "
+                f"and properties ({rt!r}, {pns!r})."
             )
         return self
 
@@ -835,6 +828,19 @@ class GraphSchema(DataModel):
             if ct != GraphConstraintType.UNIQUENESS:
                 continue
             if c.node_type == label:
+                names.update(c.property_names)
+        return names
+
+    def uniqueness_property_names_for_relationship(self, rel_label: str) -> set[str]:
+        """Property names under a UNIQUENESS constraint for this relationship type."""
+        names: set[str] = set()
+        for c in self.constraints:
+            ct = c.type
+            if isinstance(ct, str):
+                ct = GraphConstraintType(ct)
+            if ct != GraphConstraintType.UNIQUENESS:
+                continue
+            if c.relationship_type == rel_label:
                 names.update(c.property_names)
         return names
 
@@ -1225,26 +1231,46 @@ def _extraction_filter_invalid_constraints(
             continue
 
         if ctype == GraphConstraintType.UNIQUENESS.value:
-            if not node_types:
+            node_type = constraint.get("node_type") or ""
+            rel_type = constraint.get("relationship_type")
+            has_node = bool(str(node_type).strip())
+            has_rel = bool(rel_type and str(rel_type).strip())
+            if has_node == has_rel:
                 logging.info(
                     f"Filtering out constraint: {constraint}. "
-                    f"No node types are defined."
+                    f"UNIQUENESS requires exactly one of node_type or relationship_type."
                 )
                 continue
-            node_type = constraint.get("node_type")
-            if not node_type or node_type not in valid_node_labels:
-                logging.info(
-                    f"Filtering out constraint: {constraint}. "
-                    f"Node type '{node_type}' is not valid. Valid node types: {valid_node_labels}"
-                )
-                continue
-            if not _all_properties_valid(
-                prop_names,
-                node_type_properties.get(node_type, set()),
-                node_type,
-                "node type",
-            ):
-                continue
+            if has_node:
+                if node_type not in valid_node_labels:
+                    logging.info(
+                        f"Filtering out constraint: {constraint}. "
+                        f"Node type '{node_type}' is not valid. Valid node types: {valid_node_labels}"
+                    )
+                    continue
+                if not _all_properties_valid(
+                    prop_names,
+                    node_type_properties.get(node_type, set()),
+                    node_type,
+                    "node type",
+                ):
+                    continue
+            else:
+                assert rel_type is not None
+                if rel_type not in valid_rel_labels:
+                    logging.info(
+                        f"Filtering out constraint: {constraint}. "
+                        f"Relationship type '{rel_type}' is not valid. "
+                        f"Valid relationship types: {valid_rel_labels}"
+                    )
+                    continue
+                if not _all_properties_valid(
+                    prop_names,
+                    rel_type_properties.get(rel_type, set()),
+                    rel_type,
+                    "relationship type",
+                ):
+                    continue
             filtered_constraints.append(constraint)
             continue
 

--- a/src/neo4j_graphrag/generation/prompts.py
+++ b/src/neo4j_graphrag/generation/prompts.py
@@ -218,13 +218,14 @@ IMPORTANT RULES:
 5. When defining patterns, ensure that every node label and relationship label mentioned exists in your lists of node types and relationship types.
 6. Do not create node types that aren't clearly mentioned in the text.
 7. Keep your schema minimal and focused on clearly identifiable patterns in the text.
-8. UNIQUENESS CONSTRAINTS (optional, node properties only):
-8.1 Each node type may have at most one UNIQUENESS constraint in typical designs.
+8. UNIQUENESS CONSTRAINTS (optional, node or relationship properties):
+8.1 Each node or relationship type may have at most one UNIQUENESS constraint in typical designs.
 8.2 Only use properties that seem to not have too many missing values in the sample.
-8.3 Constraints reference node_types by label and specify which properties are unique via "property_names" (a list of one or more property names).
-8.4 Every property in a uniqueness constraint MUST also appear in the corresponding node_type as a property.
+8.3 Constraints reference node_types or relationship_types by label and specify which properties are unique via "property_names" (a list of one or more property names).
+8.4 Every property in a uniqueness constraint MUST also appear in the corresponding node_type or relationship_type as a property.
 8.5 Uniqueness does NOT imply that the property must exist on every node (existence is separate; see rule 9).
 8.6 For composite uniqueness (multiple properties), list all properties in "property_names". The combination of values must be unique.
+8.7 For a node property, use {{"type": "UNIQUENESS", "node_type": "<Label>", "property_names": ["<name>"], "relationship_type": ""}}. For a relationship property, use {{"type": "UNIQUENESS", "node_type": "", "property_names": ["<name>"], "relationship_type": "<REL_TYPE>"}}.
 9. EXISTENCE CONSTRAINTS (optional, single property only):
 9.1 Use EXISTENCE constraints to mark properties that MUST be present (non-null) on every instance.
 9.2 For a node property, add {{"type": "EXISTENCE", "node_type": "<Label>", "property_names": ["<name>"], "relationship_type": ""}} (use an empty string, not null, when the constraint is not on a relationship).
@@ -235,7 +236,7 @@ IMPORTANT RULES:
 10. KEY CONSTRAINTS (optional, Neo4j NODE KEY / RELATIONSHIP KEY):
 10.1 Use KEY when properties must exist on every instance and together form the natural identifier (uniqueness + mandatory presence).
 10.2 Same wire shape as EXISTENCE: exactly one of node_type or relationship_type (non-empty), with the other as "".
-10.3 Do not combine UNIQUENESS and KEY on the same node type with the same properties.
+10.3 Do not combine UNIQUENESS and KEY on the same node or relationship type with the same properties.
 10.4 Do not infer KEY from UNIQUENESS alone; KEY implies required presence, unlike UNIQUENESS alone.
 10.5 For composite key (multiple properties), list all properties in "property_names". All must exist and the combination must be unique.
 11. Never use double underscores (__) as a prefix or suffix in node labels or relationship types (e.g. __Person__ or __KNOWS__ are forbidden).
@@ -293,7 +294,13 @@ Return a valid JSON object that follows this precise structure:
       "node_type": "Person",
       "property_names": ["employee_id"],
       "relationship_type": ""
-    }}
+    }},
+    {{
+      "type": "UNIQUENESS",
+      "node_type": "",
+      "property_names": ["since"],
+      "relationship_type": "WORKS_FOR"
+    }},
     ...
   ]
 }}

--- a/tests/unit/experimental/components/test_graph_pruning.py
+++ b/tests/unit/experimental/components/test_graph_pruning.py
@@ -454,8 +454,7 @@ def test_graph_pruning_key_constraint_on_relationship_mandatory_enforced() -> No
         schema.additional_patterns,
         schema,
     )
-    assert out is not None
-    assert out.properties == {}
+    assert out is None
     assert len(pruning_stats.pruned_relationships) == 1
     assert (
         pruning_stats.pruned_relationships[0].pruned_reason
@@ -491,6 +490,67 @@ def test_graph_pruning_key_constraint_on_relationship_kept_when_present() -> Non
     assert out is not None
     assert out.properties == {"since": "2020-01-01", "role": "engineer"}
     assert pruning_stats.number_of_pruned_relationships == 0
+
+
+def test_graph_pruning_existence_constraint_on_relationship_prunes_when_missing() -> (
+    None
+):
+    """EXISTENCE on a relationship property causes the relationship to be dropped when null."""
+    schema = GraphSchema.model_validate(
+        {
+            "node_types": [
+                {"label": "Person", "properties": [{"name": "name", "type": "STRING"}]},
+                {
+                    "label": "Company",
+                    "properties": [{"name": "name", "type": "STRING"}],
+                },
+            ],
+            "relationship_types": [
+                {
+                    "label": "WORKS_FOR",
+                    "properties": [
+                        {"name": "indication", "type": "STRING"},
+                        {"name": "role", "type": "STRING"},
+                    ],
+                }
+            ],
+            "patterns": [("Person", "WORKS_FOR", "Company")],
+            "constraints": [
+                {
+                    "type": GraphConstraintType.EXISTENCE.value,
+                    "node_type": "",
+                    "property_names": ["indication"],
+                    "relationship_type": "WORKS_FOR",
+                }
+            ],
+        }
+    )
+    pruner = GraphPruning()
+    rel = Neo4jRelationship(
+        start_node_id="p1",
+        end_node_id="c1",
+        type="WORKS_FOR",
+        properties={"role": "engineer"},  # indication missing
+    )
+    pruning_stats = PruningStats()
+    rel_type = schema.relationship_type_from_label("WORKS_FOR")
+    assert rel_type is not None
+    out = pruner._validate_relationship(
+        rel,
+        {"p1": "Person", "c1": "Company"},
+        pruning_stats,
+        rel_type,
+        schema.additional_relationship_types,
+        schema.patterns,
+        schema.additional_patterns,
+        schema,
+    )
+    assert out is None
+    assert len(pruning_stats.pruned_relationships) == 1
+    assert (
+        pruning_stats.pruned_relationships[0].pruned_reason
+        == PruningReason.MISSING_REQUIRED_PROPERTY
+    )
 
 
 @pytest.fixture

--- a/tests/unit/experimental/components/test_graph_schema_extraction.py
+++ b/tests/unit/experimental/components/test_graph_schema_extraction.py
@@ -28,7 +28,7 @@ from neo4j_graphrag.experimental.components.graph_schema_extraction import (
 from neo4j_graphrag.experimental.components.schema import GraphSchema, Pattern
 
 
-def test_wire_extraction_constraints_drops_relationship_type_for_uniqueness() -> None:
+def test_wire_extraction_constraints_keeps_relationship_type_for_uniqueness() -> None:
     """Empty/null relationship_type is removed for all constraint types; non-empty relationship_type is preserved for relationship-scoped constraints."""
     out = wire_extraction_constraints_for_graph_schema(
         [

--- a/tests/unit/experimental/components/test_graph_schema_extraction.py
+++ b/tests/unit/experimental/components/test_graph_schema_extraction.py
@@ -29,7 +29,7 @@ from neo4j_graphrag.experimental.components.schema import GraphSchema, Pattern
 
 
 def test_wire_extraction_constraints_drops_relationship_type_for_uniqueness() -> None:
-    """UNIQUENESS constraints always have ``relationship_type`` removed entirely, regardless of its emitted value."""
+    """Empty/null relationship_type is removed for all constraint types; non-empty relationship_type is preserved for relationship-scoped constraints."""
     out = wire_extraction_constraints_for_graph_schema(
         [
             {
@@ -46,14 +46,15 @@ def test_wire_extraction_constraints_drops_relationship_type_for_uniqueness() ->
             },
             {
                 "type": "UNIQUENESS",
-                "node_type": "Book",
+                "node_type": "",
                 "property_names": ["isbn"],
                 "relationship_type": "KNOWS",
             },
         ]
     )
-    for entry in out:
-        assert "relationship_type" not in entry
+    assert "relationship_type" not in out[0]
+    assert "relationship_type" not in out[1]
+    assert out[2]["relationship_type"] == "KNOWS"
 
 
 def test_wire_extraction_constraints_drops_empty_relationship_type_for_non_uniqueness() -> (
@@ -94,8 +95,8 @@ def test_wire_extraction_constraints_preserves_relationship_scoped_existence() -
     assert out[0]["relationship_type"] == "KNOWS"
 
 
-def test_uniqueness_with_relationship_type_is_sanitized_by_wire_conversion() -> None:
-    """A stray ``relationship_type`` on a UNIQUENESS constraint is nulled out before runtime validation."""
+def test_uniqueness_with_relationship_type_preserved_by_wire_conversion() -> None:
+    """Relationship-scoped UNIQUENESS flows through wire conversion and into GraphSchema correctly."""
     dto = GraphSchemaExtractionOutput(
         node_types=[
             ExtractedNodeType(
@@ -103,21 +104,27 @@ def test_uniqueness_with_relationship_type_is_sanitized_by_wire_conversion() -> 
                 properties=[ExtractedPropertyType(name="name", type="STRING")],
             )
         ],
-        relationship_types=[],
+        relationship_types=[
+            ExtractedRelationshipType(
+                label="KNOWS",
+                properties=[ExtractedPropertyType(name="since", type="INTEGER")],
+            )
+        ],
         patterns=[],
         constraints=[
             ExtractedConstraintType(
                 type="UNIQUENESS",
-                node_type="Person",
-                property_names=["name"],
+                node_type="",
+                property_names=["since"],
                 relationship_type="KNOWS",
             ),
         ],
     )
     gs = GraphSchema.from_extraction_output(dto)
     assert len(gs.constraints) == 1
-    assert gs.constraints[0].relationship_type is None
-    assert gs.constraints[0].node_type == "Person"
+    assert gs.constraints[0].relationship_type == "KNOWS"
+    assert gs.constraints[0].node_type is None
+    assert gs.uniqueness_property_names_for_relationship("KNOWS") == {"since"}
 
 
 def test_invalid_constraints_dropped_by_extraction_filters_without_error() -> None:

--- a/tests/unit/experimental/components/test_kg_writer.py
+++ b/tests/unit/experimental/components/test_kg_writer.py
@@ -1141,7 +1141,9 @@ async def test_parquet_writer_relationship_key_constraint_in_metadata() -> None:
             properties={"since": 2020},
         )
         graph = Neo4jGraph(nodes=[node1, node2], relationships=[rel])
-        result = await writer.run(graph=graph, schema=GraphSchema.model_validate(schema_dict))
+        result = await writer.run(
+            graph=graph, schema=GraphSchema.model_validate(schema_dict)
+        )
         assert result.status == "SUCCESS"
         assert result.metadata is not None
         rel_file = next(f for f in result.metadata["files"] if not f["is_node"])
@@ -1186,11 +1188,15 @@ async def test_parquet_writer_relationship_uniqueness_constraint_in_metadata() -
             properties={"since": 2020},
         )
         graph = Neo4jGraph(nodes=[node1, node2], relationships=[rel])
-        result = await writer.run(graph=graph, schema=GraphSchema.model_validate(schema_dict))
+        result = await writer.run(
+            graph=graph, schema=GraphSchema.model_validate(schema_dict)
+        )
         assert result.status == "SUCCESS"
         assert result.metadata is not None
         rel_file = next(f for f in result.metadata["files"] if not f["is_node"])
-        assert {"type": "UNIQUENESS", "properties": ["since"]} in rel_file["constraints"]
+        assert {"type": "UNIQUENESS", "properties": ["since"]} in rel_file[
+            "constraints"
+        ]
 
 
 @pytest.mark.asyncio
@@ -1273,7 +1279,9 @@ async def test_parquet_writer_node_and_relationship_constraints_in_metadata() ->
             properties={"since": 2020},
         )
         graph = Neo4jGraph(nodes=[node1, node2], relationships=[rel])
-        result = await writer.run(graph=graph, schema=GraphSchema.model_validate(schema_dict))
+        result = await writer.run(
+            graph=graph, schema=GraphSchema.model_validate(schema_dict)
+        )
         assert result.status == "SUCCESS"
         assert result.metadata is not None
         node_file = next(f for f in result.metadata["files"] if f["is_node"])

--- a/tests/unit/experimental/components/test_kg_writer.py
+++ b/tests/unit/experimental/components/test_kg_writer.py
@@ -1104,6 +1104,189 @@ async def test_parquet_writer_key_uniqueness_existence_constraints_metadata() ->
 
 
 @pytest.mark.asyncio
+async def test_parquet_writer_relationship_key_constraint_in_metadata() -> None:
+    """KEY constraint on a relationship type is emitted in the relationship file's constraints."""
+    pytest.importorskip("pyarrow")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = Path(tmpdir)
+        dest = _LocalParquetDestination(out)
+        writer = ParquetWriter(
+            nodes_dest=dest,
+            relationships_dest=dest,
+            collision_handler=FilenameCollisionHandler(),
+        )
+        schema_dict: dict[str, Any] = {
+            "node_types": [
+                {"label": "Person", "properties": [{"name": "name", "type": "STRING"}]}
+            ],
+            "relationship_types": [
+                {"label": "KNOWS", "properties": [{"name": "since", "type": "INTEGER"}]}
+            ],
+            "constraints": [
+                {
+                    "type": "KEY",
+                    "node_type": "",
+                    "property_names": ["since"],
+                    "relationship_type": "KNOWS",
+                }
+            ],
+        }
+        node1 = Neo4jNode(id="n1", label="Person", properties={"name": "Alice"})
+        node2 = Neo4jNode(id="n2", label="Person", properties={"name": "Bob"})
+        rel = Neo4jRelationship(
+            start_node_id="n1",
+            end_node_id="n2",
+            type="KNOWS",
+            properties={"since": 2020},
+        )
+        graph = Neo4jGraph(nodes=[node1, node2], relationships=[rel])
+        result = await writer.run(graph=graph, schema=GraphSchema.model_validate(schema_dict))
+        assert result.status == "SUCCESS"
+        assert result.metadata is not None
+        rel_file = next(f for f in result.metadata["files"] if not f["is_node"])
+        assert {"type": "KEY", "properties": ["since"]} in rel_file["constraints"]
+
+
+@pytest.mark.asyncio
+async def test_parquet_writer_relationship_uniqueness_constraint_in_metadata() -> None:
+    """UNIQUENESS constraint on a relationship type is emitted in the relationship file's constraints."""
+    pytest.importorskip("pyarrow")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = Path(tmpdir)
+        dest = _LocalParquetDestination(out)
+        writer = ParquetWriter(
+            nodes_dest=dest,
+            relationships_dest=dest,
+            collision_handler=FilenameCollisionHandler(),
+        )
+        schema_dict: dict[str, Any] = {
+            "node_types": [
+                {"label": "Person", "properties": [{"name": "name", "type": "STRING"}]}
+            ],
+            "relationship_types": [
+                {"label": "KNOWS", "properties": [{"name": "since", "type": "INTEGER"}]}
+            ],
+            "constraints": [
+                {
+                    "type": "UNIQUENESS",
+                    "node_type": "",
+                    "property_names": ["since"],
+                    "relationship_type": "KNOWS",
+                }
+            ],
+        }
+        node1 = Neo4jNode(id="n1", label="Person", properties={"name": "Alice"})
+        node2 = Neo4jNode(id="n2", label="Person", properties={"name": "Bob"})
+        rel = Neo4jRelationship(
+            start_node_id="n1",
+            end_node_id="n2",
+            type="KNOWS",
+            properties={"since": 2020},
+        )
+        graph = Neo4jGraph(nodes=[node1, node2], relationships=[rel])
+        result = await writer.run(graph=graph, schema=GraphSchema.model_validate(schema_dict))
+        assert result.status == "SUCCESS"
+        assert result.metadata is not None
+        rel_file = next(f for f in result.metadata["files"] if not f["is_node"])
+        assert {"type": "UNIQUENESS", "properties": ["since"]} in rel_file["constraints"]
+
+
+@pytest.mark.asyncio
+async def test_parquet_writer_relationship_no_constraints_key_absent() -> None:
+    """Relationship file has no 'constraints' key when schema has no relationship constraints."""
+    pytest.importorskip("pyarrow")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = Path(tmpdir)
+        dest = _LocalParquetDestination(out)
+        writer = ParquetWriter(
+            nodes_dest=dest,
+            relationships_dest=dest,
+            collision_handler=FilenameCollisionHandler(),
+        )
+        node1 = Neo4jNode(id="n1", label="Person", properties={"name": "Alice"})
+        node2 = Neo4jNode(id="n2", label="Person", properties={"name": "Bob"})
+        rel = Neo4jRelationship(
+            start_node_id="n1", end_node_id="n2", type="KNOWS", properties={}
+        )
+        graph = Neo4jGraph(nodes=[node1, node2], relationships=[rel])
+        result = await writer.run(graph=graph)
+        assert result.status == "SUCCESS"
+        assert result.metadata is not None
+        rel_file = next(f for f in result.metadata["files"] if not f["is_node"])
+        assert "constraints" not in rel_file
+
+
+@pytest.mark.asyncio
+async def test_parquet_writer_node_and_relationship_constraints_in_metadata() -> None:
+    """Node KEY constraint does not bleed into relationship file; relationship KEY does not bleed into node file."""
+    pytest.importorskip("pyarrow")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = Path(tmpdir)
+        dest = _LocalParquetDestination(out)
+        writer = ParquetWriter(
+            nodes_dest=dest,
+            relationships_dest=dest,
+            collision_handler=FilenameCollisionHandler(),
+        )
+        schema_dict: dict[str, Any] = {
+            "node_types": [
+                {
+                    "label": "Person",
+                    "properties": [
+                        {"name": "email", "type": "STRING"},
+                        {"name": "name", "type": "STRING"},
+                    ],
+                }
+            ],
+            "relationship_types": [
+                {"label": "KNOWS", "properties": [{"name": "since", "type": "INTEGER"}]}
+            ],
+            "constraints": [
+                {
+                    "type": "KEY",
+                    "node_type": "Person",
+                    "property_names": ["email"],
+                    "relationship_type": None,
+                },
+                {
+                    "type": "KEY",
+                    "node_type": "",
+                    "property_names": ["since"],
+                    "relationship_type": "KNOWS",
+                },
+            ],
+        }
+        node1 = Neo4jNode(
+            id="n1", label="Person", properties={"email": "a@b.c", "name": "Alice"}
+        )
+        node2 = Neo4jNode(
+            id="n2", label="Person", properties={"email": "b@b.c", "name": "Bob"}
+        )
+        rel = Neo4jRelationship(
+            start_node_id="n1",
+            end_node_id="n2",
+            type="KNOWS",
+            properties={"since": 2020},
+        )
+        graph = Neo4jGraph(nodes=[node1, node2], relationships=[rel])
+        result = await writer.run(graph=graph, schema=GraphSchema.model_validate(schema_dict))
+        assert result.status == "SUCCESS"
+        assert result.metadata is not None
+        node_file = next(f for f in result.metadata["files"] if f["is_node"])
+        rel_file = next(f for f in result.metadata["files"] if not f["is_node"])
+        node_cs = node_file["constraints"]
+        rel_cs = rel_file["constraints"]
+        assert {"type": "KEY", "properties": ["email"]} in node_cs
+        assert not any(c["properties"] == ["since"] for c in node_cs)
+        assert {"type": "KEY", "properties": ["since"]} in rel_cs
+        assert not any(c["properties"] == ["email"] for c in rel_cs)
+
+
+@pytest.mark.asyncio
 async def test_parquet_writer_run_empty_graph() -> None:
     """ParquetWriter accepts an empty graph and writes no files."""
     pytest.importorskip("pyarrow")

--- a/tests/unit/experimental/components/test_schema.py
+++ b/tests/unit/experimental/components/test_schema.py
@@ -322,6 +322,31 @@ def test_schema_constraint_validation_property_not_in_node_type() -> None:
     assert "on node type 'Person'" in str(exc_info.value)
 
 
+def test_schema_constraint_validation_property_not_in_relationship_type() -> None:
+    schema_dict: dict[str, Any] = {
+        "node_types": [
+            {"label": "Person", "properties": [{"name": "name", "type": "STRING"}]}
+        ],
+        "relationship_types": [
+            {"label": "KNOWS", "properties": [{"name": "since", "type": "INTEGER"}]}
+        ],
+        "constraints": [
+            {
+                "type": "UNIQUENESS",
+                "node_type": "",
+                "relationship_type": "KNOWS",
+                "property_names": ["nonexistent_property"],
+            }
+        ],
+    }
+
+    with pytest.raises(SchemaValidationError) as exc_info:
+        GraphSchema.model_validate(schema_dict)
+
+    assert "constraint references undefined property" in str(exc_info.value)
+    assert "on relationship type 'KNOWS'" in str(exc_info.value)
+
+
 def test_schema_constraint_with_additional_properties_with_allows_unknown_property() -> (
     None
 ):
@@ -2191,6 +2216,60 @@ def test_extract_graph_constraints_from_metadata_relationship_key_maps_to_key() 
             "property_name": "since",
             "property_names": ("since",),
             "relationship_type": "WORKS_FOR",
+        }
+    ]
+
+
+def test_extract_graph_constraints_from_metadata_node_uniqueness_maps_to_uniqueness() -> None:
+    """Neo4j ``NODE_PROPERTY_UNIQUENESS`` metadata maps to node-scoped ``UNIQUENESS`` constraints."""
+    structured_schema: dict[str, Any] = {
+        "metadata": {
+            "constraint": [
+                {
+                    "type": "NODE_PROPERTY_UNIQUENESS",
+                    "labelsOrTypes": ["Person"],
+                    "properties": ["email"],
+                }
+            ]
+        }
+    }
+    out = SchemaFromExistingGraphExtractor._extract_graph_constraints_from_metadata(
+        structured_schema
+    )
+    assert out == [
+        {
+            "type": GraphConstraintType.UNIQUENESS.value,
+            "node_type": "Person",
+            "property_name": "email",
+            "property_names": ("email",),
+            "relationship_type": None,
+        }
+    ]
+
+
+def test_extract_graph_constraints_from_metadata_relationship_uniqueness_maps_to_uniqueness() -> None:
+    """Neo4j ``RELATIONSHIP_PROPERTY_UNIQUENESS`` metadata maps to relationship-scoped ``UNIQUENESS`` constraints."""
+    structured_schema: dict[str, Any] = {
+        "metadata": {
+            "constraint": [
+                {
+                    "type": "RELATIONSHIP_PROPERTY_UNIQUENESS",
+                    "labelsOrTypes": ["KNOWS"],
+                    "properties": ["since"],
+                }
+            ]
+        }
+    }
+    out = SchemaFromExistingGraphExtractor._extract_graph_constraints_from_metadata(
+        structured_schema
+    )
+    assert out == [
+        {
+            "type": GraphConstraintType.UNIQUENESS.value,
+            "node_type": "",
+            "property_name": "since",
+            "property_names": ("since",),
+            "relationship_type": "KNOWS",
         }
     ]
 

--- a/tests/unit/experimental/components/test_schema.py
+++ b/tests/unit/experimental/components/test_schema.py
@@ -2220,7 +2220,9 @@ def test_extract_graph_constraints_from_metadata_relationship_key_maps_to_key() 
     ]
 
 
-def test_extract_graph_constraints_from_metadata_node_uniqueness_maps_to_uniqueness() -> None:
+def test_extract_graph_constraints_from_metadata_node_uniqueness_maps_to_uniqueness() -> (
+    None
+):
     """Neo4j ``NODE_PROPERTY_UNIQUENESS`` metadata maps to node-scoped ``UNIQUENESS`` constraints."""
     structured_schema: dict[str, Any] = {
         "metadata": {
@@ -2247,7 +2249,9 @@ def test_extract_graph_constraints_from_metadata_node_uniqueness_maps_to_uniquen
     ]
 
 
-def test_extract_graph_constraints_from_metadata_relationship_uniqueness_maps_to_uniqueness() -> None:
+def test_extract_graph_constraints_from_metadata_relationship_uniqueness_maps_to_uniqueness() -> (
+    None
+):
     """Neo4j ``RELATIONSHIP_PROPERTY_UNIQUENESS`` metadata maps to relationship-scoped ``UNIQUENESS`` constraints."""
     structured_schema: dict[str, Any] = {
         "metadata": {

--- a/tests/unit/experimental/components/test_schema.py
+++ b/tests/unit/experimental/components/test_schema.py
@@ -318,7 +318,7 @@ def test_schema_constraint_validation_property_not_in_node_type() -> None:
     with pytest.raises(SchemaValidationError) as exc_info:
         GraphSchema.model_validate(schema_dict)
 
-    assert "Constraint references undefined property" in str(exc_info.value)
+    assert "constraint references undefined property" in str(exc_info.value)
     assert "on node type 'Person'" in str(exc_info.value)
 
 
@@ -343,7 +343,7 @@ def test_schema_constraint_with_additional_properties_with_allows_unknown_proper
     with pytest.raises(SchemaValidationError) as exc_info:
         GraphSchema.model_validate(schema_dict)
 
-    assert "Constraint references undefined property 'email'" in str(exc_info.value)
+    assert "constraint references undefined property 'email'" in str(exc_info.value)
 
 
 def test_schema_with_valid_constraints() -> None:
@@ -461,6 +461,89 @@ def test_schema_uniqueness_and_key_same_property_rejected() -> None:
                 "node_type": "Person",
                 "property_name": "id",
                 "relationship_type": None,
+            },
+        ],
+    }
+    with pytest.raises(SchemaValidationError, match="UNIQUENESS and KEY"):
+        GraphSchema.model_validate(schema_dict)
+
+
+def test_constraint_type_node_type_none_accepted() -> None:
+    constraint = ConstraintType(
+        type=GraphConstraintType.UNIQUENESS,
+        node_type=None,
+        relationship_type="KNOWS",
+        property_names=("since",),
+    )
+    assert constraint.node_type is None
+    assert constraint.relationship_type == "KNOWS"
+
+
+def test_schema_uniqueness_constraint_relationship_valid() -> None:
+    schema_dict: dict[str, Any] = {
+        "node_types": [
+            {"label": "Person", "properties": [{"name": "name", "type": "STRING"}]}
+        ],
+        "relationship_types": [
+            {"label": "KNOWS", "properties": [{"name": "since", "type": "INTEGER"}]}
+        ],
+        "constraints": [
+            {
+                "type": "UNIQUENESS",
+                "node_type": "",
+                "property_names": ["since"],
+                "relationship_type": "KNOWS",
+            }
+        ],
+    }
+    schema = GraphSchema.model_validate(schema_dict)
+    assert schema.uniqueness_property_names_for_relationship("KNOWS") == {"since"}
+    assert schema.uniqueness_property_names_for_node("Person") == set()
+
+
+def test_schema_existence_constraint_relationship_valid() -> None:
+    schema_dict: dict[str, Any] = {
+        "node_types": [
+            {"label": "Person", "properties": [{"name": "name", "type": "STRING"}]}
+        ],
+        "relationship_types": [
+            {"label": "KNOWS", "properties": [{"name": "since", "type": "INTEGER"}]}
+        ],
+        "constraints": [
+            {
+                "type": "EXISTENCE",
+                "node_type": "",
+                "property_names": ["since"],
+                "relationship_type": "KNOWS",
+            }
+        ],
+    }
+    schema = GraphSchema.model_validate(schema_dict)
+    assert schema.existence_property_names_for_relationship("KNOWS") == {"since"}
+    assert schema.mandatory_property_names_for_relationship("KNOWS") == {"since"}
+    assert schema.existence_property_names_for_node("Person") == set()
+
+
+def test_schema_uniqueness_and_key_same_relationship_rejected() -> None:
+    schema_dict: dict[str, Any] = {
+        "node_types": [
+            {"label": "Person", "properties": [{"name": "name", "type": "STRING"}]}
+        ],
+        "relationship_types": [
+            {"label": "KNOWS", "properties": [{"name": "since", "type": "INTEGER"}]}
+        ],
+        "constraints": [
+            {
+                "type": "UNIQUENESS",
+                "node_type": "",
+                "property_names": ["since"],
+                "relationship_type": "KNOWS",
+            },
+            {
+                "type": "KEY",
+                "node_type": "",
+                "property_names": ["since"],
+                "relationship_type": "KNOWS",
             },
         ],
     }


### PR DESCRIPTION
# Description
Extends the three constraint kinds (`EXISTENCE`, `KEY`, and `UNIQUENESS`) to relationship types, mirroring how Neo4j already supports them at the database level. Previously these constraints could only be scoped to node labels; this change makes `GraphSchema` express relationship-scoped constraints as first-class citizens.

## Why
`EXISTENCE` and `KEY` constraints could already be scoped to relationship types, but `UNIQUENESS` could not. Any `relationship_type` field on a `UNIQUENESS` constraint was silently stripped. Beyond that, all three constraint types shared validation and extraction logic written under the assumption of a node scope, so relationship-scoped constraints were not properly validated.

# Changes

- Schema model: The constraint model now treats node and relationship scope symmetrically. A constraint can now be scoped to either a node label or a relationship type and exactly one must be set. Empty-string sentinels from wire formats are normalised to `None` on load so callers always get a clean value. Validation now rejects schemas where both `UNIQUENESS` and `KEY` target the same relationship type and property set.
- Schema validation: Property-existence checks (every property in a constraint must be declared on the referenced type) now run for `UNIQUENESS` as well as `EXISTENCE` and `KEY`. The `UNIQUENESS`/`KEY` exclusivity rule (the two cannot apply to the same property set) is extended to relationship types, matching the existing rule for nodes.
- LLM extraction: The adapter that normalizes raw LLM output no longer drops relationship_type from `UNIQUENESS` constraints and it only strips empty or null values. The prompt updated to instruct the model to emit relationship-scoped constraints. 
- Parquet / KG writer: Relationship file entries in the parquet manifest now carry a constraints list (`KEY`, `UNIQUENESS`, `EXISTENCE`), parallel to what node entries already produced. The key is absent when there are none, keeping the format backward-compatible with existing consumers.
- Tests: New unit tests cover the schema side (relationship-scoped `UNIQUENESS` and `EXISTENCE` accepted; `UNIQUENESS`+`KEY` on the same relationship and properties rejected), the parquet writer side (all three constraint types appear in relationship file entries; the key is absent when no relationship constraints exist; node and relationship constraints don't bleed into each other's entries), and the extraction side (relationship-scoped `UNIQUENESS` preserved end-to-end through the LLM output adapter).

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Medium

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [x] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [x] CHANGELOG.md updated if appropriate
