### PR TITLE
feat(llm): support structured output in AnthropicLLM via response_format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## 1.18.0
 
+### Added
+
+- `AnthropicLLM` now supports structured output via the `response_format` argument, accepting a Pydantic model or an Anthropic output config dict, alongside `OpenAILLM` and `VertexAILLM`.
+
 ### Changed
 
 - Experimental: `GraphSchema` validation now rejects `KEY` and `EXISTENCE` constraints on the same node or relationship property (including composite KEY members), since KEY already implies mandatory presence. Legacy `PropertyType.required` migration no longer adds redundant EXISTENCE constraints for KEY-covered properties. The schema-from-text extraction prompt includes the same rule.
@@ -11,16 +15,16 @@
 - Experimental: LLM-auto-generated schemas now reconcile duplicate `relationship_types` (entries sharing the same label) by merging them into a single type that carries the union of their properties, emitting a warning log. This reflects that Neo4j relationship types are global per name.
 - Experimental (**breaking**): `GraphSchema` now raises `SchemaValidationError` when the same label appears more than once in `relationship_types`. Because Neo4j relationship types are global per name (every relationship of a given type shares the same properties and constraints regardless of its endpoints), a label cannot have two conflicting definitions. 
 
+### Fixed
+
+- Fixed a bug in `FixedSizeSplitter` that was stuck into an infinite loop with texts containing long whitespaces.
+
 ## 1.17.0
 
 ### Added
 
 - Vector index for all nodes embedding properties in the ParquetWriter result metadata.
 - Added `GeminiEmbedder` and `GeminiLLM` to replace the to be deprecated `VertexAIEmbedder` and `VertexAILLM`.
-
-### Fixed
-
-- Fixed a bug in `FixedSizeSplitter` that was stuck into an infinite loop with texts containing long whitespaces.
 
 
 ## 1.16.1

--- a/src/neo4j_graphrag/llm/anthropic_llm.py
+++ b/src/neo4j_graphrag/llm/anthropic_llm.py
@@ -187,12 +187,10 @@ class AnthropicLLM(LLMBase):
         response_format: Optional[Union[Type[BaseModel], dict[str, Any]]] = None,
         **kwargs: Any,
     ) -> LLMResponse:
-        if response_format is not None:
-            raise NotImplementedError(
-                "AnthropicLLM does not currently support structured output"
-            )
         try:
             system_instruction, messages = self.get_messages_v2(input)
+            if response_format is not None:
+                kwargs["output_config"] = self._build_output_config(response_format)
             response = self.client.messages.create(
                 model=self.model_name,
                 system=system_instruction,
@@ -267,17 +265,17 @@ class AnthropicLLM(LLMBase):
 
         Args:
             input (List[LLMMessage]): The messages to send to the LLM.
-            response_format: Not supported by AnthropicLLM.
+            response_format (Optional[Union[Type[BaseModel], dict[str, Any]]]): Optional
+                response format. Can be a Pydantic model class for structured output
+                or a dict matching Anthropic's output format schema.
 
         Returns:
             LLMResponse: The response from the LLM.
         """
-        if response_format is not None:
-            raise NotImplementedError(
-                "AnthropicLLM does not currently support structured output"
-            )
         try:
             system_instruction, messages = self.get_messages_v2(input)
+            if response_format is not None:
+                kwargs["output_config"] = self._build_output_config(response_format)
             response = await self.async_client.messages.create(
                 model=self.model_name,
                 system=system_instruction,
@@ -321,6 +319,16 @@ class AnthropicLLM(LLMBase):
             messages.extend(cast(Iterable[dict[str, Any]], message_history))
         messages.append(UserMessage(content=input).model_dump())
         return messages  # type: ignore
+
+    @staticmethod
+    def _build_output_config(
+        response_format: Union[Type[BaseModel], dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Builds the Anthropic output_config for structured output."""
+        if isinstance(response_format, type) and issubclass(response_format, BaseModel):
+            schema = response_format.model_json_schema()
+            return {"format": {"type": "json_schema", "schema": schema}}
+        return response_format
 
     def get_messages_v2(
         self,

--- a/tests/unit/llm/test_anthropic_llm.py
+++ b/tests/unit/llm/test_anthropic_llm.py
@@ -413,24 +413,97 @@ def test_anthropic_llm_invoke_v2_empty_response_error(mock_anthropic: Mock) -> N
     assert "LLM returned empty response" in str(exc_info.value)
 
 
-def test_anthropic_invoke_v2_with_response_format_raises_error(
+class _TestModelForAnthropic(BaseModel):
+    """Test model for structured output tests."""
+
+    model_config = ConfigDict(extra="forbid")
+    value: str
+
+
+def test_anthropic_llm_invoke_v2_with_pydantic_response_format(
     mock_anthropic: Mock,
 ) -> None:
-    """Test V2 interface raises NotImplementedError when response_format is used."""
-
-    class TestModel(BaseModel):
-        model_config = ConfigDict(extra="forbid")
-        value: str
+    """Test V2 interface passes a Pydantic response_format as output_config."""
+    mock_anthropic.Anthropic.return_value.messages.create.return_value = MagicMock(
+        content=[MagicMock(text='{"value": "ok"}')]
+    )
+    mock_anthropic.types.MessageParam = MagicMock(side_effect=lambda **kwargs: kwargs)
 
     messages: List[LLMMessage] = [{"role": "user", "content": "Test"}]
-    llm = AnthropicLLM(api_key="test", model_name="claude-3-opus")
+    llm = AnthropicLLM(model_name="claude-3-opus-20240229")
+    response = llm.invoke(messages, response_format=_TestModelForAnthropic)
 
-    with pytest.raises(NotImplementedError) as exc_info:
-        llm.invoke(messages, response_format=TestModel)
+    assert isinstance(response, LLMResponse)
+    assert response.content == '{"value": "ok"}'
 
-    assert "AnthropicLLM does not currently support structured output" in str(
-        exc_info.value
+    call_args = _as_mock(llm.client.messages.create).call_args[1]
+    output_config = call_args["output_config"]
+    assert output_config["format"]["type"] == "json_schema"
+    assert (
+        output_config["format"]["schema"] == _TestModelForAnthropic.model_json_schema()
     )
+
+
+def test_anthropic_llm_invoke_v2_with_dict_response_format(
+    mock_anthropic: Mock,
+) -> None:
+    """Test V2 interface passes a dict response_format through as output_config."""
+    mock_anthropic.Anthropic.return_value.messages.create.return_value = MagicMock(
+        content=[MagicMock(text='{"value": "ok"}')]
+    )
+    mock_anthropic.types.MessageParam = MagicMock(side_effect=lambda **kwargs: kwargs)
+
+    output_config = {
+        "format": {
+            "type": "json_schema",
+            "schema": {"type": "object", "properties": {"value": {"type": "string"}}},
+        }
+    }
+    messages: List[LLMMessage] = [{"role": "user", "content": "Test"}]
+    llm = AnthropicLLM(model_name="claude-3-opus-20240229")
+    response = llm.invoke(messages, response_format=output_config)
+
+    assert response.content == '{"value": "ok"}'
+    call_args = _as_mock(llm.client.messages.create).call_args[1]
+    assert call_args["output_config"] == output_config
+
+
+def test_anthropic_llm_invoke_v2_without_response_format_omits_output_config(
+    mock_anthropic: Mock,
+) -> None:
+    """Test V2 interface does not pass output_config when no response_format is given."""
+    mock_anthropic.Anthropic.return_value.messages.create.return_value = MagicMock(
+        content=[MagicMock(text="plain response")]
+    )
+    mock_anthropic.types.MessageParam = MagicMock(side_effect=lambda **kwargs: kwargs)
+
+    messages: List[LLMMessage] = [{"role": "user", "content": "Test"}]
+    llm = AnthropicLLM(model_name="claude-3-opus-20240229")
+    response = llm.invoke(messages)
+
+    assert response.content == "plain response"
+    call_args = _as_mock(llm.client.messages.create).call_args[1]
+    assert "output_config" not in call_args
+
+
+@pytest.mark.asyncio
+async def test_anthropic_llm_ainvoke_v2_with_pydantic_response_format(
+    mock_anthropic: Mock,
+) -> None:
+    """Test V2 async interface passes a Pydantic response_format as output_config."""
+    mock_response = AsyncMock()
+    mock_response.content = [MagicMock(text='{"value": "ok"}')]
+    mock_model = mock_anthropic.AsyncAnthropic.return_value
+    mock_model.messages.create = AsyncMock(return_value=mock_response)
+    mock_anthropic.types.MessageParam = MagicMock(side_effect=lambda **kwargs: kwargs)
+
+    messages: List[LLMMessage] = [{"role": "user", "content": "Test"}]
+    llm = AnthropicLLM(model_name="claude-3-opus-20240229")
+    response = await llm.ainvoke(messages, response_format=_TestModelForAnthropic)
+
+    assert response.content == '{"value": "ok"}'
+    call_args = _as_async_mock(llm.async_client.messages.create).call_args[1]
+    assert call_args["output_config"]["format"]["type"] == "json_schema"
 
 
 def test_anthropic_llm_close(mock_anthropic: Mock) -> None:


### PR DESCRIPTION
# Description

Closes #493. `AnthropicLLM.invoke`/`ainvoke` previously raised `NotImplementedError` for `response_format`; this adds structured output support so `AnthropicLLM` works alongside `OpenAILLM` and `VertexAILLM`. A Pydantic model is converted to a JSON schema and a passthrough dict is also accepted, both forwarded as Anthropic's `output_config`; behavior is unchanged when `response_format` is omitted. The issue is labelled `help wanted` and `good first issue` by the maintainers, and the request is "to add structured output support for `AnthropicLLM` alongside `OpenAILLM` and `VertexLLM` providers".

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Low

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
- [x] CHANGELOG.md updated if appropriate