### PR TITLE
Add sentence boundry recognition to `FixedSizeSplitter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+### Added
+
+- Experimental: `FixedSizeSplitter` gains a `sentence_boundaries` parameter (default `False`). When `True`, chunk boundaries are aligned to sentence ends using the nltk Punkt tokenizer; sentences that exceed `chunk_size` fall back to fixed-size cuts. The `punkt_tab` corpus is downloaded automatically on first use. Requires the `experimental` extra (`nltk>=3.8.0`).
+
 ## 1.16.1
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ experimental = [
     "langchain-text-splitters>=0.3.0,<2.0.0",
     "neo4j-viz>=0.4.2,<0.5.0",
     "llama-index>=0.13.0,<0.14.0",
+    "nltk>=3.8.0,<4.0.0",
     "pyarrow>=20.0.0",  # ParquetWriter, Neo4jGraphParquetFormatter
 ]
 examples = [
@@ -114,6 +115,7 @@ exclude = ["docs"]
 module = [
     "weaviate.*",
     "sentence_transformers.*",
+    "nltk.*",
     "conftest",
 ]
 ignore_missing_imports = true

--- a/src/neo4j_graphrag/experimental/components/text_splitters/fixed_size_splitter.py
+++ b/src/neo4j_graphrag/experimental/components/text_splitters/fixed_size_splitter.py
@@ -12,10 +12,36 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import bisect
+from typing import cast
+
 from pydantic import validate_call
 
 from neo4j_graphrag.experimental.components.text_splitters.base import TextSplitter
 from neo4j_graphrag.experimental.components.types import TextChunk, TextChunks
+
+
+def _get_sentence_spans(text: str) -> list[tuple[int, int]]:
+    try:
+        import nltk
+        from nltk.tokenize import PunktSentenceTokenizer
+    except ImportError:
+        raise ImportError(
+            "nltk is required for sentence boundary splitting. "
+            "Install it with: pip install nltk"
+        ) from None
+    try:
+        tokenizer = cast(
+            PunktSentenceTokenizer,
+            nltk.data.load("tokenizers/punkt_tab/english.pickle"),
+        )
+    except LookupError:
+        nltk.download("punkt_tab", quiet=True)
+        tokenizer = cast(
+            PunktSentenceTokenizer,
+            nltk.data.load("tokenizers/punkt_tab/english.pickle"),
+        )
+    return list(tokenizer.span_tokenize(text))
 
 
 def _adjust_chunk_start(text: str, approximate_start: int) -> int:
@@ -67,6 +93,35 @@ def _adjust_chunk_end(text: str, start: int, approximate_end: int) -> int:
     return end
 
 
+def _adjust_chunk_start_by_sentence(
+    sentence_starts: list[int], approximate_start: int
+) -> int:
+    """
+    Shift the starting index backward to the beginning of the sentence that contains
+    approximate_start. Falls back to approximate_start if no sentence boundary is found.
+    """
+    if not sentence_starts:
+        return approximate_start
+    idx = bisect.bisect_right(sentence_starts, approximate_start) - 1
+    return sentence_starts[idx] if idx >= 0 else approximate_start
+
+
+def _adjust_chunk_end_by_sentence(
+    sentence_ends: list[int], start: int, approximate_end: int
+) -> int:
+    """
+    Shift the ending index backward to the nearest sentence end that is <= approximate_end
+    and > start. Falls back to approximate_end if no such boundary exists (e.g. a single
+    sentence exceeds chunk_size).
+    """
+    if not sentence_ends:
+        return approximate_end
+    idx = bisect.bisect_right(sentence_ends, approximate_end) - 1
+    if idx >= 0 and sentence_ends[idx] > start:
+        return sentence_ends[idx]
+    return approximate_end
+
+
 class FixedSizeSplitter(TextSplitter):
     """Text splitter which splits the input text into fixed or approximate fixed size
        chunks with optional overlap.
@@ -77,6 +132,11 @@ class FixedSizeSplitter(TextSplitter):
                             with each chunk. Must be less than `chunk_size`.
         approximate (bool): If True, avoids splitting words in the middle at chunk
                             boundaries. Defaults to True.
+        sentence_boundaries (bool): If True, avoids splitting sentences in the middle at
+                            chunk boundaries using nltk's sentence tokenizer. When a
+                            sentence exceeds chunk_size it falls back to approximate_end.
+                            Requires the ``nltk`` package and the ``punkt_tab`` corpus
+                            (downloaded automatically on first use). Defaults to False.
 
 
     Example:
@@ -93,7 +153,11 @@ class FixedSizeSplitter(TextSplitter):
 
     @validate_call
     def __init__(
-        self, chunk_size: int = 4000, chunk_overlap: int = 200, approximate: bool = True
+        self,
+        chunk_size: int = 4000,
+        chunk_overlap: int = 200,
+        approximate: bool = True,
+        sentence_boundaries: bool = False,
     ) -> None:
         if chunk_size <= 0:
             raise ValueError("chunk_size must be strictly greater than 0")
@@ -102,6 +166,7 @@ class FixedSizeSplitter(TextSplitter):
         self.chunk_size = chunk_size
         self.chunk_overlap = chunk_overlap
         self.approximate = approximate
+        self.sentence_boundaries = sentence_boundaries
 
     @validate_call
     async def run(self, text: str) -> TextChunks:
@@ -121,8 +186,24 @@ class FixedSizeSplitter(TextSplitter):
         skip_adjust_chunk_start = False
         end = 0
 
+        sentence_starts: list[int] = []
+        sentence_ends: list[int] = []
+        if self.sentence_boundaries:
+            spans = _get_sentence_spans(text)
+            sentence_starts = [s for s, _ in spans]
+            sentence_ends = [e for _, e in spans]
+
         while end < text_length:
-            if self.approximate:
+            if self.sentence_boundaries:
+                start = (
+                    approximate_start
+                    if skip_adjust_chunk_start
+                    else _adjust_chunk_start_by_sentence(sentence_starts, approximate_start)
+                )
+                approximate_end = min(start + self.chunk_size, text_length)
+                end = _adjust_chunk_end_by_sentence(sentence_ends, start, approximate_end)
+                skip_adjust_chunk_start = end == approximate_end
+            elif self.approximate:
                 start = (
                     approximate_start
                     if skip_adjust_chunk_start

--- a/tests/unit/experimental/components/text_splitters/test_fixed_size_splitter.py
+++ b/tests/unit/experimental/components/text_splitters/test_fixed_size_splitter.py
@@ -13,12 +13,15 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from itertools import zip_longest
+from unittest.mock import patch
 
 import pytest
 from neo4j_graphrag.experimental.components.text_splitters.fixed_size_splitter import (
     FixedSizeSplitter,
     _adjust_chunk_end,
+    _adjust_chunk_end_by_sentence,
     _adjust_chunk_start,
+    _adjust_chunk_start_by_sentence,
 )
 from neo4j_graphrag.experimental.components.types import TextChunk
 
@@ -138,6 +141,113 @@ def test_adjust_chunk_end(
     """
     result = _adjust_chunk_end(text, start, approximate_end)
     assert result == expected_end
+
+
+@pytest.mark.parametrize(
+    "sentence_starts, approximate_start, expected_start",
+    [
+        # approximate_start is exactly at a sentence start
+        ([0, 14, 30], 14, 14),
+        # approximate_start is inside a sentence — snap back to sentence start
+        ([0, 14, 30], 20, 14),
+        # approximate_start is before all sentence starts — no snap
+        ([5, 14, 30], 2, 2),
+        # empty sentence list — passthrough
+        ([], 10, 10),
+        # approximate_start == 0
+        ([0, 14], 0, 0),
+    ],
+)
+def test_adjust_chunk_start_by_sentence(
+    sentence_starts: list[int],
+    approximate_start: int,
+    expected_start: int,
+) -> None:
+    assert _adjust_chunk_start_by_sentence(sentence_starts, approximate_start) == expected_start
+
+
+@pytest.mark.parametrize(
+    "sentence_ends, start, approximate_end, expected_end",
+    [
+        # approximate_end is exactly at a sentence end
+        ([13, 29, 45], 0, 29, 29),
+        # approximate_end is inside a sentence — snap back to previous sentence end
+        ([13, 29, 45], 0, 35, 29),
+        # only sentence end available is <= start — fallback to approximate_end
+        ([5], 10, 20, 20),
+        # empty sentence list — passthrough
+        ([], 0, 20, 20),
+        # approximate_end is past all sentence ends — return last sentence end
+        ([13, 29], 0, 50, 29),
+    ],
+)
+def test_adjust_chunk_end_by_sentence(
+    sentence_ends: list[int],
+    start: int,
+    approximate_end: int,
+    expected_end: int,
+) -> None:
+    assert _adjust_chunk_end_by_sentence(sentence_ends, start, approximate_end) == expected_end
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "spans, chunk_size, chunk_overlap, expected_chunks",
+    [
+        # Each sentence fits in its own chunk
+        # text = "Hello, world. This is nltk. Last sentence." (42 chars)
+        # sentence spans: [0,13), [14,27), [28,42)
+        (
+            [(0, 13), (14, 27), (28, 42)],
+            20,
+            0,
+            ["Hello, world.", "This is nltk.", "Last sentence."],
+        ),
+        # chunk_size large enough to fit two sentences; third goes to its own chunk
+        (
+            [(0, 13), (14, 27), (28, 42)],
+            30,
+            0,
+            ["Hello, world. This is nltk.", "Last sentence."],
+        ),
+        # with overlap: start snaps back to the sentence containing approximate_start
+        (
+            [(0, 13), (14, 27), (28, 42)],
+            20,
+            5,
+            ["Hello, world.", "This is nltk.", "Last sentence."],
+        ),
+        # sentence longer than chunk_size — falls back to fixed-size cuts
+        (
+            [(0, 42)],
+            20,
+            0,
+            ["Hello, world. This i", "s nltk. Last sentenc", "e."],
+        ),
+    ],
+)
+async def test_fixed_size_splitter_sentence_boundaries(
+    spans: list[tuple[int, int]],
+    chunk_size: int,
+    chunk_overlap: int,
+    expected_chunks: list[str],
+) -> None:
+    text = "Hello, world. This is nltk. Last sentence."
+    with patch(
+        "neo4j_graphrag.experimental.components.text_splitters.fixed_size_splitter._get_sentence_spans",
+        return_value=spans,
+    ):
+        splitter = FixedSizeSplitter(
+            chunk_size=chunk_size,
+            chunk_overlap=chunk_overlap,
+            sentence_boundaries=True,
+        )
+        result = await splitter.run(text)
+
+    assert len(result.chunks) == len(expected_chunks)
+    for i, expected_text in enumerate(expected_chunks):
+        assert result.chunks[i].text == expected_text
+        assert result.chunks[i].index == i
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description

This pull request introduces an experimental feature to the `FixedSizeSplitter` text splitter, allowing chunk boundaries to align with sentence ends using the NLTK Punkt tokenizer. It also updates dependencies and adds comprehensive tests for the new functionality.

* Added a `sentence_boundaries` parameter to `FixedSizeSplitter` (default `False`). When enabled, chunk boundaries are aligned to sentence ends using the NLTK Punkt tokenizer. Sentences longer than `chunk_size` are split using the existing logic. The required `punkt_tab` corpus is downloaded automatically if missing. 
* Implemented helper functions (`_get_sentence_spans`, `_adjust_chunk_start_by_sentence`, `_adjust_chunk_end_by_sentence`) to support sentence-based chunking. 
* Added `nltk>=3.8.0` to the `experimental` dependencies in `pyproject.toml`, and updated type checking configuration to ignore `nltk.*` import errors. 
* Added unit tests for the new sentence boundary logic, including edge cases and integration tests for `FixedSizeSplitter` with sentence boundaries enabled. 


## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: low

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [x] CHANGELOG.md updated if appropriate
