### PR TITLE
Add support for existing graph nodes and relationsships to the entity and relationship extractor

### DIFF
--- a/src/neo4j_graphrag/experimental/components/entity_relation_extractor.py
+++ b/src/neo4j_graphrag/experimental/components/entity_relation_extractor.py
@@ -228,13 +228,30 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
         self.prompt_template = template
 
     async def extract_for_chunk(
-        self, schema: GraphSchema, examples: str, chunk: TextChunk
+        self,
+        schema: GraphSchema,
+        examples: str,
+        chunk: TextChunk,
+        existing_graph: Optional[Neo4jGraph] = None,
     ) -> Neo4jGraph:
         """Run entity extraction for a given text chunk."""
+        existing_nodes = None
+        existing_rels = None
+        if existing_graph:
+            existing_nodes = [
+                n.model_dump(exclude={"embedding_properties"}, exclude_none=True)
+                for n in existing_graph.nodes
+            ]
+            existing_rels = [
+                r.model_dump(exclude={"embedding_properties"}, exclude_none=True)
+                for r in existing_graph.relationships
+            ]
         prompt = self.prompt_template.format(
             text=chunk.text,
             schema=schema.model_dump(exclude_none=True),
             examples=examples,
+            existing_nodes=existing_nodes,
+            existing_rels=existing_rels,
         )
 
         # Use structured output (V2) if enabled
@@ -322,10 +339,13 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
         schema: GraphSchema,
         examples: str,
         lexical_graph_builder: Optional[LexicalGraphBuilder] = None,
+        existing_graph: Optional[Neo4jGraph] = None,
     ) -> Neo4jGraph:
         """Run extraction, validation and post processing for a single chunk"""
         async with sem:
-            chunk_graph = await self.extract_for_chunk(schema, examples, chunk)
+            chunk_graph = await self.extract_for_chunk(
+                schema, examples, chunk, existing_graph
+            )
             # final_chunk_graph = self.validate_chunk(chunk_graph, schema)
             await self.post_process_chunk(
                 chunk_graph,
@@ -342,6 +362,7 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
         lexical_graph_config: Optional[LexicalGraphConfig] = None,
         schema: Optional[GraphSchema] = None,
         examples: str = "",
+        existing_graph: Optional[Neo4jGraph] = None,
         **kwargs: Any,
     ) -> Neo4jGraph:
         """Perform entity and relation extraction for all chunks in a list.
@@ -357,6 +378,7 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
             lexical_graph_config (Optional[LexicalGraphConfig], optional): Lexical graph configuration to customize node labels and relationship types in the lexical graph.
             schema (GraphSchema | None): Definition of the schema to guide the LLM in its extraction.
             examples (str): Examples for few-shot learning in the prompt.
+            existing_graph (Optional[Neo4jGraph]): Nodes and relationships already in the knowledge graph. When provided, the LLM is instructed to reuse their IDs for matching entities instead of creating new ones.
         """
         lexical_graph_builder = None
         lexical_graph = None
@@ -381,6 +403,7 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
                 schema,
                 examples,
                 lexical_graph_builder,
+                existing_graph,
             )
             for chunk in chunks.chunks
         ]

--- a/src/neo4j_graphrag/experimental/components/entity_relation_extractor.py
+++ b/src/neo4j_graphrag/experimental/components/entity_relation_extractor.py
@@ -362,7 +362,7 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
         lexical_graph_config: Optional[LexicalGraphConfig] = None,
         schema: Optional[GraphSchema] = None,
         examples: str = "",
-        existing_graph: Optional[Neo4jGraph] = None,
+        existing_graphs: Optional[list[Neo4jGraph]] = None,
         **kwargs: Any,
     ) -> Neo4jGraph:
         """Perform entity and relation extraction for all chunks in a list.
@@ -378,8 +378,13 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
             lexical_graph_config (Optional[LexicalGraphConfig], optional): Lexical graph configuration to customize node labels and relationship types in the lexical graph.
             schema (GraphSchema | None): Definition of the schema to guide the LLM in its extraction.
             examples (str): Examples for few-shot learning in the prompt.
-            existing_graph (Optional[Neo4jGraph]): Nodes and relationships already in the knowledge graph. When provided, the LLM is instructed to reuse their IDs for matching entities instead of creating new ones.
+            existing_graphs (Optional[list[Neo4jGraph]]): One subgraph per chunk, each containing nodes and relationships already in the knowledge graph that are relevant to that chunk. When provided, the LLM is instructed to reuse their IDs for matching entities instead of creating new ones. Must have the same length as chunks.
         """
+        if existing_graphs is not None and len(existing_graphs) != len(chunks.chunks):
+            raise ValueError(
+                f"existing_graphs length ({len(existing_graphs)}) must match "
+                f"chunks length ({len(chunks.chunks)})"
+            )
         lexical_graph_builder = None
         lexical_graph = None
         if self.create_lexical_graph:
@@ -403,9 +408,9 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
                 schema,
                 examples,
                 lexical_graph_builder,
-                existing_graph,
+                existing_graphs[i] if existing_graphs else None,
             )
-            for chunk in chunks.chunks
+            for i, chunk in enumerate(chunks.chunks)
         ]
         chunk_graphs: list[Neo4jGraph] = list(await asyncio.gather(*tasks))
         graph = self.combine_chunk_graphs(lexical_graph, chunk_graphs)

--- a/src/neo4j_graphrag/generation/prompts.py
+++ b/src/neo4j_graphrag/generation/prompts.py
@@ -14,6 +14,7 @@
 #  limitations under the License.
 from __future__ import annotations
 
+import json
 import warnings
 from typing import Any, Optional
 
@@ -178,6 +179,7 @@ Assign a unique ID (string) to each node, and reuse it to define relationships.
 Do respect the source and target node types for relationship and
 the relationship direction.
 
+{existing_entities}
 Make sure you adhere to the following rules to produce valid JSON objects:
 - Do not return any additional information other than the JSON in it.
 - Omit any backticks around the JSON - simply output the JSON on its own.
@@ -198,8 +200,31 @@ Input text:
         schema: dict[str, Any],
         examples: str,
         text: str = "",
+        existing_nodes: Optional[list[dict[str, Any]]] = None,
+        existing_rels: Optional[list[dict[str, Any]]] = None,
     ) -> str:
-        return super().format(text=text, schema=schema, examples=examples)
+        if existing_nodes or existing_rels:
+            existing_entities = (
+                "The following nodes and relationships already exist in the knowledge graph.\n"
+                "When an entity in the text matches an existing node, reuse its exact ID instead of\n"
+                "creating a new one. Only assign a new ID to genuinely new entities.\n\n"
+                "Existing graph entities:\n"
+                + json.dumps(
+                    {
+                        "nodes": existing_nodes or [],
+                        "relationships": existing_rels or [],
+                    }
+                )
+                + "\n"
+            )
+        else:
+            existing_entities = ""
+        return super().format(
+            text=text,
+            schema=schema,
+            examples=examples,
+            existing_entities=existing_entities,
+        )
 
 
 class SchemaExtractionTemplate(PromptTemplate):

--- a/tests/e2e/experimental/test_kg_builder_pipeline_e2e.py
+++ b/tests/e2e/experimental/test_kg_builder_pipeline_e2e.py
@@ -37,6 +37,10 @@ from neo4j_graphrag.experimental.components.schema import (
     PropertyType,
     RelationshipType,
 )
+from neo4j_graphrag.experimental.components.types import (
+    Neo4jGraph,
+    Neo4jNode,
+)
 from neo4j_graphrag.experimental.components.text_splitters.fixed_size_splitter import (
     FixedSizeSplitter,
 )
@@ -598,3 +602,107 @@ async def test_pipeline_builder_two_documents(
         "MATCH (:__Entity__)-[r]->(:__Entity__) RETURN r"
     )
     assert len(created_rels.records) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("setup_neo4j_for_kg_construction")
+async def test_pipeline_builder_with_existing_graph(
+    harry_potter_text: str,
+    llm: MagicMock,
+    embedder: MagicMock,
+    driver: neo4j.Driver,
+    kg_builder_pipeline: Pipeline,
+) -> None:
+    """Test that existing graph entities are forwarded to the LLM and that the
+    LLM can complement them with newly extracted nodes.
+
+    One existing node ("Alastor Mad-Eye Moody", id "existing-0") is provided as
+    an existing graph for the first chunk. The mocked LLM reuses that id and adds
+    a new node ("Harry Potter", id "0").  The test verifies:
+    - the prompt received by the LLM contained the existing node
+    - the final Neo4j graph contains both the pre-existing and new entities
+    """
+    driver.execute_query("MATCH (n) DETACH DELETE n")
+    embedder.async_embed_query.return_value = [1, 2, 3]
+
+    # The LLM reuses the existing node id "existing-0" for Mad-Eye Moody and
+    # introduces a new node "Harry Potter" with id "0".
+    llm.ainvoke.side_effect = [
+        LLMResponse(
+            content="""{
+                "nodes": [
+                    {
+                        "id": "existing-0",
+                        "label": "Person",
+                        "properties": {"name": "Alastor Mad-Eye Moody"}
+                    },
+                    {
+                        "id": "0",
+                        "label": "Person",
+                        "properties": {"name": "Harry Potter"}
+                    }
+                ],
+                "relationships": [
+                    {
+                        "type": "KNOWS",
+                        "start_node_id": "0",
+                        "end_node_id": "existing-0"
+                    }
+                ]
+            }"""
+        ),
+        LLMResponse(content='{"nodes": [], "relationships": []}'),
+    ]
+
+    # One existing subgraph per chunk. The first chunk gets the pre-existing node;
+    # the second chunk gets an empty graph.
+    existing_graphs = [
+        Neo4jGraph(
+            nodes=[
+                Neo4jNode(
+                    id="existing-0",
+                    label="Person",
+                    properties={"name": "Alastor Mad-Eye Moody"},
+                )
+            ],
+            relationships=[],
+        ),
+        Neo4jGraph(),
+    ]
+
+    pipe_inputs = {
+        "splitter": {"text": harry_potter_text},
+        "schema": {
+            "node_types": [
+                NodeType(
+                    label="Person",
+                    properties=[PropertyType(name="name", type="STRING")],
+                ),
+            ],
+            "relationship_types": [RelationshipType(label="KNOWS")],
+            "patterns": [("Person", "KNOWS", "Person")],
+        },
+        "extractor": {"existing_graphs": existing_graphs},
+    }
+
+    res = await kg_builder_pipeline.run(pipe_inputs)
+
+    assert isinstance(res, PipelineResult)
+    assert res.run_id is not None
+
+    # The LLM prompt for the first chunk must have contained the existing node.
+    first_call_prompt = llm.ainvoke.call_args_list[0][0][0]
+    assert "Alastor Mad-Eye Moody" in first_call_prompt
+    assert "existing-0" in first_call_prompt
+
+    # Both nodes must be present in the DB after writing.
+    created_nodes = driver.execute_query("MATCH (n:Person) RETURN n")
+    names = {r["n"]["name"] for r in created_nodes.records}
+    assert "Harry Potter" in names
+    assert "Alastor Mad-Eye Moody" in names
+
+    # The KNOWS relationship must have been written.
+    created_rels = driver.execute_query(
+        "MATCH (:Person)-[r:KNOWS]->(:Person) RETURN r"
+    )
+    assert len(created_rels.records) == 1

--- a/tests/unit/experimental/components/test_entity_relation_extractor.py
+++ b/tests/unit/experimental/components/test_entity_relation_extractor.py
@@ -475,17 +475,19 @@ def test_extractor_structured_output_unsupported_llm() -> None:
 
 
 @pytest.mark.asyncio
-async def test_extractor_with_existing_graph_includes_entities_in_prompt() -> None:
+async def test_extractor_with_existing_graphs_includes_entities_in_prompt() -> None:
     llm = MagicMock(spec=LLMInterface)
     llm.ainvoke.return_value = LLMResponse(content='{"nodes": [], "relationships": []}')
 
     extractor = LLMEntityRelationExtractor(llm=llm, create_lexical_graph=False)
     chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
-    existing_graph = Neo4jGraph(
-        nodes=[Neo4jNode(id="0", label="Person", properties={"name": "Alice"})],
-        relationships=[],
-    )
-    await extractor.run(chunks=chunks, existing_graph=existing_graph)
+    existing_graphs = [
+        Neo4jGraph(
+            nodes=[Neo4jNode(id="0", label="Person", properties={"name": "Alice"})],
+            relationships=[],
+        )
+    ]
+    await extractor.run(chunks=chunks, existing_graphs=existing_graphs)
 
     prompt = llm.ainvoke.call_args[0][0]
     assert "Existing graph entities" in prompt
@@ -493,38 +495,40 @@ async def test_extractor_with_existing_graph_includes_entities_in_prompt() -> No
 
 
 @pytest.mark.asyncio
-async def test_extractor_with_existing_graph_excludes_embedding_properties() -> None:
+async def test_extractor_with_existing_graphs_excludes_embedding_properties() -> None:
     llm = MagicMock(spec=LLMInterface)
     llm.ainvoke.return_value = LLMResponse(content='{"nodes": [], "relationships": []}')
 
     extractor = LLMEntityRelationExtractor(llm=llm, create_lexical_graph=False)
     chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
-    existing_graph = Neo4jGraph(
-        nodes=[
-            Neo4jNode(
-                id="0",
-                label="Person",
-                properties={"name": "Alice"},
-                embedding_properties={"embedding": [0.1, 0.2, 0.3]},
-            )
-        ],
-        relationships=[
-            Neo4jRelationship(
-                start_node_id="0",
-                end_node_id="1",
-                type="KNOWS",
-                embedding_properties={"embedding": [0.4, 0.5]},
-            )
-        ],
-    )
-    await extractor.run(chunks=chunks, existing_graph=existing_graph)
+    existing_graphs = [
+        Neo4jGraph(
+            nodes=[
+                Neo4jNode(
+                    id="0",
+                    label="Person",
+                    properties={"name": "Alice"},
+                    embedding_properties={"embedding": [0.1, 0.2, 0.3]},
+                )
+            ],
+            relationships=[
+                Neo4jRelationship(
+                    start_node_id="0",
+                    end_node_id="1",
+                    type="KNOWS",
+                    embedding_properties={"embedding": [0.4, 0.5]},
+                )
+            ],
+        )
+    ]
+    await extractor.run(chunks=chunks, existing_graphs=existing_graphs)
 
     prompt = llm.ainvoke.call_args[0][0]
     assert "embedding_properties" not in prompt
 
 
 @pytest.mark.asyncio
-async def test_extractor_without_existing_graph_omits_entities_block() -> None:
+async def test_extractor_without_existing_graphs_omits_entities_block() -> None:
     llm = MagicMock(spec=LLMInterface)
     llm.ainvoke.return_value = LLMResponse(content='{"nodes": [], "relationships": []}')
 
@@ -534,6 +538,51 @@ async def test_extractor_without_existing_graph_omits_entities_block() -> None:
 
     prompt = llm.ainvoke.call_args[0][0]
     assert "Existing graph entities" not in prompt
+
+
+@pytest.mark.asyncio
+async def test_extractor_existing_graphs_per_chunk_routes_correctly() -> None:
+    llm = MagicMock(spec=LLMInterface)
+    llm.ainvoke.return_value = LLMResponse(content='{"nodes": [], "relationships": []}')
+
+    extractor = LLMEntityRelationExtractor(llm=llm, create_lexical_graph=False)
+    chunks = TextChunks(
+        chunks=[
+            TextChunk(text="chunk one", index=0),
+            TextChunk(text="chunk two", index=1),
+        ]
+    )
+    existing_graphs = [
+        Neo4jGraph(
+            nodes=[Neo4jNode(id="0", label="Person", properties={"name": "Alice"})],
+            relationships=[],
+        ),
+        Neo4jGraph(
+            nodes=[Neo4jNode(id="1", label="Company", properties={"name": "Acme"})],
+            relationships=[],
+        ),
+    ]
+    await extractor.run(chunks=chunks, existing_graphs=existing_graphs)
+
+    prompts = [call[0][0] for call in llm.ainvoke.call_args_list]
+    assert any('"Alice"' in p for p in prompts)
+    assert any('"Acme"' in p for p in prompts)
+
+
+@pytest.mark.asyncio
+async def test_extractor_existing_graphs_length_mismatch_raises() -> None:
+    llm = MagicMock(spec=LLMInterface)
+    extractor = LLMEntityRelationExtractor(llm=llm, create_lexical_graph=False)
+    chunks = TextChunks(
+        chunks=[
+            TextChunk(text="chunk one", index=0),
+            TextChunk(text="chunk two", index=1),
+        ]
+    )
+    existing_graphs = [Neo4jGraph()]  # only one graph for two chunks
+
+    with pytest.raises(ValueError, match="existing_graphs length"):
+        await extractor.run(chunks=chunks, existing_graphs=existing_graphs)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/experimental/components/test_entity_relation_extractor.py
+++ b/tests/unit/experimental/components/test_entity_relation_extractor.py
@@ -28,6 +28,8 @@ from neo4j_graphrag.experimental.components.entity_relation_extractor import (
 from neo4j_graphrag.experimental.components.types import (
     DocumentInfo,
     Neo4jGraph,
+    Neo4jNode,
+    Neo4jRelationship,
     TextChunk,
     TextChunks,
 )
@@ -470,6 +472,68 @@ def test_extractor_structured_output_unsupported_llm() -> None:
         )
 
     assert "Structured output is not supported" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_extractor_with_existing_graph_includes_entities_in_prompt() -> None:
+    llm = MagicMock(spec=LLMInterface)
+    llm.ainvoke.return_value = LLMResponse(content='{"nodes": [], "relationships": []}')
+
+    extractor = LLMEntityRelationExtractor(llm=llm, create_lexical_graph=False)
+    chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
+    existing_graph = Neo4jGraph(
+        nodes=[Neo4jNode(id="0", label="Person", properties={"name": "Alice"})],
+        relationships=[],
+    )
+    await extractor.run(chunks=chunks, existing_graph=existing_graph)
+
+    prompt = llm.ainvoke.call_args[0][0]
+    assert "Existing graph entities" in prompt
+    assert '"Alice"' in prompt
+
+
+@pytest.mark.asyncio
+async def test_extractor_with_existing_graph_excludes_embedding_properties() -> None:
+    llm = MagicMock(spec=LLMInterface)
+    llm.ainvoke.return_value = LLMResponse(content='{"nodes": [], "relationships": []}')
+
+    extractor = LLMEntityRelationExtractor(llm=llm, create_lexical_graph=False)
+    chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
+    existing_graph = Neo4jGraph(
+        nodes=[
+            Neo4jNode(
+                id="0",
+                label="Person",
+                properties={"name": "Alice"},
+                embedding_properties={"embedding": [0.1, 0.2, 0.3]},
+            )
+        ],
+        relationships=[
+            Neo4jRelationship(
+                start_node_id="0",
+                end_node_id="1",
+                type="KNOWS",
+                embedding_properties={"embedding": [0.4, 0.5]},
+            )
+        ],
+    )
+    await extractor.run(chunks=chunks, existing_graph=existing_graph)
+
+    prompt = llm.ainvoke.call_args[0][0]
+    assert "embedding_properties" not in prompt
+
+
+@pytest.mark.asyncio
+async def test_extractor_without_existing_graph_omits_entities_block() -> None:
+    llm = MagicMock(spec=LLMInterface)
+    llm.ainvoke.return_value = LLMResponse(content='{"nodes": [], "relationships": []}')
+
+    extractor = LLMEntityRelationExtractor(llm=llm, create_lexical_graph=False)
+    chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
+    await extractor.run(chunks=chunks)
+
+    prompt = llm.ainvoke.call_args[0][0]
+    assert "Existing graph entities" not in prompt
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_prompt_template.py
+++ b/tests/unit/test_prompt_template.py
@@ -1,9 +1,11 @@
+import json
+
 import pytest
 from neo4j_graphrag.exceptions import (
     PromptMissingInputError,
     PromptMissingPlaceholderError,
 )
-from neo4j_graphrag.generation.prompts import PromptTemplate
+from neo4j_graphrag.generation.prompts import ERExtractionTemplate, PromptTemplate
 
 
 def test_prompt_template_all_default() -> None:
@@ -79,3 +81,54 @@ def test_prompt_template_format_given_unused_kwargs() -> None:
     assert (
         template.format(query_text="what do?", banana="b") == "My question is what do?"
     )
+
+
+def test_er_extraction_template_no_existing_entities() -> None:
+    template = ERExtractionTemplate()
+    prompt = template.format(schema={}, examples="", text="some text")
+    assert "Existing graph entities" not in prompt
+    assert "None" not in prompt
+
+
+def test_er_extraction_template_with_existing_nodes() -> None:
+    template = ERExtractionTemplate()
+    existing_nodes = [{"id": "0", "label": "Person", "properties": {"name": "Alice"}}]
+    prompt = template.format(
+        schema={},
+        examples="",
+        text="some text",
+        existing_nodes=existing_nodes,
+    )
+    assert "Existing graph entities" in prompt
+    assert json.dumps({"nodes": existing_nodes, "relationships": []}) in prompt
+
+
+def test_er_extraction_template_with_existing_nodes_and_rels() -> None:
+    template = ERExtractionTemplate()
+    existing_nodes = [{"id": "0", "label": "Person", "properties": {"name": "Alice"}}]
+    existing_rels = [
+        {"type": "KNOWS", "start_node_id": "0", "end_node_id": "1", "properties": {}}
+    ]
+    prompt = template.format(
+        schema={},
+        examples="",
+        text="some text",
+        existing_nodes=existing_nodes,
+        existing_rels=existing_rels,
+    )
+    assert "Existing graph entities" in prompt
+    assert (
+        json.dumps({"nodes": existing_nodes, "relationships": existing_rels}) in prompt
+    )
+
+
+def test_er_extraction_template_with_empty_existing_lists() -> None:
+    template = ERExtractionTemplate()
+    prompt = template.format(
+        schema={},
+        examples="",
+        text="some text",
+        existing_nodes=[],
+        existing_rels=[],
+    )
+    assert "Existing graph entities" not in prompt


### PR DESCRIPTION
# Description

This pull request enhances the entity and relation extraction process by allowing the system to incorporate information about existing nodes and relationships in the knowledge graph. When provided, these existing entities are included in the prompt to the language model, instructing it to reuse IDs for matching entities instead of creating duplicates. The changes also ensure that sensitive or unnecessary properties (like embeddings) are excluded from the prompt and add comprehensive tests for the new functionality.

* The `LLMEntityRelationExtractor` now accepts an optional `existing_graph` parameter in its main methods (`run`, `run_for_chunk`, and `extract_for_chunk`). When supplied, the extractor serializes existing nodes and relationships (excluding `embedding_properties`) and includes them in the prompt to guide the language model to reuse entity IDs. 
* The `ERExtractionTemplate` prompt now conditionally adds a section listing existing nodes and relationships, formatted as JSON, and provides clear instructions to the LLM about reusing IDs for existing entities. If no existing entities are provided, this section is omitted.
* New unit tests verify that:
  - Existing entities are included in the prompt when provided.
  - `embedding_properties` are excluded from the prompt.
  - The "Existing graph entities" section is omitted when no existing entities are provided.
  - The prompt template formats the existing entity information correctly under various scenarios. 

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: low

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
