### PR TITLE
fix(schema): raise a clear error for duplicate relationship types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ ENVIRONMENT MANAGEMENT:
 - `WeakKeyDictionary` works for caching per-driver since `neo4j.Driver` is hashable
 - Neo4j 2026 CREATE VECTOR INDEX syntax: WITH clause must come BEFORE OPTIONS, not after
 - E2E tests for SEARCH clause: use `docker compose -f tests/e2e/docker-compose.neo4j2026.yml up -d`
+- GraphSchema (experimental) validation tests live in `tests/unit/experimental/components/test_schema.py`; the root `tests/unit/test_schema.py` only covers `neo4j_graphrag.schema` DB introspection
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,6 @@ ENVIRONMENT MANAGEMENT:
 - `WeakKeyDictionary` works for caching per-driver since `neo4j.Driver` is hashable
 - Neo4j 2026 CREATE VECTOR INDEX syntax: WITH clause must come BEFORE OPTIONS, not after
 - E2E tests for SEARCH clause: use `docker compose -f tests/e2e/docker-compose.neo4j2026.yml up -d`
-- GraphSchema (experimental) validation tests live in `tests/unit/experimental/components/test_schema.py`; the root `tests/unit/test_schema.py` only covers `neo4j_graphrag.schema` DB introspection
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Experimental: `GraphSchema` validation now rejects `KEY` and `EXISTENCE` constraints on the same node or relationship property (including composite KEY members), since KEY already implies mandatory presence. Legacy `PropertyType.required` migration no longer adds redundant EXISTENCE constraints for KEY-covered properties. The schema-from-text extraction prompt includes the same rule.
 - Experimental: the schema-from-text extraction prompt now instructs the LLM to define each relationship type once and reuse it across patterns, using distinct type names only when patterns genuinely need different properties or constraints.
 - Experimental: LLM-auto-generated schemas now reconcile duplicate `relationship_types` (entries sharing the same label) by merging them into a single type that carries the union of their properties, emitting a warning log. This reflects that Neo4j relationship types are global per name.
+- Experimental (**breaking**): `GraphSchema` now raises `SchemaValidationError` when the same label appears more than once in `relationship_types`. Previously such duplicates were silently resolved by last-write-wins. Because Neo4j relationship types are global per name (every relationship of a given type shares the same properties and constraints regardless of its endpoints), a label cannot have two conflicting definitions.
 
 ## 1.17.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Experimental: `GraphSchema` validation now rejects `KEY` and `EXISTENCE` constraints on the same node or relationship property (including composite KEY members), since KEY already implies mandatory presence. Legacy `PropertyType.required` migration no longer adds redundant EXISTENCE constraints for KEY-covered properties. The schema-from-text extraction prompt includes the same rule.
 - Experimental: the schema-from-text extraction prompt now instructs the LLM to define each relationship type once and reuse it across patterns, using distinct type names only when patterns genuinely need different properties or constraints.
 - Experimental: LLM-auto-generated schemas now reconcile duplicate `relationship_types` (entries sharing the same label) by merging them into a single type that carries the union of their properties, emitting a warning log. This reflects that Neo4j relationship types are global per name.
-- Experimental (**breaking**): `GraphSchema` now raises `SchemaValidationError` when the same label appears more than once in `relationship_types`. Previously such duplicates were silently resolved by last-write-wins. Because Neo4j relationship types are global per name (every relationship of a given type shares the same properties and constraints regardless of its endpoints), a label cannot have two conflicting definitions.
+- Experimental (**breaking**): `GraphSchema` now raises `SchemaValidationError` when the same label appears more than once in `relationship_types`. Because Neo4j relationship types are global per name (every relationship of a given type shares the same properties and constraints regardless of its endpoints), a label cannot have two conflicting definitions. 
 
 ## 1.17.0
 

--- a/src/neo4j_graphrag/experimental/components/schema.py
+++ b/src/neo4j_graphrag/experimental/components/schema.py
@@ -381,6 +381,30 @@ def _validate_constraint_property_defined(
                 )
 
 
+def _format_duplicate_relationship_types_error(
+    duplicates: dict[str, list[RelationshipType]],
+) -> str:
+    """Build the SchemaValidationError message for duplicate relationship-type labels."""
+    parts: list[str] = []
+    for label, entries in duplicates.items():
+        property_sets = ", ".join(
+            "{" + ", ".join(sorted(p.name for p in rel.properties)) + "}"
+            for rel in entries
+        )
+        parts.append(
+            f"Duplicate relationship type '{label}' defined {len(entries)} times "
+            f"with property sets: {property_sets}."
+        )
+    parts.append(
+        "In Neo4j a relationship type is global per name: entries sharing a label "
+        "describe the same type, and any constraint on it applies to every instance "
+        "regardless of source/target nodes. Define the relationship type once and reuse it across patterns, "
+        "or use distinct relationship types when patterns need different properties "
+        "or constraints."
+    )
+    return " ".join(parts)
+
+
 class Pattern(BaseModel):
     """Represents a relationship pattern in the graph schema.
 
@@ -700,6 +724,28 @@ class GraphSchema(DataModel):
                         f"Node type '{entity2}' is not defined in the provided node_types."
                     )
 
+        return self
+
+    @model_validator(mode="after")
+    def validate_no_duplicate_relationship_types(self) -> Self:
+        """Reject duplicate ``relationship_types`` labels.
+
+        In Neo4j a relationship type is global per name, so two entries sharing
+        the same ``label`` describe the same type and are an invalid model. This
+        check runs before constraint validation so the resulting error is the
+        clear duplicate-label message rather than a misleading "undefined
+        property" constraint error produced by the last-write-wins index.
+        """
+        seen: dict[str, list[RelationshipType]] = {}
+        for rel in self.relationship_types:
+            seen.setdefault(rel.label, []).append(rel)
+        duplicates = {
+            label: entries for label, entries in seen.items() if len(entries) > 1
+        }
+        if duplicates:
+            raise SchemaValidationError(
+                _format_duplicate_relationship_types_error(duplicates)
+            )
         return self
 
     @model_validator(mode="after")

--- a/src/neo4j_graphrag/experimental/components/schema.py
+++ b/src/neo4j_graphrag/experimental/components/schema.py
@@ -390,11 +390,12 @@ def _format_duplicate_relationship_types_error(
         property_sets = ", ".join(
             "{" + ", ".join(sorted(p.name for p in rel.properties)) + "}"
             for rel in entries
+            if rel.properties
         )
-        parts.append(
-            f"Duplicate relationship type '{label}' defined {len(entries)} times "
-            f"with property sets: {property_sets}."
-        )
+        message = f"Duplicate relationship type '{label}' defined {len(entries)} times"
+        if property_sets:
+            message += f" with property sets: {property_sets}"
+        parts.append(f"{message}.")
     parts.append(
         "In Neo4j a relationship type is global per name: entries sharing a label "
         "describe the same type, and any constraint on it applies to every instance "

--- a/src/neo4j_graphrag/experimental/components/schema.py
+++ b/src/neo4j_graphrag/experimental/components/schema.py
@@ -403,7 +403,7 @@ def _format_duplicate_relationship_types_error(
         "or use distinct relationship types when patterns need different properties "
         "or constraints."
     )
-    return " ".join(parts)
+    return "\n".join(parts)
 
 
 class Pattern(BaseModel):

--- a/tests/unit/experimental/components/test_schema.py
+++ b/tests/unit/experimental/components/test_schema.py
@@ -2804,3 +2804,83 @@ def test_merge_duplicate_relationship_types_handles_missing_or_none_properties()
     assert len(result) == 1
     assert result[0]["label"] == "KNOWS"
     assert [p["name"] for p in result[0]["properties"]] == ["since"]
+
+
+def test_schema_duplicate_relationship_types_repro_raises_clear_error() -> None:
+    # Repro: two PARTICIPATED_IN relationship_types with differing properties
+    # plus a KEY constraint. The duplicate-label error must replace the old
+    # misleading "undefined property" constraint error.
+    schema_dict: dict[str, Any] = {
+        "node_types": [
+            {"label": "Patient", "properties": [{"name": "name", "type": "STRING"}]},
+            {"label": "Encounter", "properties": [{"name": "name", "type": "STRING"}]},
+            {"label": "Physician", "properties": [{"name": "name", "type": "STRING"}]},
+        ],
+        "relationship_types": [
+            {
+                "label": "PARTICIPATED_IN",
+                "properties": [{"name": "encounter_name", "type": "STRING"}],
+            },
+            {
+                "label": "PARTICIPATED_IN",
+                "properties": [{"name": "physician_name", "type": "STRING"}],
+            },
+        ],
+        "constraints": [
+            {
+                "type": "KEY",
+                "node_type": "",
+                "relationship_type": "PARTICIPATED_IN",
+                "property_names": ["date"],
+            }
+        ],
+    }
+
+    with pytest.raises(SchemaValidationError) as exc_info:
+        GraphSchema.model_validate(schema_dict)
+
+    message = str(exc_info.value)
+    # Names the duplicated label.
+    assert "PARTICIPATED_IN" in message
+    # Names both property sets.
+    assert "encounter_name" in message
+    assert "physician_name" in message
+    # Is the new duplicate-label error, not the old constraint error.
+    assert "Duplicate relationship type" in message
+    assert "undefined property" not in message
+    assert "Valid properties" not in message
+
+
+def test_schema_duplicate_relationship_types_identical_properties_raises() -> None:
+    # Any duplicate label triggers the error, even when properties are identical.
+    schema_dict: dict[str, Any] = {
+        "node_types": [
+            {"label": "Person", "properties": [{"name": "name", "type": "STRING"}]}
+        ],
+        "relationship_types": [
+            {"label": "KNOWS", "properties": [{"name": "since", "type": "INTEGER"}]},
+            {"label": "KNOWS", "properties": [{"name": "since", "type": "INTEGER"}]},
+        ],
+    }
+
+    with pytest.raises(SchemaValidationError) as exc_info:
+        GraphSchema.model_validate(schema_dict)
+
+    assert "Duplicate relationship type 'KNOWS'" in str(exc_info.value)
+
+
+def test_schema_unique_relationship_types_validate_successfully() -> None:
+    # All-unique relationship-type labels validate without error (no regression).
+    schema_dict: dict[str, Any] = {
+        "node_types": [
+            {"label": "Person", "properties": [{"name": "name", "type": "STRING"}]}
+        ],
+        "relationship_types": [
+            {"label": "KNOWS", "properties": [{"name": "since", "type": "INTEGER"}]},
+            {"label": "LIKES", "properties": [{"name": "score", "type": "INTEGER"}]},
+        ],
+    }
+
+    schema = GraphSchema.model_validate(schema_dict)
+
+    assert {rel.label for rel in schema.relationship_types} == {"KNOWS", "LIKES"}

--- a/tests/unit/experimental/components/test_schema.py
+++ b/tests/unit/experimental/components/test_schema.py
@@ -2807,7 +2807,7 @@ def test_merge_duplicate_relationship_types_handles_missing_or_none_properties()
 
 
 def test_schema_duplicate_relationship_types_repro_raises_clear_error() -> None:
-    # Repro: two PARTICIPATED_IN relationship_types with differing properties
+    # PRD repro: two PARTICIPATED_IN relationship_types with differing properties
     # plus a KEY constraint. The duplicate-label error must replace the old
     # misleading "undefined property" constraint error.
     schema_dict: dict[str, Any] = {
@@ -2816,22 +2816,40 @@ def test_schema_duplicate_relationship_types_repro_raises_clear_error() -> None:
             {"label": "Encounter", "properties": [{"name": "name", "type": "STRING"}]},
             {"label": "Physician", "properties": [{"name": "name", "type": "STRING"}]},
         ],
+        "patterns": [
+            {
+                "source": "Patient",
+                "relationship": "PARTICIPATED_IN",
+                "target": "Encounter",
+            },
+            {
+                "source": "Encounter",
+                "relationship": "PARTICIPATED_IN",
+                "target": "Physician",
+            },
+        ],
         "relationship_types": [
             {
                 "label": "PARTICIPATED_IN",
-                "properties": [{"name": "encounter_name", "type": "STRING"}],
+                "properties": [
+                    {"name": "date", "type": "DATE"},
+                    {"name": "patient_name", "type": "STRING"},
+                    {"name": "encounter_name", "type": "STRING"},
+                ],
             },
             {
                 "label": "PARTICIPATED_IN",
-                "properties": [{"name": "physician_name", "type": "STRING"}],
+                "properties": [
+                    {"name": "encounter_name", "type": "STRING"},
+                    {"name": "physician_name", "type": "STRING"},
+                ],
             },
         ],
         "constraints": [
             {
                 "type": "KEY",
-                "node_type": "",
                 "relationship_type": "PARTICIPATED_IN",
-                "property_names": ["date"],
+                "property_names": ["date", "patient_name", "encounter_name"],
             }
         ],
     }
@@ -2842,7 +2860,7 @@ def test_schema_duplicate_relationship_types_repro_raises_clear_error() -> None:
     message = str(exc_info.value)
     # Names the duplicated label.
     assert "PARTICIPATED_IN" in message
-    # Names both property sets.
+    # Names both conflicting property sets.
     assert "encounter_name" in message
     assert "physician_name" in message
     # Is the new duplicate-label error, not the old constraint error.
@@ -2867,20 +2885,3 @@ def test_schema_duplicate_relationship_types_identical_properties_raises() -> No
         GraphSchema.model_validate(schema_dict)
 
     assert "Duplicate relationship type 'KNOWS'" in str(exc_info.value)
-
-
-def test_schema_unique_relationship_types_validate_successfully() -> None:
-    # All-unique relationship-type labels validate without error (no regression).
-    schema_dict: dict[str, Any] = {
-        "node_types": [
-            {"label": "Person", "properties": [{"name": "name", "type": "STRING"}]}
-        ],
-        "relationship_types": [
-            {"label": "KNOWS", "properties": [{"name": "since", "type": "INTEGER"}]},
-            {"label": "LIKES", "properties": [{"name": "score", "type": "INTEGER"}]},
-        ],
-    }
-
-    schema = GraphSchema.model_validate(schema_dict)
-
-    assert {rel.label for rel in schema.relationship_types} == {"KNOWS", "LIKES"}


### PR DESCRIPTION
# Description

Improves the `SchemaValidationError` raised for graph schemas that define the same relationship-type label more than once in `relationship_types` with different properties and constraints. 
e.g.
```
"patterns": [
    {"source": "Patient",   "relationship": "PARTICIPATED_IN", "target": "Encounter"},
    {"source": "Encounter", "relationship": "PARTICIPATED_IN", "target": "Physician"}
  ],
  "relationship_types": [
    {"label": "PARTICIPATED_IN", "properties": [                                                                                                                                             
      {"name": "date"},
      {"name": "patient_name"},
      {"name": "encounter_name"}
    ]},
    {"label": "PARTICIPATED_IN", "properties": [                                                                                                                                             
      {"name": "encounter_name"},
      {"name": "physician_name"}
    ]}
  ],
  "constraints": [
    {"relationship_type": "PARTICIPATED_IN", "type": "KEY",
     "property_names": ["date", "patient_name", "encounter_name"]}
  ]
```
Currently, on schema validation, duplicate relationship-type labels are silently collapsed by last-write-wins lookup index. When a constraint then references a property that lived on the shadowed (overwritten) duplicate, validation fails with a *misleading* error that listed the surviving entry's properties as the only "valid" ones 

```
  File "/workspace/.venv/lib/python3.12/site-packages/neo4j_graphrag/experimental/components/schema.py", line 708, in validate_constraints_against_node_types
    _validate_constraint_property_defined(
  File "/workspace/.venv/lib/python3.12/site-packages/neo4j_graphrag/experimental/components/schema.py", line 376, in _validate_constraint_property_defined
    raise SchemaValidationError(
neo4j_graphrag.exceptions.SchemaValidationError: KEY constraint references undefined property 'date' on relationship type 'PARTICIPATED_IN'. Valid properties: {'encounter_name', 'physician_name'}
```

This is incorrect on two counts: the property *does* exist (on the other duplicate), and - per Neo4j semantics - a relationship type is global per name, so two entries with the same label and different definitions are an invalid model in the first place.

`GraphSchema` now detects duplicate `relationship_types` labels up front and raises a clear, actionable `SchemaValidationError` that names the duplicated label, its property sets, the underlying Neo4j rule, and a suggestion to fix it. The check runs before constraint validation, so the clear duplicate-label error replaces the old misleading one.

This path intended for user-provided schema (where users should be informed about what's going wrong with their provided model). Follow-up PRs will handle the LLM schema-generation path, where the prompt will be slightly tuned to avoid having that + a post extraction validation step to reconcile automatically duplicate relationship types.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [x] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High
>
>

Complexity: Low

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [x] CHANGELOG.md updated if appropriate
