### PR TITLE
Auto-reconcile duplicate relationship types in LLM-generated schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Experimental: the schema-from-text extraction prompt now instructs the LLM to define each relationship type once and reuse it across patterns, using distinct type names only when patterns genuinely need different properties or constraints.
+- Experimental: LLM-auto-generated schemas now reconcile duplicate `relationship_types` (entries sharing the same label) by merging them into a single type that carries the union of their properties, emitting a warning log. This reflects that Neo4j relationship types are global per name.
 
 ## 1.17.0
 

--- a/src/neo4j_graphrag/experimental/components/schema.py
+++ b/src/neo4j_graphrag/experimental/components/schema.py
@@ -1344,6 +1344,66 @@ def _extraction_apply_cross_reference_filters(
     return extracted_patterns, extracted_constraints
 
 
+def _merge_duplicate_relationship_types(
+    rel_types: Optional[List[Dict[str, Any]]],
+) -> Optional[List[Dict[str, Any]]]:
+    """Merge relationship types that share the same label into a single entry.
+
+    Neo4j relationship types are global per name, so an LLM-extracted schema that
+    lists the same relationship type more than once must be reconciled into one
+    definition. Properties are unioned and de-duplicated by name in
+    first-occurrence order (the first definition wins on a name conflict);
+    non-property fields (e.g. ``description``, ``additional_properties``) keep the
+    first entry's values. Entries that are not dicts or have no usable label are
+    left in place untouched. Output ordering is deterministic.
+    """
+    if not rel_types:
+        return rel_types
+
+    merged: List[Dict[str, Any]] = []
+    index_by_label: Dict[str, int] = {}
+    merged_labels: set[str] = set()
+
+    for rel_dict in rel_types:
+        label = rel_dict.get("label") if isinstance(rel_dict, dict) else None
+        if not isinstance(rel_dict, dict) or not label:
+            merged.append(rel_dict)
+            continue
+
+        if label not in index_by_label:
+            new_entry = dict(rel_dict)
+            new_entry["properties"] = list(rel_dict.get("properties") or [])
+            index_by_label[label] = len(merged)
+            merged.append(new_entry)
+            continue
+
+        merged_labels.add(label)
+        existing = merged[index_by_label[label]]
+        existing_props: List[Dict[str, Any]] = existing["properties"]
+        existing_names = {
+            p.get("name")
+            for p in existing_props
+            if isinstance(p, dict) and p.get("name")
+        }
+        for prop in rel_dict.get("properties") or []:
+            name = prop.get("name") if isinstance(prop, dict) else None
+            if name and name in existing_names:
+                continue
+            existing_props.append(prop)
+            if name:
+                existing_names.add(name)
+
+    for label in sorted(merged_labels):
+        logger.warning(
+            f"Reconciled duplicate relationship type '{label}' from the "
+            f"extracted schema into a single definition (union of properties). "
+            f"Neo4j relationship types are global per name, so a type cannot be "
+            f"defined more than once."
+        )
+
+    return merged
+
+
 def validate_extraction_dict_to_graph_schema(
     extracted_schema: Dict[str, Any],
 ) -> GraphSchema:
@@ -1353,7 +1413,9 @@ def validate_extraction_dict_to_graph_schema(
     :class:`SchemaFromTextExtractor` (V1 and V2). Does not require a configured LLM.
     """
     node_types = extracted_schema.get("node_types") or []
-    rel_types = extracted_schema.get("relationship_types")
+    rel_types = _merge_duplicate_relationship_types(
+        extracted_schema.get("relationship_types")
+    )
     patterns = extracted_schema.get("patterns")
     constraints = extracted_schema.get("constraints")
 

--- a/tests/unit/experimental/components/test_schema.py
+++ b/tests/unit/experimental/components/test_schema.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import Tuple, Any
 from unittest.mock import AsyncMock, patch, Mock
 
@@ -2367,3 +2368,224 @@ def test_validate_extraction_dict_to_graph_schema() -> None:
     gs = validate_extraction_dict_to_graph_schema(d)
     assert len(gs.node_types) == 1
     assert gs.node_types[0].label == "Person"
+
+
+def test_validate_extraction_dict_merges_duplicate_relationship_types() -> None:
+    """Duplicate same-label relationship types merge into one with unioned properties.
+
+    A KEY constraint referencing properties spread across both duplicates must
+    validate without error, instead of the previous "undefined property" failure.
+    """
+    from neo4j_graphrag.experimental.components.schema import (
+        validate_extraction_dict_to_graph_schema,
+    )
+
+    d = {
+        "node_types": [
+            {"label": "Person", "properties": [{"name": "name", "type": "STRING"}]}
+        ],
+        "relationship_types": [
+            {"label": "KNOWS", "properties": [{"name": "since", "type": "INTEGER"}]},
+            {"label": "KNOWS", "properties": [{"name": "weight", "type": "FLOAT"}]},
+        ],
+        "patterns": [],
+        "constraints": [
+            {
+                "type": "KEY",
+                "node_type": "",
+                "relationship_type": "KNOWS",
+                "property_names": ["since", "weight"],
+            }
+        ],
+    }
+
+    gs = validate_extraction_dict_to_graph_schema(d)
+
+    assert len(gs.relationship_types) == 1
+    rel = gs.relationship_type_from_label("KNOWS")
+    assert rel is not None
+    assert [p.name for p in rel.properties] == ["since", "weight"]
+    # The KEY constraint spanning both duplicates' properties is preserved.
+    assert len(gs.constraints) == 1
+    assert gs.constraints[0].property_names == ("since", "weight")
+
+
+def test_validate_extraction_dict_merge_resolves_property_name_conflict_first_wins() -> (
+    None
+):
+    """On a property-name conflict the first definition's attributes are kept."""
+    from neo4j_graphrag.experimental.components.schema import (
+        validate_extraction_dict_to_graph_schema,
+    )
+
+    d = {
+        "node_types": [
+            {"label": "Person", "properties": [{"name": "name", "type": "STRING"}]}
+        ],
+        "relationship_types": [
+            {
+                "label": "KNOWS",
+                "properties": [
+                    {
+                        "name": "since",
+                        "type": "INTEGER",
+                        "description": "first definition",
+                    }
+                ],
+            },
+            {
+                "label": "KNOWS",
+                "properties": [
+                    {
+                        "name": "since",
+                        "type": "STRING",
+                        "description": "second definition",
+                    }
+                ],
+            },
+        ],
+        "patterns": [],
+    }
+
+    gs = validate_extraction_dict_to_graph_schema(d)
+
+    rel = gs.relationship_type_from_label("KNOWS")
+    assert rel is not None
+    # Exactly one property per name; the first definition's attributes win.
+    assert len(rel.properties) == 1
+    assert rel.properties[0].name == "since"
+    assert rel.properties[0].type == "INTEGER"
+    assert rel.properties[0].description == "first definition"
+
+
+def test_validate_extraction_dict_merge_keeps_first_entry_non_property_fields() -> None:
+    """The merged entry's description/additional_properties match the first entry."""
+    from neo4j_graphrag.experimental.components.schema import (
+        validate_extraction_dict_to_graph_schema,
+    )
+
+    d = {
+        "node_types": [
+            {"label": "Person", "properties": [{"name": "name", "type": "STRING"}]}
+        ],
+        "relationship_types": [
+            {
+                "label": "KNOWS",
+                "description": "first description",
+                "additional_properties": False,
+                "properties": [{"name": "since", "type": "INTEGER"}],
+            },
+            {
+                "label": "KNOWS",
+                "description": "second description",
+                "additional_properties": True,
+                "properties": [{"name": "weight", "type": "FLOAT"}],
+            },
+        ],
+        "patterns": [],
+    }
+
+    gs = validate_extraction_dict_to_graph_schema(d)
+
+    rel = gs.relationship_type_from_label("KNOWS")
+    assert rel is not None
+    assert rel.description == "first description"
+    assert rel.additional_properties is False
+
+
+def test_validate_extraction_dict_merge_emits_warning_per_label(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """One warning is logged for each label that had duplicates reconciled."""
+    from neo4j_graphrag.experimental.components.schema import (
+        validate_extraction_dict_to_graph_schema,
+    )
+
+    d = {
+        "node_types": [
+            {"label": "Person", "properties": [{"name": "name", "type": "STRING"}]}
+        ],
+        "relationship_types": [
+            {"label": "KNOWS", "properties": [{"name": "since", "type": "INTEGER"}]},
+            {"label": "KNOWS", "properties": [{"name": "weight", "type": "FLOAT"}]},
+            {"label": "LIKES", "properties": [{"name": "rating", "type": "INTEGER"}]},
+            {"label": "LIKES", "properties": [{"name": "comment", "type": "STRING"}]},
+        ],
+        "patterns": [],
+    }
+
+    with caplog.at_level(logging.WARNING):
+        validate_extraction_dict_to_graph_schema(d)
+
+    warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    knows_warnings = [w for w in warnings if "'KNOWS'" in w]
+    likes_warnings = [w for w in warnings if "'LIKES'" in w]
+    assert len(knows_warnings) == 1
+    assert len(likes_warnings) == 1
+    assert "global per name" in knows_warnings[0]
+
+
+def test_validate_extraction_dict_unique_relationship_labels_unchanged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """All-unique relationship-type labels pass through with no merge and no warning."""
+    from neo4j_graphrag.experimental.components.schema import (
+        validate_extraction_dict_to_graph_schema,
+    )
+
+    d = {
+        "node_types": [
+            {"label": "Person", "properties": [{"name": "name", "type": "STRING"}]}
+        ],
+        "relationship_types": [
+            {"label": "KNOWS", "properties": [{"name": "since", "type": "INTEGER"}]},
+            {"label": "LIKES", "properties": [{"name": "rating", "type": "INTEGER"}]},
+        ],
+        "patterns": [],
+    }
+
+    with caplog.at_level(logging.WARNING):
+        gs = validate_extraction_dict_to_graph_schema(d)
+
+    assert {r.label for r in gs.relationship_types} == {"KNOWS", "LIKES"}
+    assert not [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "global per name" in r.getMessage()
+    ]
+
+
+def test_from_extraction_output_merges_duplicate_relationship_types() -> None:
+    """The V2 structured-output path also merges duplicate relationship types."""
+    from neo4j_graphrag.experimental.components.graph_schema_extraction import (
+        ExtractedNodeType,
+        ExtractedPropertyType,
+        ExtractedRelationshipType,
+        GraphSchemaExtractionOutput,
+    )
+
+    dto = GraphSchemaExtractionOutput(
+        node_types=[
+            ExtractedNodeType(
+                label="Person",
+                properties=[ExtractedPropertyType(name="name", type="STRING")],
+            )
+        ],
+        relationship_types=[
+            ExtractedRelationshipType(
+                label="KNOWS",
+                properties=[ExtractedPropertyType(name="since", type="INTEGER")],
+            ),
+            ExtractedRelationshipType(
+                label="KNOWS",
+                properties=[ExtractedPropertyType(name="weight", type="FLOAT")],
+            ),
+        ],
+    )
+
+    gs = GraphSchema.from_extraction_output(dto)
+
+    assert len(gs.relationship_types) == 1
+    rel = gs.relationship_type_from_label("KNOWS")
+    assert rel is not None
+    assert [p.name for p in rel.properties] == ["since", "weight"]

--- a/tests/unit/experimental/components/test_schema.py
+++ b/tests/unit/experimental/components/test_schema.py
@@ -34,6 +34,8 @@ from neo4j_graphrag.experimental.components.schema import (
     GraphSchema,
     SchemaFromExistingGraphExtractor,
     Pattern,
+    validate_extraction_dict_to_graph_schema,
+    _merge_duplicate_relationship_types,
 )
 import os
 import tempfile
@@ -2350,10 +2352,6 @@ def test_graph_schema_from_extraction_output() -> None:
 
 
 def test_validate_extraction_dict_to_graph_schema() -> None:
-    from neo4j_graphrag.experimental.components.schema import (
-        validate_extraction_dict_to_graph_schema,
-    )
-
     d = {
         "node_types": [
             {
@@ -2376,9 +2374,6 @@ def test_validate_extraction_dict_merges_duplicate_relationship_types() -> None:
     A KEY constraint referencing properties spread across both duplicates must
     validate without error, instead of the previous "undefined property" failure.
     """
-    from neo4j_graphrag.experimental.components.schema import (
-        validate_extraction_dict_to_graph_schema,
-    )
 
     d = {
         "node_types": [
@@ -2414,9 +2409,6 @@ def test_validate_extraction_dict_merge_resolves_property_name_conflict_first_wi
     None
 ):
     """On a property-name conflict the first definition's attributes are kept."""
-    from neo4j_graphrag.experimental.components.schema import (
-        validate_extraction_dict_to_graph_schema,
-    )
 
     d = {
         "node_types": [
@@ -2460,9 +2452,6 @@ def test_validate_extraction_dict_merge_resolves_property_name_conflict_first_wi
 
 def test_validate_extraction_dict_merge_keeps_first_entry_non_property_fields() -> None:
     """The merged entry's description/additional_properties match the first entry."""
-    from neo4j_graphrag.experimental.components.schema import (
-        validate_extraction_dict_to_graph_schema,
-    )
 
     d = {
         "node_types": [
@@ -2497,9 +2486,6 @@ def test_validate_extraction_dict_merge_emits_warning_per_label(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """One warning is logged for each label that had duplicates reconciled."""
-    from neo4j_graphrag.experimental.components.schema import (
-        validate_extraction_dict_to_graph_schema,
-    )
 
     d = {
         "node_types": [
@@ -2529,9 +2515,6 @@ def test_validate_extraction_dict_unique_relationship_labels_unchanged(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """All-unique relationship-type labels pass through with no merge and no warning."""
-    from neo4j_graphrag.experimental.components.schema import (
-        validate_extraction_dict_to_graph_schema,
-    )
 
     d = {
         "node_types": [
@@ -2589,3 +2572,63 @@ def test_from_extraction_output_merges_duplicate_relationship_types() -> None:
     rel = gs.relationship_type_from_label("KNOWS")
     assert rel is not None
     assert [p.name for p in rel.properties] == ["since", "weight"]
+
+
+def test_validate_extraction_dict_does_not_mutate_input_relationship_types() -> None:
+    """Merging must not mutate the caller's input relationship_types in place."""
+    rel_types: list[dict[str, Any]] = [
+        {"label": "KNOWS", "properties": [{"name": "since", "type": "INTEGER"}]},
+        {"label": "KNOWS", "properties": [{"name": "weight", "type": "FLOAT"}]},
+    ]
+    d = {
+        "node_types": [
+            {"label": "Person", "properties": [{"name": "name", "type": "STRING"}]}
+        ],
+        "relationship_types": rel_types,
+        "patterns": [],
+    }
+
+    validate_extraction_dict_to_graph_schema(d)
+
+    # The caller's original list and its entries are left untouched.
+    assert len(rel_types) == 2
+    assert len(rel_types[0]["properties"]) == 1
+    assert rel_types[0]["properties"][0]["name"] == "since"
+    assert rel_types[1]["properties"][0]["name"] == "weight"
+
+
+def test_merge_duplicate_relationship_types_passes_through_non_dict_and_label_less() -> (
+    None
+):
+    """Non-dict and label-less entries pass through untouched and are never merged."""
+    no_label_a = {"properties": [{"name": "a", "type": "STRING"}]}
+    no_label_b = {"label": "", "properties": [{"name": "b", "type": "STRING"}]}
+    not_a_dict: Any = "KNOWS"
+    rel_types: list[Any] = [no_label_a, no_label_b, not_a_dict]
+
+    result = _merge_duplicate_relationship_types(rel_types)
+
+    assert result is not None
+    # All three kept separately, in order; the two label-less dicts are not merged.
+    assert len(result) == 3
+    assert result[0] is no_label_a
+    assert result[1] is no_label_b
+    assert result[2] is not_a_dict
+
+
+def test_merge_duplicate_relationship_types_handles_missing_or_none_properties() -> (
+    None
+):
+    """Entries with a missing or None properties field are treated as empty."""
+    rel_types: list[dict[str, Any]] = [
+        {"label": "KNOWS"},
+        {"label": "KNOWS", "properties": None},
+        {"label": "KNOWS", "properties": [{"name": "since", "type": "INTEGER"}]},
+    ]
+
+    result = _merge_duplicate_relationship_types(rel_types)
+
+    assert result is not None
+    assert len(result) == 1
+    assert result[0]["label"] == "KNOWS"
+    assert [p["name"] for p in result[0]["properties"]] == ["since"]


### PR DESCRIPTION
# Description

This PR is to guarantee a `GraphSchema` auto-generated from text by an LLM (`SchemaFromTextExtractor`) never ends up with two or more `relationship_types` entries that share the same `label`. 

Rather than hard failing an auto-generated schema, this PR reconciles duplicate relationship types: 
- `validate_extraction_dict_to_graph_schema` now merges same-label `relationship_types` into a single entry whose properties are the **union** of the duplicates' properties (de-duplicated by name, first-occurrence wins on conflicts), keeps the first entry's non-property fields, and logs a warning for each merged label. The merge runs on the raw extraction dict **before** the cross-reference filters and `model_validate`, so the unioned property set is visible to both - a previously dropped/misreported constraint now validates correctly.

PS:
- why merging instead of splitting: splitting one label into distinct per-pattern types can't be done reliably - nothing binds a relationship-type definition to a specific pattern, so it would require fragile heuristics. Merging is deterministic and keeps the type global per name as Neo4j requires.
- This PR on [PR#535](https://github.com/neo4j/neo4j-graphrag-python/pull/535) that makes user-provided schemas hard-fail on duplicate relationship types; this PR handles the LLM-generated path by auto-reconciling instead of erroring. The two are independent and compose cleanly.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: low

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [x] CHANGELOG.md updated if appropriate
