### PR TITLE
Guide LLM to define each relationship type once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+### Changed
+
+- Experimental: the schema-from-text extraction prompt and `GraphSchemaExtractionOutput` now instruct the LLM to define each relationship type once and reuse it across patterns, using distinct type names only when patterns genuinely need different properties or constraints.
+
 ## 1.17.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Experimental: the schema-from-text extraction prompt and `GraphSchemaExtractionOutput` now instruct the LLM to define each relationship type once and reuse it across patterns, using distinct type names only when patterns genuinely need different properties or constraints.
+- Experimental: the schema-from-text extraction prompt now instructs the LLM to define each relationship type once and reuse it across patterns, using distinct type names only when patterns genuinely need different properties or constraints.
 
 ## 1.17.0
 

--- a/src/neo4j_graphrag/generation/prompts.py
+++ b/src/neo4j_graphrag/generation/prompts.py
@@ -214,6 +214,7 @@ IMPORTANT RULES:
 1. Return only abstract schema information, not concrete instances.
 2. Use singular PascalCase labels for node types (e.g., Person, Company, Product).
 3. Use UPPER_SNAKE_CASE labels for relationship types (e.g., WORKS_FOR, MANAGES).
+3.1 Define each relationship type once in "relationship_types". A relationship type name is global: the same type may be reused across multiple patterns (different source/target node pairs), sharing a single set of properties and constraints. Use distinct type names only when patterns genuinely need different properties or constraints.
 4. Include property definitions only when the type can be confidently inferred, otherwise omit them.
 5. When defining patterns, ensure that every node label and relationship label mentioned exists in your lists of node types and relationship types.
 6. Do not create node types that aren't clearly mentioned in the text.


### PR DESCRIPTION
# Description

Add prompt guidance stating that a relationship type is global, may be reused across patterns, and that distinct names are for genuinely different properties or constraints.


## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

low

Complexity:

## How Has This Been Tested?
- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [x] CHANGELOG.md updated if appropriate
