### PR TITLE
feat(llm): expose cached_tokens from Vertex AI context caching

### DIFF
--- a/src/neo4j_graphrag/llm/types.py
+++ b/src/neo4j_graphrag/llm/types.py
@@ -27,11 +27,15 @@ class LLMUsage(BaseModel):
             ``None`` when not reported by the provider.
         total_tokens (Optional[int]): Total tokens consumed by the call.
             ``None`` when not reported by the provider.
+        cached_tokens (Optional[int]): Number of prompt tokens served from the
+            provider's context cache (e.g. Vertex AI implicit caching).
+            ``None`` when not reported by the provider.
     """
 
     request_tokens: Optional[int] = None
     response_tokens: Optional[int] = None
     total_tokens: Optional[int] = None
+    cached_tokens: Optional[int] = None
 
 
 class LLMResponse(BaseModel):

--- a/src/neo4j_graphrag/llm/vertexai_llm.py
+++ b/src/neo4j_graphrag/llm/vertexai_llm.py
@@ -593,9 +593,19 @@ class VertexAILLM(LLMBase):
         usage = None
         metadata = response.usage_metadata
         if metadata:
+            cached = metadata.cached_content_token_count or None
             usage = LLMUsage(
                 request_tokens=metadata.prompt_token_count,
                 response_tokens=metadata.candidates_token_count,
                 total_tokens=metadata.total_token_count,
+                cached_tokens=cached,
             )
+            if cached:
+                from openinference.semconv.trace import SpanAttributes
+                from opentelemetry import trace as otel_trace
+
+                otel_trace.get_current_span().set_attribute(
+                    SpanAttributes.LLM_TOKEN_COUNT_PROMPT_DETAILS_CACHE_READ,
+                    cached,
+                )
         return LLMResponse(content=response.text, usage=usage)


### PR DESCRIPTION
## Summary

- Add `cached_tokens: Optional[int] = None` to `LLMUsage` for prompt tokens served from Vertex AI's implicit context cache (`cached_content_token_count` in `UsageMetadata`)
- Update `VertexAILLM._parse_content_response` to populate `cached_tokens` and set `llm.token_count.prompt_details.cache_read` span attribute on the active OpenTelemetry span when cached tokens are present

## Context

Vertex AI's implicit caching transparently caches repeated context (system prompt, schema) and reports cached token counts in `UsageMetadata.cached_content_token_count`. The `openinference-instrumentation-vertexai` library does not currently expose this count. Setting the attribute in `_parse_content_response` works because it runs while the openinference instrumentation span is still active.

## Test plan

- [ ] Run `pytest tests/unit/llm/test_vertexai_llm.py` to verify existing tests pass
- [ ] Manually verify `cached_tokens` appears in `LLMResponse.usage` for a real VertexAI call with context caching enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)