### PR TITLE
Forbid KEY and EXISTENCE constraints on the same properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Experimental: `GraphSchema` validation now rejects `KEY` and `EXISTENCE` constraints on the same node or relationship property (including composite KEY members), since KEY already implies mandatory presence. Legacy `PropertyType.required` migration no longer adds redundant EXISTENCE constraints for KEY-covered properties. The schema-from-text extraction prompt includes the same rule.
 - Experimental: the schema-from-text extraction prompt now instructs the LLM to define each relationship type once and reuse it across patterns, using distinct type names only when patterns genuinely need different properties or constraints.
 - Experimental: LLM-auto-generated schemas now reconcile duplicate `relationship_types` (entries sharing the same label) by merging them into a single type that carries the union of their properties, emitting a warning log. This reflects that Neo4j relationship types are global per name.
 

--- a/src/neo4j_graphrag/experimental/components/schema.py
+++ b/src/neo4j_graphrag/experimental/components/schema.py
@@ -101,7 +101,8 @@ class GraphConstraintType(str, enum.Enum):
     constraints are allowed.  ``EXISTENCE`` marks a mandatory (non-null) node or
     relationship property (single property only — Neo4j does not support composite
     existence).  ``KEY`` matches Neo4j NODE KEY / RELATIONSHIP KEY: mandatory and unique;
-    supports composite (multi-property) constraints.
+    supports composite (multi-property) constraints. KEY subsumes EXISTENCE for its
+    properties — do not combine KEY and EXISTENCE on the same property.
     """
 
     UNIQUENESS = "UNIQUENESS"
@@ -504,10 +505,36 @@ class GraphSchema(DataModel):
             return ("", "", "", "")
 
         seen_existence: set[tuple[str, str, str]] = set()
+        key_covered: set[tuple[str, str, str]] = set()
         for c in constraints:
             t, nt, rt, pn = _constraint_identity(c)
             if t in (GraphConstraintType.EXISTENCE.value, "EXISTENCE"):
                 seen_existence.add((nt or "", rt or "", pn))
+            if t not in (GraphConstraintType.KEY.value, "KEY"):
+                continue
+            if isinstance(c, ConstraintType):
+                pnames = c.property_names
+                nt = c.node_type or ""
+                rt = c.relationship_type or ""
+            elif isinstance(c, dict):
+                pnames = c.get("property_names") or ()
+                if isinstance(pnames, str):
+                    pnames = (pnames,)
+                else:
+                    pnames = tuple(pnames)
+                if not pnames:
+                    pn = c.get("property_name") or ""
+                    pnames = (pn,) if pn else ()
+                nt = str(c.get("node_type") or "")
+                rt = str(c.get("relationship_type") or "")
+            else:
+                continue
+            for key_prop_name in pnames:
+                if key_prop_name:
+                    key_covered.add((nt or "", rt or "", key_prop_name))
+
+        def _skip_required_migration(key: tuple[str, str, str]) -> bool:
+            return key in seen_existence or key in key_covered
 
         for node in data.get("node_types") or []:
             if not isinstance(node, dict):
@@ -524,7 +551,7 @@ class GraphSchema(DataModel):
                 if not pname:
                     continue
                 key = (label, "", pname)
-                if key in seen_existence:
+                if _skip_required_migration(key):
                     prop["required"] = False
                     continue
                 constraints.append(
@@ -557,7 +584,7 @@ class GraphSchema(DataModel):
                         new_props.append(prop)
                         continue
                     key = (label, "", pname)
-                    if key in seen_existence:
+                    if _skip_required_migration(key):
                         new_props.append(prop.model_copy(update={"required": False}))
                         continue
                     constraints.append(
@@ -588,7 +615,7 @@ class GraphSchema(DataModel):
                 if not pname:
                     continue
                 key = ("", rlabel, pname)
-                if key in seen_existence:
+                if _skip_required_migration(key):
                     prop["required"] = False
                     continue
                 constraints.append(
@@ -621,7 +648,7 @@ class GraphSchema(DataModel):
                         rel_new_props.append(prop)
                         continue
                     key = ("", rlabel, pname)
-                    if key in seen_existence:
+                    if _skip_required_migration(key):
                         rel_new_props.append(
                             prop.model_copy(update={"required": False})
                         )
@@ -754,6 +781,53 @@ class GraphSchema(DataModel):
                 f"UNIQUENESS and KEY constraints cannot apply to the same relationship type "
                 f"and properties ({rt!r}, {pns!r})."
             )
+        return self
+
+    @model_validator(mode="after")
+    def validate_constraints_key_existence_exclusivity(self) -> Self:
+        """KEY subsumes EXISTENCE: redundant EXISTENCE on KEY-covered properties is invalid."""
+        node_key_props: dict[str, set[str]] = {}
+        rel_key_props: dict[str, set[str]] = {}
+        for c in self.constraints:
+            ct = c.type
+            if isinstance(ct, str):
+                ct = GraphConstraintType(ct)
+            if ct != GraphConstraintType.KEY:
+                continue
+            has_node = bool(c.node_type and str(c.node_type).strip())
+            has_rel = bool(c.relationship_type and str(c.relationship_type).strip())
+            if has_node:
+                assert c.node_type is not None
+                node_key_props.setdefault(c.node_type, set()).update(c.property_names)
+            elif has_rel:
+                assert c.relationship_type is not None
+                rel_key_props.setdefault(c.relationship_type, set()).update(
+                    c.property_names
+                )
+        for c in self.constraints:
+            ct = c.type
+            if isinstance(ct, str):
+                ct = GraphConstraintType(ct)
+            if ct != GraphConstraintType.EXISTENCE:
+                continue
+            pname = c.property_names[0]
+            has_node = bool(c.node_type and str(c.node_type).strip())
+            has_rel = bool(c.relationship_type and str(c.relationship_type).strip())
+            if has_node:
+                assert c.node_type is not None
+                if pname in node_key_props.get(c.node_type, set()):
+                    raise SchemaValidationError(
+                        f"EXISTENCE and KEY constraints cannot apply to the same node type "
+                        f"and property ({c.node_type!r}, {pname!r})."
+                    )
+            elif has_rel:
+                assert c.relationship_type is not None
+                if pname in rel_key_props.get(c.relationship_type, set()):
+                    raise SchemaValidationError(
+                        f"EXISTENCE and KEY constraints cannot apply to the same "
+                        f"relationship type and property "
+                        f"({c.relationship_type!r}, {pname!r})."
+                    )
         return self
 
     def node_type_from_label(self, label: str) -> Optional[NodeType]:

--- a/src/neo4j_graphrag/generation/prompts.py
+++ b/src/neo4j_graphrag/generation/prompts.py
@@ -240,6 +240,7 @@ IMPORTANT RULES:
 10.3 Do not combine UNIQUENESS and KEY on the same node or relationship type with the same properties.
 10.4 Do not infer KEY from UNIQUENESS alone; KEY implies required presence, unlike UNIQUENESS alone.
 10.5 For composite key (multiple properties), list all properties in "property_names". All must exist and the combination must be unique.
+10.6 Do not add EXISTENCE on a property already covered by a KEY constraint (KEY already implies mandatory presence).
 11. Never use double underscores (__) as a prefix or suffix in node labels or relationship types (e.g. __Person__ or __KNOWS__ are forbidden).
 
 Accepted property types are: BOOLEAN, DATE, DURATION, FLOAT, INTEGER, LIST,

--- a/tests/unit/experimental/components/test_schema.py
+++ b/tests/unit/experimental/components/test_schema.py
@@ -579,6 +579,178 @@ def test_schema_uniqueness_and_key_same_relationship_rejected() -> None:
         GraphSchema.model_validate(schema_dict)
 
 
+def test_schema_key_and_existence_same_node_property_rejected() -> None:
+    schema_dict: dict[str, Any] = {
+        "node_types": [
+            {"label": "Person", "properties": [{"name": "id", "type": "STRING"}]}
+        ],
+        "constraints": [
+            {
+                "type": "KEY",
+                "node_type": "Person",
+                "property_name": "id",
+                "relationship_type": None,
+            },
+            {
+                "type": "EXISTENCE",
+                "node_type": "Person",
+                "property_name": "id",
+                "relationship_type": None,
+            },
+        ],
+    }
+    with pytest.raises(SchemaValidationError, match="EXISTENCE and KEY"):
+        GraphSchema.model_validate(schema_dict)
+
+
+def test_schema_key_and_existence_same_relationship_rejected() -> None:
+    schema_dict: dict[str, Any] = {
+        "node_types": [
+            {"label": "Person", "properties": [{"name": "name", "type": "STRING"}]}
+        ],
+        "relationship_types": [
+            {"label": "KNOWS", "properties": [{"name": "since", "type": "INTEGER"}]}
+        ],
+        "constraints": [
+            {
+                "type": "KEY",
+                "node_type": "",
+                "property_names": ["since"],
+                "relationship_type": "KNOWS",
+            },
+            {
+                "type": "EXISTENCE",
+                "node_type": "",
+                "property_names": ["since"],
+                "relationship_type": "KNOWS",
+            },
+        ],
+    }
+    with pytest.raises(SchemaValidationError, match="EXISTENCE and KEY"):
+        GraphSchema.model_validate(schema_dict)
+
+
+def test_schema_composite_key_and_existence_on_member_rejected() -> None:
+    schema_dict: dict[str, Any] = {
+        "node_types": [
+            {
+                "label": "Actor",
+                "properties": [
+                    {"name": "firstname", "type": "STRING"},
+                    {"name": "surname", "type": "STRING"},
+                ],
+            }
+        ],
+        "constraints": [
+            {
+                "type": "KEY",
+                "node_type": "Actor",
+                "property_names": ["firstname", "surname"],
+            },
+            {
+                "type": "EXISTENCE",
+                "node_type": "Actor",
+                "property_names": ["firstname"],
+            },
+        ],
+    }
+    with pytest.raises(SchemaValidationError, match="EXISTENCE and KEY"):
+        GraphSchema.model_validate(schema_dict)
+
+
+def test_schema_key_and_existence_different_properties_allowed() -> None:
+    schema_dict: dict[str, Any] = {
+        "node_types": [
+            {
+                "label": "Actor",
+                "properties": [
+                    {"name": "firstname", "type": "STRING"},
+                    {"name": "surname", "type": "STRING"},
+                    {"name": "birthdate", "type": "DATE"},
+                ],
+            }
+        ],
+        "constraints": [
+            {
+                "type": "KEY",
+                "node_type": "Actor",
+                "property_names": ["firstname", "surname"],
+            },
+            {
+                "type": "EXISTENCE",
+                "node_type": "Actor",
+                "property_names": ["birthdate"],
+            },
+        ],
+    }
+    schema = GraphSchema.model_validate(schema_dict)
+    assert schema.key_property_names_for_node("Actor") == {"firstname", "surname"}
+    assert schema.existence_property_names_for_node("Actor") == {"birthdate"}
+    assert schema.mandatory_property_names_for_node("Actor") == {
+        "firstname",
+        "surname",
+        "birthdate",
+    }
+
+
+def test_schema_uniqueness_and_existence_same_property_allowed() -> None:
+    schema_dict: dict[str, Any] = {
+        "node_types": [
+            {
+                "label": "Person",
+                "properties": [
+                    {"name": "email", "type": "STRING"},
+                ],
+            }
+        ],
+        "constraints": [
+            {
+                "type": "UNIQUENESS",
+                "node_type": "Person",
+                "property_names": ["email"],
+            },
+            {
+                "type": "EXISTENCE",
+                "node_type": "Person",
+                "property_names": ["email"],
+            },
+        ],
+    }
+    schema = GraphSchema.model_validate(schema_dict)
+    assert schema.uniqueness_property_names_for_node("Person") == {"email"}
+    assert schema.existence_property_names_for_node("Person") == {"email"}
+
+
+def test_required_migration_skips_key_covered_node_property() -> None:
+    schema_dict: dict[str, Any] = {
+        "node_types": [
+            {
+                "label": "Person",
+                "properties": [
+                    {"name": "id", "type": "STRING", "required": True},
+                    {"name": "name", "type": "STRING", "required": True},
+                ],
+            }
+        ],
+        "constraints": [
+            {
+                "type": "KEY",
+                "node_type": "Person",
+                "property_names": ["id"],
+            },
+        ],
+    }
+    schema = GraphSchema.model_validate(schema_dict)
+    person = schema.node_type_from_label("Person")
+    assert person is not None
+    assert all(not p.model_dump().get("required") for p in person.properties)
+    existence_constraints = [
+        c for c in schema.constraints if c.type == GraphConstraintType.EXISTENCE
+    ]
+    assert len(existence_constraints) == 1
+    assert existence_constraints[0].property_names == ("name",)
+
+
 # --- Composite (multi-property) constraint tests ---
 
 


### PR DESCRIPTION
https://linear.app/neo4j/issue/GENKGB-1520/forbid-key-existence-constraints-on-the-same-property-in-graphschema

# Description

Adds `GraphSchema` validation to reject redundant `KEY` + `EXISTENCE` constraints on the same property (node or relationship scope), mirroring the existing UNIQUENESS + KEY exclusivity check.

In Neo4j, a KEY constraint already requires properties to exist and be unique, so a separate EXISTENCE constraint on the same property is redundant. This validation catches invalid schemas early—before KG pipeline work—rather than letting them pass through with duplicate constraint metadata (e.g. in Parquet export).

**Changes:**
- New `validate_constraints_key_existence_exclusivity` validator on `GraphSchema` (rejects EXISTENCE on any property covered by a KEY constraint, including composite KEY members)
- Legacy `PropertyType.required` → EXISTENCE migration skips properties already covered by KEY
- Schema-from-text extraction prompt: new rule 10.6 (do not add EXISTENCE on KEY-covered properties)
- Unit tests for rejection, allowed cases (KEY + EXISTENCE on different properties; UNIQUENESS + EXISTENCE still allowed), and migration behavior

Schemas imported from Neo4j via `SchemaFromExistingGraphExtractor` are unaffected.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Low

## How Has This Been Tested?

- [x] Unit tests
- [ ] E2E tests
- [x] Manual tests (smoke tested on HP dataset in k3d)

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
- [x] CHANGELOG.md updated if appropriate