### PR TITLE
ci: download en_core_web_sm model in PR workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -35,7 +35,7 @@ jobs:
         run: uv sync --frozen --all-extras --group dev
       - name: Download SpaCy model
         if: matrix.python-version != '3.14'
-        run: uv run --frozen python -m spacy download en_core_web_sm
+        run: uv tool run spacy download en_core_web_sm
       - name: Check format and linting
         run: |
           uv run --frozen ruff check .

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -35,7 +35,7 @@ jobs:
         run: uv sync --frozen --all-extras --group dev
       - name: Download SpaCy model
         if: matrix.python-version != '3.14'
-        run: uv tool run spacy download en_core_web_sm
+        run: uv pip install "en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl"
       - name: Check format and linting
         run: |
           uv run --frozen ruff check .

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -33,6 +33,9 @@ jobs:
       - name: Install dependencies
         if: steps.cached-venv.outputs.cache-hit != 'true'
         run: uv sync --frozen --all-extras --group dev
+      - name: Download SpaCy model
+        if: matrix.python-version != '3.14'
+        run: uv run --frozen python -m spacy download en_core_web_sm
       - name: Check format and linting
         run: |
           uv run --frozen ruff check .


### PR DESCRIPTION
Adds a step to download the `en_core_web_sm` SpaCy model (~12 MB) during the PR unit test workflow so that the SpaCy integration tests run properly instead of being skipped.

The step is conditioned on `python-version != '3.14'` to match the `pyproject.toml` guard (`spacy==3.8.7; python_version < '3.14'`).

```yaml
- name: Download SpaCy model
  if: matrix.python-version != '3.14'
  run: uv run --frozen python -m spacy download en_core_web_sm
```

Prerequisite for:
- #547 (`SpacyEntityRelationExtractor` — 3 integration tests)
- #548 (`HierarchicalTextSplitter` — 2 integration tests)