### PR TITLE
Add OpenAI embedding dimensions parameter

### DIFF
--- a/docs/source/user_guide_rag.rst
+++ b/docs/source/user_guide_rag.rst
@@ -621,7 +621,20 @@ Currently, this package supports the following embedders:
 - :ref:`azureopenaiembeddings`
 - :ref:`ollamaembeddings`
 
-The `OpenAIEmbeddings` was illustrated previously. Here is how to use the `SentenceTransformerEmbeddings`:
+The `OpenAIEmbeddings` was illustrated previously. If the selected OpenAI
+embedding model supports configurable output dimensions, set ``dimensions`` on
+the embedder to match the dimensions used when creating the Neo4j vector index:
+
+.. code:: python
+
+    from neo4j_graphrag.embeddings import OpenAIEmbeddings
+
+    embedder = OpenAIEmbeddings(
+        model="text-embedding-3-large",
+        dimensions=1536,
+    )
+
+Here is how to use the `SentenceTransformerEmbeddings`:
 
 .. code:: python
 
@@ -1470,7 +1483,7 @@ Create a Vector Index
     AUTH = ("neo4j", "password")
 
     INDEX_NAME = "chunk-index"
-    DIMENSION=1536
+    DIMENSION = 1536
 
     # Connect to Neo4j database
     driver = GraphDatabase.driver(URI, auth=AUTH)

--- a/examples/customize/embeddings/openai_embeddings.py
+++ b/examples/customize/embeddings/openai_embeddings.py
@@ -4,9 +4,14 @@ using OpenAI models and API.
 
 from neo4j_graphrag.embeddings import OpenAIEmbeddings
 
-# set api key here on in the OPENAI_API_KEY env var
+# set api key here or in the OPENAI_API_KEY env var
 api_key = None
+dimensions = 1536
 
-embeder = OpenAIEmbeddings(model="text-embedding-ada-002", api_key=api_key)
-res = embeder.embed_query("my question")
+embedder = OpenAIEmbeddings(
+    model="text-embedding-3-large",
+    dimensions=dimensions,
+    api_key=api_key,
+)
+res = embedder.embed_query("my question")
 print(res[:10])

--- a/src/neo4j_graphrag/embeddings/openai.py
+++ b/src/neo4j_graphrag/embeddings/openai.py
@@ -36,6 +36,7 @@ class BaseOpenAIEmbeddings(Embedder, abc.ABC):
     def __init__(
         self,
         model: str = "text-embedding-ada-002",
+        dimensions: Optional[int] = None,
         rate_limit_handler: Optional[RateLimitHandler] = None,
         **kwargs: Any,
     ) -> None:
@@ -49,6 +50,7 @@ class BaseOpenAIEmbeddings(Embedder, abc.ABC):
         super().__init__(rate_limit_handler)
         self.openai = openai
         self.model = model
+        self.dimensions = dimensions
         self.client = self._initialize_client(**kwargs)
 
     @abc.abstractmethod
@@ -66,11 +68,15 @@ class BaseOpenAIEmbeddings(Embedder, abc.ABC):
 
         Args:
             text (str): The text to generate an embedding for.
-            **kwargs (Any): Additional arguments to pass to the OpenAI embedding generation function.
+            **kwargs (Any): Additional arguments to pass to the OpenAI
+                embedding generation function.
         """
         try:
+            embedding_params = kwargs.copy()
+            if self.dimensions is not None and "dimensions" not in embedding_params:
+                embedding_params["dimensions"] = self.dimensions
             response = self.client.embeddings.create(
-                input=text, model=self.model, **kwargs
+                input=text, model=self.model, **embedding_params
             )
             embedding: list[float] = response.data[0].embedding
             return embedding
@@ -86,7 +92,11 @@ class OpenAIEmbeddings(BaseOpenAIEmbeddings):
     This class uses the OpenAI python client to generate embeddings for text data.
 
     Args:
-        model (str): The name of the OpenAI embedding model to use. Defaults to "text-embedding-ada-002".
+        model (str): The name of the OpenAI embedding model to use. Defaults to
+            "text-embedding-ada-002".
+        dimensions (Optional[int]): The number of dimensions the resulting
+            output embeddings should have. Only supported by OpenAI embedding
+            models that allow shortening embeddings.
         kwargs: All other parameters will be passed to the openai.OpenAI init.
     """
 
@@ -100,8 +110,13 @@ class AzureOpenAIEmbeddings(BaseOpenAIEmbeddings):
     This class uses the Azure OpenAI python client to generate embeddings for text data.
 
     Args:
-        model (str): The name of the Azure OpenAI embedding model to use. Defaults to "text-embedding-ada-002".
-        kwargs: All other parameters will be passed to the openai.AzureOpenAI init.
+        model (str): The name of the Azure OpenAI embedding model to use.
+            Defaults to "text-embedding-ada-002".
+        dimensions (Optional[int]): The number of dimensions the resulting
+            output embeddings should have. Only supported by Azure OpenAI
+            embedding models that allow shortening embeddings.
+        kwargs: All other parameters will be passed to the openai.AzureOpenAI
+            init.
     """
 
     def _initialize_client(self, **kwargs: Any) -> Any:

--- a/tests/unit/embeddings/test_openai_embedder.py
+++ b/tests/unit/embeddings/test_openai_embedder.py
@@ -48,6 +48,56 @@ def test_openai_embedder_happy_path(mock_import: Mock) -> None:
     res = embedder.embed_query("my text")
     assert isinstance(res, list)
     assert res == [1.0, 2.0]
+    mock_openai.OpenAI.return_value.embeddings.create.assert_called_once_with(
+        input="my text",
+        model="text-embedding-ada-002",
+    )
+
+
+@patch("builtins.__import__")
+def test_openai_embedder_dimensions(mock_import: Mock) -> None:
+    mock_openai = get_mock_openai()
+    mock_import.return_value = mock_openai
+
+    mock_openai.OpenAI.return_value.embeddings.create.return_value = MagicMock(
+        data=[MagicMock(embedding=[1.0, 2.0])],
+    )
+    embedder = OpenAIEmbeddings(
+        model="text-embedding-3-large",
+        dimensions=1024,
+        api_key="my key",
+    )
+    res = embedder.embed_query("my text")
+    assert isinstance(res, list)
+    assert res == [1.0, 2.0]
+    mock_openai.OpenAI.return_value.embeddings.create.assert_called_once_with(
+        input="my text",
+        model="text-embedding-3-large",
+        dimensions=1024,
+    )
+
+
+@patch("builtins.__import__")
+def test_openai_embedder_embed_query_dimensions_override(mock_import: Mock) -> None:
+    mock_openai = get_mock_openai()
+    mock_import.return_value = mock_openai
+
+    mock_openai.OpenAI.return_value.embeddings.create.return_value = MagicMock(
+        data=[MagicMock(embedding=[1.0, 2.0])],
+    )
+    embedder = OpenAIEmbeddings(
+        model="text-embedding-3-large",
+        dimensions=1024,
+        api_key="my key",
+    )
+    res = embedder.embed_query("my text", dimensions=256)
+    assert isinstance(res, list)
+    assert res == [1.0, 2.0]
+    mock_openai.OpenAI.return_value.embeddings.create.assert_called_once_with(
+        input="my text",
+        model="text-embedding-3-large",
+        dimensions=256,
+    )
 
 
 @patch("builtins.__import__", side_effect=ImportError)
@@ -73,6 +123,31 @@ def test_azure_openai_embedder_happy_path(mock_import: Mock) -> None:
     res = embedder.embed_query("my text")
     assert isinstance(res, list)
     assert res == [1.0, 2.0]
+
+
+@patch("builtins.__import__")
+def test_azure_openai_embedder_dimensions(mock_import: Mock) -> None:
+    mock_openai = get_mock_openai()
+    mock_import.return_value = mock_openai
+
+    mock_openai.AzureOpenAI.return_value.embeddings.create.return_value = MagicMock(
+        data=[MagicMock(embedding=[1.0, 2.0])],
+    )
+    embedder = AzureOpenAIEmbeddings(
+        model="text-embedding-3-large",
+        dimensions=1024,
+        azure_endpoint="https://test.openai.azure.com/",
+        api_key="my key",
+        api_version="version",
+    )
+    res = embedder.embed_query("my text")
+    assert isinstance(res, list)
+    assert res == [1.0, 2.0]
+    mock_openai.AzureOpenAI.return_value.embeddings.create.assert_called_once_with(
+        input="my text",
+        model="text-embedding-3-large",
+        dimensions=1024,
+    )
 
 
 def test_azure_openai_embedder_does_not_call_openai_client() -> None:


### PR DESCRIPTION
## Description
Fixes [#445](https://github.com/neo4j/neo4j-graphrag-python/issues/445)

Adds a persistent `dimensions` parameter to `OpenAIEmbeddings` and `AzureOpenAIEmbeddings`.

This allows users to configure supported OpenAI embedding output dimensions at embedder initialization time, so retrievers that call `embed_query(query_text)` automatically generate vectors with the intended size. This helps keep query embeddings aligned with Neo4j vector indexes created using `create_vector_index(dimensions=...)`.

This PR intentionally keeps the change scoped to OpenAI/Azure OpenAI embedders. A broader alternative would be to make retrievers read the vector index dimension from Neo4j and automatically pass that value into the embedder. However, that would require changing or expanding the generic `Embedder` contract, since not all embedding providers support configurable dimensions, and providers that do support it may expose the setting through different API parameters. It could also introduce implicit behavior where the retriever silently changes embedder output based on index metadata.

The current implementation keeps dimension selection explicit at embedder initialization time while preserving the existing retriever and base embedder interfaces. Future work could explore a provider-agnostic dimension interface, or retriever-side validation that generated query vectors match the Neo4j vector index dimensions.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Low

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [x] Examples have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate