### PR TITLE
docs: OpenAI-compatible multi-model gateway example (DaoXE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,35 @@ text = (
 )
 asyncio.run(kg_builder.run_async(text=text))
 driver.close()
+
+### OpenAI-compatible multi-model gateways
+
+`OpenAILLM` and `OpenAIEmbeddings` accept OpenAI Python client kwargs such as `base_url` and `api_key`. Point them at any OpenAI-compatible Chat Completions / embeddings host. Example with [DaoXE](https://daoxe.com) (`https://daoxe.com/v1`):
+
+```python
+from neo4j_graphrag.embeddings import OpenAIEmbeddings
+from neo4j_graphrag.llm import OpenAILLM
+
+llm = OpenAILLM(
+    model_name="your-account-model-id",  # exact ID from GET /v1/models or dashboard
+    api_key="your_daoxe_api_key",
+    base_url="https://daoxe.com/v1",
+)
+
+embedder = OpenAIEmbeddings(
+    model="your-account-embedding-model-id",
+    api_key="your_daoxe_api_key",
+    base_url="https://daoxe.com/v1",
+)
+```
+
+Notes:
+
+- Model IDs are account-scoped; do not hardcode a static public catalog.
+- Chat Completions / embeddings paths only for this snippet.
+- DaoXE is not available in mainland China.
+- Contributor disclosure: this example was contributed by a DaoXE affiliate.
+
 ```
 
 > Warning: In order to run this code, the `openai` Python package needs to be installed: `pip install "neo4j_graphrag[openai]"`


### PR DESCRIPTION
# Description

Add README example showing `OpenAILLM` / `OpenAIEmbeddings` with OpenAI client kwargs (`base_url`, `api_key`) pointed at OpenAI-compatible multi-model gateway. Example uses DaoXE (`https://daoxe.com/v1`), account-scoped model IDs, Chat Completions / embeddings paths. Same kwargs path already used for custom OpenAI clients — docs only, no code change.

Note: DaoXE not available in mainland China. Contributor affiliated with DaoXE.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Low

## How Has This Been Tested?
- [x] Manual tests (README renders)

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [ ] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
