### PR TITLE
fix(llm): route http_client to the matching sync/async Anthropic client

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ ENVIRONMENT MANAGEMENT:
 - `WeakKeyDictionary` works for caching per-driver since `neo4j.Driver` is hashable
 - Neo4j 2026 CREATE VECTOR INDEX syntax: WITH clause must come BEFORE OPTIONS, not after
 - E2E tests for SEARCH clause: use `docker compose -f tests/e2e/docker-compose.neo4j2026.yml up -d`
+- If `tests/unit/llm/test_anthropic_llm.py` fails with `AttributeError: module 'anthropic' has no attribute 'omit'`, or other unit test files error on missing optional-dependency imports (openai, cohere, etc.) at collection time, the local `.venv` is stale relative to `pyproject.toml` extras. Run `uv sync --all-extras` to fix.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,6 @@ ENVIRONMENT MANAGEMENT:
 - `WeakKeyDictionary` works for caching per-driver since `neo4j.Driver` is hashable
 - Neo4j 2026 CREATE VECTOR INDEX syntax: WITH clause must come BEFORE OPTIONS, not after
 - E2E tests for SEARCH clause: use `docker compose -f tests/e2e/docker-compose.neo4j2026.yml up -d`
-- If `tests/unit/llm/test_anthropic_llm.py` fails with `AttributeError: module 'anthropic' has no attribute 'omit'`, or other unit test files error on missing optional-dependency imports (openai, cohere, etc.) at collection time, the local `.venv` is stale relative to `pyproject.toml` extras. Run `uv sync --all-extras` to fix.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
   - `TaskProgressNotifierProtocol` and `RunContext` have been moved to `neo4j_graphrag.components.base`
   - The `Component` base class has been moved to `neo4j_graphrag.components.base`
 
+### Fixed
+
+- Fixed a bug in `AnthropicLLM` where an `http_client` passed via kwargs (whether an `httpx.Client` or `httpx.AsyncClient`) was forwarded to both the sync `anthropic.Anthropic` and async `anthropic.AsyncAnthropic` clients, causing a type mismatch. `http_client` is now routed to the matching sync/async client only; other kwargs remain shared. An `http_client` of an unrecognized type now emits a warning and is ignored instead of raising, matching `OpenAILLM`'s existing behavior.
 
 ## 1.18.0
 

--- a/src/neo4j_graphrag/llm/anthropic_llm.py
+++ b/src/neo4j_graphrag/llm/anthropic_llm.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import json
+import warnings
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -231,6 +232,11 @@ class AnthropicLLM(LLMBase):
             sync_params["http_client"] = http_client
         elif httpx is not None and isinstance(http_client, httpx.AsyncClient):
             async_params["http_client"] = http_client
+        elif http_client is not None:
+            warnings.warn(
+                f"Invalid http_client type (got {type(http_client)}, expected httpx.Client or httpx.AsyncClient). Using default client.",
+                stacklevel=2,
+            )
         self.client = anthropic.Anthropic(**sync_params)
         self.async_client = anthropic.AsyncAnthropic(**async_params)
 

--- a/src/neo4j_graphrag/llm/anthropic_llm.py
+++ b/src/neo4j_graphrag/llm/anthropic_llm.py
@@ -25,6 +25,12 @@ from typing import (
     cast,
 )
 
+# 3rd party dependencies
+try:
+    import httpx
+except ImportError:
+    httpx = None  # type: ignore[assignment]
+
 from pydantic import BaseModel, ValidationError
 
 from neo4j_graphrag.exceptions import LLMGenerationError
@@ -218,8 +224,15 @@ class AnthropicLLM(LLMBase):
             **kwargs,
         )
         self.anthropic = anthropic
-        self.client = anthropic.Anthropic(**kwargs)
-        self.async_client = anthropic.AsyncAnthropic(**kwargs)
+        http_client = kwargs.pop("http_client", None)
+        sync_params = kwargs.copy()
+        async_params = kwargs.copy()
+        if httpx is not None and isinstance(http_client, httpx.Client):
+            sync_params["http_client"] = http_client
+        elif httpx is not None and isinstance(http_client, httpx.AsyncClient):
+            async_params["http_client"] = http_client
+        self.client = anthropic.Anthropic(**sync_params)
+        self.async_client = anthropic.AsyncAnthropic(**async_params)
 
     def invoke(
         self,

--- a/tests/unit/llm/test_anthropic_llm.py
+++ b/tests/unit/llm/test_anthropic_llm.py
@@ -19,6 +19,7 @@ from typing import Any, Generator, List, cast
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import anthropic
+import httpx
 import pytest
 from neo4j_graphrag.exceptions import LLMGenerationError
 from neo4j_graphrag.components.types import Neo4jGraph
@@ -536,6 +537,66 @@ def test_anthropic_llm_close(mock_anthropic: Mock) -> None:
 
     mock_anthropic.Anthropic.return_value.close.assert_called_once()
     mock_anthropic.AsyncAnthropic.return_value.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# http_client sync/async routing tests
+# ---------------------------------------------------------------------------
+
+
+def test_anthropic_llm_with_httpx_client(mock_anthropic: Mock) -> None:
+    """Test that httpx.Client is forwarded only to the sync Anthropic client."""
+    http_client = httpx.Client()
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            AnthropicLLM(model_name="claude-3-opus-20240229", http_client=http_client)
+
+        assert not any("Invalid http_client" in str(w.message) for w in caught)
+        _, sync_kwargs = mock_anthropic.Anthropic.call_args
+        assert sync_kwargs.get("http_client") is http_client
+        _, async_kwargs = mock_anthropic.AsyncAnthropic.call_args
+        assert "http_client" not in async_kwargs
+    finally:
+        http_client.close()
+
+
+@pytest.mark.asyncio
+async def test_anthropic_llm_with_httpx_async_client(mock_anthropic: Mock) -> None:
+    """Test that httpx.AsyncClient is forwarded only to the async Anthropic client."""
+    async_http_client = httpx.AsyncClient()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        AnthropicLLM(model_name="claude-3-opus-20240229", http_client=async_http_client)
+
+    assert not any("Invalid http_client" in str(w.message) for w in caught)
+    _, sync_kwargs = mock_anthropic.Anthropic.call_args
+    assert "http_client" not in sync_kwargs
+    _, async_kwargs = mock_anthropic.AsyncAnthropic.call_args
+    assert async_kwargs.get("http_client") is async_http_client
+
+    await async_http_client.aclose()
+
+
+def test_anthropic_llm_no_http_client_no_warning(mock_anthropic: Mock) -> None:
+    """Test that omitting http_client does not emit a warning."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        AnthropicLLM(model_name="claude-3-opus-20240229")
+
+    assert not any("Invalid http_client" in str(w.message) for w in caught)
+
+
+def test_anthropic_llm_with_invalid_http_client_warns(mock_anthropic: Mock) -> None:
+    """Test that an invalid http_client type emits a warning and falls back to
+    default construction for both clients."""
+    with pytest.warns(UserWarning, match="Invalid http_client type"):
+        AnthropicLLM(model_name="claude-3-opus-20240229", http_client="not-a-client")
+
+    _, sync_kwargs = mock_anthropic.Anthropic.call_args
+    _, async_kwargs = mock_anthropic.AsyncAnthropic.call_args
+    assert "http_client" not in sync_kwargs
+    assert "http_client" not in async_kwargs
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Stack

Merge order: **#565 → #567 → #566 → #571 / #572** (last two in either order). Each PR builds on the previous one. Until its base merges, GitHub may show parent commits in the diff — review only the commits unique to this branch.

# Description

`AnthropicLLM` builds two SDK clients — one sync, one async — from the same `**kwargs`. Most settings are safe to share between them, but `http_client` is not: the sync client needs an `httpx.Client` and the async client needs an `httpx.AsyncClient`. Today whichever one you pass is forwarded to **both** clients, so one of them always receives the wrong type. In practice there is no way to inject a custom HTTP client into `AnthropicLLM` at all.

This PR fixes that:

- `http_client` now goes only to the client whose type it matches.
- Passing anything else emits a warning and is ignored (both clients fall back to their defaults) — the same behavior `OpenAILLM` already has.
- Every other kwarg is still shared between both clients, unchanged.

No new parameters, no signature changes. If you never pass `http_client`, nothing changes for you.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Low

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

- [ ] Documentation has been updated
- [x] Unit tests have been updated
- [ ] Examples have been updated
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [x] CHANGELOG.md updated
