### PR TITLE
feat(llm): GeminiLLM declares supports_structured_output = True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - (**breaking**) `AnthropicLLM.supports_structured_output` is now `True`. As a result, `SchemaFromTextExtractor` and `LLMEntityRelationExtractor` (and `SimpleKGPipeline`, which enables structured output automatically when the LLM supports it) now use structured output by default with `AnthropicLLM`. This requires a Claude 4.5+ model (e.g. `claude-sonnet-4-5`); using `AnthropicLLM` with an older Claude model in these components will now raise an error where it previously worked. To keep the previous behavior, use a Claude 4.5+ model, or construct `LLMEntityRelationExtractor` / `SchemaFromTextExtractor` directly with `use_structured_output=False`.
+- (**breaking**) `GeminiLLM.supports_structured_output` is now `True`. `GeminiLLM` already implemented structured-output handling via `response_schema`/`response_mime_type` but never declared the capability flag, so components gating on it saw `False`. As a result, `SchemaFromTextExtractor` and `LLMEntityRelationExtractor` (and `SimpleKGPipeline`, which enables structured output automatically when the LLM supports it) now use structured output by default with `GeminiLLM`. To keep the previous behavior, construct `LLMEntityRelationExtractor` / `SchemaFromTextExtractor` directly with `use_structured_output=False`.
 
 ## 1.18.0
 

--- a/src/neo4j_graphrag/llm/google_genai_llm.py
+++ b/src/neo4j_graphrag/llm/google_genai_llm.py
@@ -72,6 +72,8 @@ class GeminiLLM(LLMInterface, LLMInterfaceV2):
         **kwargs (Any): Arguments passed to the genai.Client.
     """
 
+    supports_structured_output: bool = True
+
     def __init__(
         self,
         model_name: str = "gemini-2.0-flash",

--- a/tests/unit/llm/test_google_genai_llm.py
+++ b/tests/unit/llm/test_google_genai_llm.py
@@ -134,3 +134,12 @@ def test_gemini_invoke_error(mock_genai: Tuple[MagicMock, MagicMock]) -> None:
     llm = GeminiLLM("gemini-2.0-flash")
     with pytest.raises(LLMGenerationError):
         llm.invoke("hello")
+
+
+def test_gemini_llm_supports_structured_output(
+    mock_genai: Tuple[MagicMock, MagicMock],
+) -> None:
+    """GeminiLLM implements structured output (response_schema/response_mime_type),
+    so it must declare the capability flag components gate on."""
+    llm = GeminiLLM("gemini-2.0-flash")
+    assert llm.supports_structured_output is True


### PR DESCRIPTION
# Description

`GeminiLLM` already supports structured output (via `response_schema` / `response_mime_type`), but never declared the `supports_structured_output` capability flag. Pipeline components that check the flag saw `False` and fell back to prompt-based JSON.

This PR sets the flag to `True`.

**Breaking for pipeline users:** `SimpleKGPipeline`, `SchemaFromTextExtractor`, and `LLMEntityRelationExtractor` now enable structured output by default with `GeminiLLM`. To keep the previous behavior, construct the extractors with `use_structured_output=False`. The changelog documents this with the same wording as the equivalent `AnthropicLLM` change.

Split out of #571 so that refactor stays strictly behavior-neutral. Independent of the #565–#572 stack — can merge before or after it.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Low

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

- [ ] Documentation has been updated
- [x] Unit tests have been updated
- [ ] Examples have been updated
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [x] CHANGELOG.md updated
