### PR TITLE
Fix Renovate configuration to use pep621 manager for Python dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,7 @@
   "extends": [
     "config:recommended"
   ],
-  "enabledManagers": ["github-actions", "uv"],
+  "enabledManagers": ["github-actions", "pep621"],
   "schedule": ["before 9am on monday"],
   "minimumReleaseAge": "3 days",
   "lockFileMaintenance": {
@@ -18,15 +18,15 @@
       "labels": ["dependencies", "github-actions"]
     },
     {
-      "matchManagers": ["uv"],
-      "matchDepTypes": ["dev"],
+      "matchManagers": ["pep621"],
+      "matchDepTypes": ["dependency-groups"],
       "rangeStrategy": "bump",
       "groupName": "dev dependencies",
       "labels": ["dependencies", "python"]
     },
     {
-      "matchManagers": ["uv"],
-      "matchDepTypes": ["runtime"],
+      "matchManagers": ["pep621"],
+      "matchDepTypes": ["project.dependencies"],
       "rangeStrategy": "bump",
       "labels": ["dependencies", "python"]
     }


### PR DESCRIPTION
# Description

To fix the issue raised in #577,  this pull request updates the Renovate configuration to switch Python dependency management from `uv` to `pep621`. The changes ensure that Renovate will now use the `pep621` manager to handle both development and runtime Python dependencies, aligning with modern Python packaging standards.

* Changed the `enabledManagers` in `.github/renovate.json` from `uv` to `pep621`, so Renovate will use `pep621` for Python projects.
* Updated the dependency matchers to use `pep621` with `dependency-groups` for development dependencies and `project.dependencies` for runtime dependencies, replacing the previous `uv`-based configuration.


## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: low

## How Has This Been Tested?
- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
