### PR TITLE
Add image_bytes support to GeminiLLM for multimodal inputs

### DIFF
--- a/src/neo4j_graphrag/llm/__init__.py
+++ b/src/neo4j_graphrag/llm/__init__.py
@@ -19,7 +19,13 @@ from .anthropic_llm import AnthropicLLM, BaseAnthropicLLM
 from .base import LLMBase, LLMInterface, LLMInterfaceV2
 from .bedrock_llm import BedrockLLM
 from .cohere_llm import CohereLLM
-from .google_genai_llm import BaseGeminiLLM, GeminiLLM
+from .google_genai_llm import (
+    GEMINI_DEFAULT_IMAGE_MIME_TYPE,
+    GEMINI_SUPPORTED_IMAGE_MIME_TYPES,
+    BaseGeminiLLM,
+    GeminiImageMimeType,
+    GeminiLLM,
+)
 from .mistralai_llm import MistralAILLM
 from .ollama_llm import OllamaLLM
 from .openai_llm import AzureOpenAILLM, BaseOpenAILLM, OpenAILLM
@@ -28,11 +34,14 @@ from .utils import split_http_client_kwargs
 from .vertexai_llm import VertexAILLM
 
 __all__ = [
+    "GEMINI_DEFAULT_IMAGE_MIME_TYPE",
+    "GEMINI_SUPPORTED_IMAGE_MIME_TYPES",
     "AnthropicLLM",
     "BaseAnthropicLLM",
     "BaseGeminiLLM",
     "BedrockLLM",
     "CohereLLM",
+    "GeminiImageMimeType",
     "GeminiLLM",
     "LLMResponse",
     "LLMUsage",

--- a/src/neo4j_graphrag/llm/google_genai_llm.py
+++ b/src/neo4j_graphrag/llm/google_genai_llm.py
@@ -225,7 +225,8 @@ class BaseGeminiLLM(LLMBase, abc.ABC):
             image_bytes = kwargs.pop("image_bytes", None)
             image_mime_type = kwargs.pop("image_mime_type", "image/png")
             system_instruction, contents = self.get_messages_v2(
-                input, image_bytes=image_bytes, image_mime_type=image_mime_type)
+                input, image_bytes=image_bytes, image_mime_type=image_mime_type
+            )
             config = self._build_config(
                 system_instruction=system_instruction,
                 response_format=response_format,
@@ -349,9 +350,11 @@ class BaseGeminiLLM(LLMBase, abc.ABC):
         if image_bytes is not None:
             if not messages or messages[-1].role != "user":
                 messages.append(types.Content(role="user", parts=[]))
-            messages[-1].parts.append(
-                types.Part.from_bytes(data=image_bytes, mime_type=image_mime_type)
-            )
+            parts = messages[-1].parts
+            if parts is not None:
+                parts.append(
+                    types.Part.from_bytes(data=image_bytes, mime_type=image_mime_type)
+                )
         return system_instruction, messages
 
     def _build_config(

--- a/src/neo4j_graphrag/llm/google_genai_llm.py
+++ b/src/neo4j_graphrag/llm/google_genai_llm.py
@@ -195,7 +195,11 @@ class BaseGeminiLLM(LLMBase, abc.ABC):
         **kwargs: Any,
     ) -> LLMResponse:
         try:
-            system_instruction, contents = self.get_messages_v2(input)
+            image_bytes = kwargs.pop("image_bytes", None)
+            image_mime_type = kwargs.pop("image_mime_type", "image/png")
+            system_instruction, contents = self.get_messages_v2(
+                input, image_bytes=image_bytes, image_mime_type=image_mime_type
+            )
             config = self._build_config(
                 system_instruction=system_instruction,
                 response_format=response_format,
@@ -218,7 +222,10 @@ class BaseGeminiLLM(LLMBase, abc.ABC):
         **kwargs: Any,
     ) -> LLMResponse:
         try:
-            system_instruction, contents = self.get_messages_v2(input)
+            image_bytes = kwargs.pop("image_bytes", None)
+            image_mime_type = kwargs.pop("image_mime_type", "image/png")
+            system_instruction, contents = self.get_messages_v2(
+                input, image_bytes=image_bytes, image_mime_type=image_mime_type)
             config = self._build_config(
                 system_instruction=system_instruction,
                 response_format=response_format,
@@ -317,6 +324,8 @@ class BaseGeminiLLM(LLMBase, abc.ABC):
     def get_messages_v2(
         self,
         input: List[LLMMessage],
+        image_bytes: Optional[bytes] = None,
+        image_mime_type: str = "image/png",
     ) -> tuple[str | None, list[types.Content]]:
         messages: list[types.Content] = []
         system_instruction = None
@@ -337,6 +346,12 @@ class BaseGeminiLLM(LLMBase, abc.ABC):
                         role="model", parts=[types.Part.from_text(text=content)]
                     )
                 )
+        if image_bytes is not None:
+            if not messages or messages[-1].role != "user":
+                messages.append(types.Content(role="user", parts=[]))
+            messages[-1].parts.append(
+                types.Part.from_bytes(data=image_bytes, mime_type=image_mime_type)
+            )
         return system_instruction, messages
 
     def _build_config(

--- a/src/neo4j_graphrag/llm/google_genai_llm.py
+++ b/src/neo4j_graphrag/llm/google_genai_llm.py
@@ -20,11 +20,13 @@ import abc
 from typing import (
     Any,
     List,
+    Literal,
     Optional,
     Sequence,
     Type,
     Union,
     cast,
+    get_args,
     overload,
 )
 
@@ -60,6 +62,19 @@ try:
 except ImportError:
     genai = None  # type: ignore[assignment]
     types = None  # type: ignore[assignment]
+
+
+# Image MIME types Gemini's inlineData part accepts. See
+# https://ai.google.dev/gemini-api/docs/image-understanding
+GeminiImageMimeType = Literal[
+    "image/png", "image/jpeg", "image/webp", "image/heic", "image/heif"
+]
+GEMINI_SUPPORTED_IMAGE_MIME_TYPES: frozenset[str] = frozenset(
+    get_args(GeminiImageMimeType)
+)
+
+# Default image_mime_type for invoke/ainvoke's image_bytes parameter.
+GEMINI_DEFAULT_IMAGE_MIME_TYPE: GeminiImageMimeType = "image/png"
 
 
 # pylint: disable=redefined-builtin, arguments-differ, raise-missing-from, no-else-return, import-outside-toplevel
@@ -106,6 +121,8 @@ class BaseGeminiLLM(LLMBase, abc.ABC):
         self,
         input: List[LLMMessage],
         response_format: Optional[Union[Type[BaseModel], dict[str, Any]]] = None,
+        image_bytes: Optional[bytes] = None,
+        image_mime_type: GeminiImageMimeType = GEMINI_DEFAULT_IMAGE_MIME_TYPE,
         **kwargs: Any,
     ) -> LLMResponse: ...
 
@@ -122,6 +139,8 @@ class BaseGeminiLLM(LLMBase, abc.ABC):
         self,
         input: List[LLMMessage],
         response_format: Optional[Union[Type[BaseModel], dict[str, Any]]] = None,
+        image_bytes: Optional[bytes] = None,
+        image_mime_type: GeminiImageMimeType = GEMINI_DEFAULT_IMAGE_MIME_TYPE,
         **kwargs: Any,
     ) -> LLMResponse: ...
 
@@ -131,11 +150,37 @@ class BaseGeminiLLM(LLMBase, abc.ABC):
         message_history: Optional[Union[List[LLMMessage], MessageHistory]] = None,
         system_instruction: Optional[str] = None,
         response_format: Optional[Union[Type[BaseModel], dict[str, Any]]] = None,
+        image_bytes: Optional[bytes] = None,
+        image_mime_type: GeminiImageMimeType = GEMINI_DEFAULT_IMAGE_MIME_TYPE,
         **kwargs: Any,
     ) -> LLMResponse:
+        """Sends input to the LLM and returns a response.
+
+        Args:
+            input (Union[str, List[LLMMessage]]): Text (v1) or list of messages (v2)
+                sent to the LLM.
+            message_history: v1 only. Previous messages, each with a role assigned.
+            system_instruction: v1 only. Overrides the LLM system message for this call.
+            response_format: v2 only. A Pydantic model class or a JSON schema dict.
+            image_bytes (Optional[bytes]): v2 only. Raw image data appended as an inline
+                image part to the last user message. Defaults to None.
+            image_mime_type (GeminiImageMimeType): MIME type of ``image_bytes``. Must be
+                one of ``GEMINI_SUPPORTED_IMAGE_MIME_TYPES``. Ignored when
+                ``image_bytes`` is None. Defaults to "image/png".
+        """
         if isinstance(input, str):
+            if image_bytes is not None:
+                raise ValueError(
+                    "image_bytes is only supported with a list of messages as input."
+                )
             return self.__invoke_v1(input, message_history, system_instruction)
-        return self.__invoke_v2(input, response_format=response_format, **kwargs)
+        return self.__invoke_v2(
+            input,
+            response_format=response_format,
+            image_bytes=image_bytes,
+            image_mime_type=image_mime_type,
+            **kwargs,
+        )
 
     async def ainvoke(  # type: ignore[no-redef]
         self,
@@ -143,11 +188,24 @@ class BaseGeminiLLM(LLMBase, abc.ABC):
         message_history: Optional[Union[List[LLMMessage], MessageHistory]] = None,
         system_instruction: Optional[str] = None,
         response_format: Optional[Union[Type[BaseModel], dict[str, Any]]] = None,
+        image_bytes: Optional[bytes] = None,
+        image_mime_type: GeminiImageMimeType = GEMINI_DEFAULT_IMAGE_MIME_TYPE,
         **kwargs: Any,
     ) -> LLMResponse:
+        """Asynchronous version of :meth:`invoke`."""
         if isinstance(input, str):
+            if image_bytes is not None:
+                raise ValueError(
+                    "image_bytes is only supported with a list of messages as input."
+                )
             return await self.__ainvoke_v1(input, message_history, system_instruction)
-        return await self.__ainvoke_v2(input, response_format=response_format, **kwargs)
+        return await self.__ainvoke_v2(
+            input,
+            response_format=response_format,
+            image_bytes=image_bytes,
+            image_mime_type=image_mime_type,
+            **kwargs,
+        )
 
     @rate_limit_handler_decorator
     def __invoke_v1(
@@ -192,11 +250,11 @@ class BaseGeminiLLM(LLMBase, abc.ABC):
         self,
         input: List[LLMMessage],
         response_format: Optional[Union[Type[BaseModel], dict[str, Any]]] = None,
+        image_bytes: Optional[bytes] = None,
+        image_mime_type: GeminiImageMimeType = GEMINI_DEFAULT_IMAGE_MIME_TYPE,
         **kwargs: Any,
     ) -> LLMResponse:
         try:
-            image_bytes = kwargs.pop("image_bytes", None)
-            image_mime_type = kwargs.pop("image_mime_type", "image/png")
             system_instruction, contents = self.get_messages_v2(
                 input, image_bytes=image_bytes, image_mime_type=image_mime_type
             )
@@ -219,11 +277,11 @@ class BaseGeminiLLM(LLMBase, abc.ABC):
         self,
         input: List[LLMMessage],
         response_format: Optional[Union[Type[BaseModel], dict[str, Any]]] = None,
+        image_bytes: Optional[bytes] = None,
+        image_mime_type: GeminiImageMimeType = GEMINI_DEFAULT_IMAGE_MIME_TYPE,
         **kwargs: Any,
     ) -> LLMResponse:
         try:
-            image_bytes = kwargs.pop("image_bytes", None)
-            image_mime_type = kwargs.pop("image_mime_type", "image/png")
             system_instruction, contents = self.get_messages_v2(
                 input, image_bytes=image_bytes, image_mime_type=image_mime_type
             )
@@ -326,8 +384,16 @@ class BaseGeminiLLM(LLMBase, abc.ABC):
         self,
         input: List[LLMMessage],
         image_bytes: Optional[bytes] = None,
-        image_mime_type: str = "image/png",
+        image_mime_type: GeminiImageMimeType = GEMINI_DEFAULT_IMAGE_MIME_TYPE,
     ) -> tuple[str | None, list[types.Content]]:
+        if (
+            image_bytes is not None
+            and image_mime_type not in GEMINI_SUPPORTED_IMAGE_MIME_TYPES
+        ):
+            raise ValueError(
+                f"Unsupported image_mime_type '{image_mime_type}'. Supported types: "
+                f"{sorted(GEMINI_SUPPORTED_IMAGE_MIME_TYPES)}."
+            )
         messages: list[types.Content] = []
         system_instruction = None
         for message in input:

--- a/tests/unit/llm/test_google_genai_llm.py
+++ b/tests/unit/llm/test_google_genai_llm.py
@@ -258,3 +258,105 @@ async def test_gemini_llm_aclose_closes_sync_and_async_clients(
 
     mock_client.close.assert_called_once()
     mock_client.aio.aclose.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# image_bytes support
+# ---------------------------------------------------------------------------
+
+
+def _content_factory(**kwargs):  # type: ignore[no-untyped-def]
+    """Return a MagicMock that mimics types.Content attribute access."""
+    obj = MagicMock()
+    obj.role = kwargs.get("role")
+    obj.parts = list(kwargs.get("parts", []))
+    return obj
+
+
+def test_get_messages_v2_with_image_bytes_appends_part(
+    mock_genai: Tuple[MagicMock, MagicMock],
+) -> None:
+    """get_messages_v2 appends a from_bytes Part to the last user Content."""
+    _, mock_types = mock_genai
+    mock_types.Content = MagicMock(side_effect=_content_factory)
+    mock_types.Part.from_text = MagicMock(return_value=MagicMock())
+    mock_image_part = MagicMock()
+    mock_types.Part.from_bytes = MagicMock(return_value=mock_image_part)
+
+    llm = GeminiLLM("gemini-2.0-flash")
+    _, contents = llm.get_messages_v2(
+        [{"role": "user", "content": "describe this"}],
+        image_bytes=b"fake-png",
+        image_mime_type="image/png",
+    )
+
+    mock_types.Part.from_bytes.assert_called_once_with(
+        data=b"fake-png", mime_type="image/png"
+    )
+    assert contents[-1].parts is not None
+    assert mock_image_part in contents[-1].parts
+
+
+def test_get_messages_v2_without_image_bytes_unchanged(
+    mock_genai: Tuple[MagicMock, MagicMock],
+) -> None:
+    """get_messages_v2 without image_bytes does not call Part.from_bytes (regression)."""
+    _, mock_types = mock_genai
+    mock_types.Part.from_bytes = MagicMock()
+
+    llm = GeminiLLM("gemini-2.0-flash")
+    _, contents = llm.get_messages_v2([{"role": "user", "content": "hello"}])
+
+    mock_types.Part.from_bytes.assert_not_called()
+    assert len(contents) == 1
+
+
+def test_invoke_v2_image_bytes_not_forwarded_to_config(
+    mock_genai: Tuple[MagicMock, MagicMock],
+) -> None:
+    """image_bytes must be popped before _build_config — unknown fields raise in GenerateContentConfig."""
+    mock_gen, mock_types = mock_genai
+    mock_types.Content = MagicMock(side_effect=_content_factory)
+    mock_types.Part.from_text = MagicMock(return_value=MagicMock())
+    mock_types.Part.from_bytes = MagicMock(return_value=MagicMock())
+    mock_gen.Client.return_value.models.generate_content.return_value.text = "ok"
+
+    llm = GeminiLLM("gemini-2.0-flash")
+    response = llm.invoke(
+        [{"role": "user", "content": "describe this"}],
+        image_bytes=b"fake-png",
+        image_mime_type="image/png",
+    )
+
+    assert response.content == "ok"
+    config_kwargs = mock_types.GenerateContentConfig.call_args.kwargs
+    assert "image_bytes" not in config_kwargs
+    assert "image_mime_type" not in config_kwargs
+
+
+@pytest.mark.asyncio
+async def test_ainvoke_v2_image_bytes_not_forwarded_to_config(
+    mock_genai: Tuple[MagicMock, MagicMock],
+) -> None:
+    """Same as sync: image_bytes must not reach GenerateContentConfig in the async path."""
+    mock_gen, mock_types = mock_genai
+    mock_types.Content = MagicMock(side_effect=_content_factory)
+    mock_types.Part.from_text = MagicMock(return_value=MagicMock())
+    mock_types.Part.from_bytes = MagicMock(return_value=MagicMock())
+    mock_response = MagicMock()
+    mock_response.text = "async ok"
+    mock_gen.Client.return_value.aio.models.generate_content = AsyncMock(
+        return_value=mock_response
+    )
+
+    llm = GeminiLLM("gemini-2.0-flash")
+    response = await llm.ainvoke(
+        [{"role": "user", "content": "describe this"}],
+        image_bytes=b"fake-png",
+        image_mime_type="image/png",
+    )
+
+    assert response.content == "async ok"
+    config_kwargs = mock_types.GenerateContentConfig.call_args.kwargs
+    assert "image_bytes" not in config_kwargs
+    assert "image_mime_type" not in config_kwargs

--- a/tests/unit/llm/test_google_genai_llm.py
+++ b/tests/unit/llm/test_google_genai_llm.py
@@ -14,13 +14,19 @@
 #  limitations under the License.
 from __future__ import annotations
 
-from typing import Generator, Tuple
+from typing import Generator, Tuple, get_args
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from neo4j_graphrag.exceptions import LLMGenerationError
-from neo4j_graphrag.llm import BaseGeminiLLM, GeminiLLM
+from neo4j_graphrag.llm import (
+    GEMINI_DEFAULT_IMAGE_MIME_TYPE,
+    GEMINI_SUPPORTED_IMAGE_MIME_TYPES,
+    BaseGeminiLLM,
+    GeminiImageMimeType,
+    GeminiLLM,
+)
 from neo4j_graphrag.types import LLMMessage
 
 
@@ -360,3 +366,58 @@ async def test_ainvoke_v2_image_bytes_not_forwarded_to_config(
     config_kwargs = mock_types.GenerateContentConfig.call_args.kwargs
     assert "image_bytes" not in config_kwargs
     assert "image_mime_type" not in config_kwargs
+
+
+def test_get_messages_v2_rejects_unsupported_image_mime_type(
+    mock_genai: Tuple[MagicMock, MagicMock],
+) -> None:
+    """An image_mime_type outside GEMINI_SUPPORTED_IMAGE_MIME_TYPES is rejected."""
+    llm = GeminiLLM("gemini-2.0-flash")
+
+    with pytest.raises(ValueError, match="Unsupported image_mime_type"):
+        llm.get_messages_v2(
+            [{"role": "user", "content": "describe this"}],
+            image_bytes=b"fake-gif",
+            image_mime_type="image/gif",  # type: ignore[arg-type]
+        )
+
+
+def test_get_messages_v2_ignores_mime_type_without_image_bytes(
+    mock_genai: Tuple[MagicMock, MagicMock],
+) -> None:
+    """image_mime_type is only validated when image_bytes is provided."""
+    llm = GeminiLLM("gemini-2.0-flash")
+
+    _, contents = llm.get_messages_v2(
+        [{"role": "user", "content": "hello"}],
+        image_mime_type="image/gif",  # type: ignore[arg-type]
+    )
+
+    assert len(contents) == 1
+
+
+def test_invoke_v1_rejects_image_bytes(
+    mock_genai: Tuple[MagicMock, MagicMock],
+) -> None:
+    """The v1 (str input) path does not support images."""
+    llm = GeminiLLM("gemini-2.0-flash")
+
+    with pytest.raises(ValueError, match="only supported with a list of messages"):
+        llm.invoke("describe this", image_bytes=b"fake-png")  # type: ignore[call-overload]
+
+
+@pytest.mark.asyncio
+async def test_ainvoke_v1_rejects_image_bytes(
+    mock_genai: Tuple[MagicMock, MagicMock],
+) -> None:
+    """Same as sync: the v1 path does not support images."""
+    llm = GeminiLLM("gemini-2.0-flash")
+
+    with pytest.raises(ValueError, match="only supported with a list of messages"):
+        await llm.ainvoke("describe this", image_bytes=b"fake-png")  # type: ignore[call-overload]
+
+
+def test_gemini_image_mime_type_constants() -> None:
+    """The supported set is derived from the Literal and the default is a member."""
+    assert GEMINI_SUPPORTED_IMAGE_MIME_TYPES == frozenset(get_args(GeminiImageMimeType))
+    assert GEMINI_DEFAULT_IMAGE_MIME_TYPE in GEMINI_SUPPORTED_IMAGE_MIME_TYPES


### PR DESCRIPTION
# Description

Add support for passing image bytes alongside text in `GeminiLLM` invocations via the existing `ainvoke/invoke` interface.

When `image_bytes` (and optionally `image_mime_type`) are passed as keyword arguments, `GeminiLLM` attaches the image as an inlineData Part on the last user turn before sending the request to the Gemini API. Text-only callers are unaffected so If `image_bytes` is not supplied the method delegates to the existing path unchanged.

## Type of Change
- [X] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity
Complexity: Low

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [X] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [X] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
