### PR TITLE
feat: allow caller-supplied metadata on extracted entity nodes and relationships

### DIFF
--- a/examples/customize/build_graph/components/extractors/custom_extractor.py
+++ b/examples/customize/build_graph/components/extractors/custom_extractor.py
@@ -32,6 +32,7 @@ class MyExtractor(EntityRelationExtractor):
         chunks: TextChunks,
         document_info: Optional[DocumentInfo] = None,
         lexical_graph_config: Optional[LexicalGraphConfig] = None,
+        entity_metadata: Optional[dict[str, Any]] = None,
         **kwargs: Any,
     ) -> Neo4jGraph:
         # Implement your logic here

--- a/src/neo4j_graphrag/components/entity_relation_extractor.py
+++ b/src/neo4j_graphrag/components/entity_relation_extractor.py
@@ -135,6 +135,7 @@ class EntityRelationExtractor(Component):
         chunks: TextChunks,
         document_info: Optional[DocumentInfo] = None,
         lexical_graph_config: Optional[LexicalGraphConfig] = None,
+        entity_metadata: Optional[dict[str, Any]] = None,
         **kwargs: Any,
     ) -> Neo4jGraph:
         raise NotImplementedError()
@@ -290,12 +291,23 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
         chunk_graph: Neo4jGraph,
         chunk: TextChunk,
         lexical_graph_builder: Optional[LexicalGraphBuilder] = None,
+        entity_metadata: Optional[dict[str, Any]] = None,
     ) -> None:
         """Perform post-processing after entity and relation extraction:
         - Update node IDs to make them unique across chunks
+        - Merge entity_metadata into node and relationship properties
         - Build the lexical graph if requested
         """
         self.update_ids(chunk_graph, chunk)
+        if entity_metadata:
+            for node in chunk_graph.nodes:
+                if node.properties is None:
+                    node.properties = {}
+                node.properties.update(entity_metadata)
+            for rel in chunk_graph.relationships:
+                if rel.properties is None:
+                    rel.properties = {}
+                rel.properties.update(entity_metadata)
         if lexical_graph_builder:
             await lexical_graph_builder.process_chunk_extracted_entities(
                 chunk_graph,
@@ -322,6 +334,7 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
         schema: GraphSchema,
         examples: str,
         lexical_graph_builder: Optional[LexicalGraphBuilder] = None,
+        entity_metadata: Optional[dict[str, Any]] = None,
     ) -> Neo4jGraph:
         """Run extraction, validation and post processing for a single chunk"""
         async with sem:
@@ -331,6 +344,7 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
                 chunk_graph,
                 chunk,
                 lexical_graph_builder,
+                entity_metadata,
             )
             return chunk_graph
 
@@ -340,6 +354,7 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
         chunks: TextChunks,
         document_info: Optional[DocumentInfo] = None,
         lexical_graph_config: Optional[LexicalGraphConfig] = None,
+        entity_metadata: Optional[dict[str, Any]] = None,
         schema: Optional[GraphSchema] = None,
         examples: str = "",
         **kwargs: Any,
@@ -357,6 +372,7 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
             lexical_graph_config (Optional[LexicalGraphConfig], optional): Lexical graph configuration to customize node labels and relationship types in the lexical graph.
             schema (GraphSchema | None): Definition of the schema to guide the LLM in its extraction.
             examples (str): Examples for few-shot learning in the prompt.
+            entity_metadata (Optional[dict[str, Any]], optional): Metadata to attach to extracted entity nodes and relationships. Keys supplied by the caller take precedence over any keys produced by the LLM.
         """
         lexical_graph_builder = None
         lexical_graph = None
@@ -381,6 +397,7 @@ class LLMEntityRelationExtractor(EntityRelationExtractor):
                 schema,
                 examples,
                 lexical_graph_builder,
+                entity_metadata,
             )
             for chunk in chunks.chunks
         ]

--- a/src/neo4j_graphrag/experimental/pipeline/config/template_pipeline/simple_kg_builder.py
+++ b/src/neo4j_graphrag/experimental/pipeline/config/template_pipeline/simple_kg_builder.py
@@ -447,4 +447,8 @@ class SimpleKGPipelineConfig(TemplatePipelineConfig):
                 metadata=user_input.get("document_metadata"),
                 document_type=DocumentType.INLINE_TEXT,
             )
+        if user_input.get("entity_metadata") is not None:
+            run_params["extractor"]["entity_metadata"] = user_input.get(
+                "entity_metadata"
+            )
         return run_params

--- a/src/neo4j_graphrag/experimental/pipeline/kg_builder.py
+++ b/src/neo4j_graphrag/experimental/pipeline/kg_builder.py
@@ -177,6 +177,7 @@ class SimpleKGPipeline:
         file_path: Optional[str] = None,
         text: Optional[str] = None,
         document_metadata: Optional[dict[str, Any]] = None,
+        entity_metadata: Optional[dict[str, Any]] = None,
     ) -> PipelineResult:
         """
         Asynchronously runs the knowledge graph building process.
@@ -186,6 +187,9 @@ class SimpleKGPipeline:
                 If `from_file` is False, can be used to set the Document node path property.
             text (Optional[str]): The text content to process. Required if `from_file` is False.
             document_metadata (Optional[dict[str, Any]]): The metadata to attach to the document.
+            entity_metadata (Optional[dict[str, Any]]): Properties to stamp on every
+                extracted entity node and relationship, in addition to the properties the
+                LLM produces. Useful for tenant, owner or ingestion-time markers.
 
         Returns:
             PipelineResult: The result of the pipeline execution.
@@ -195,5 +199,6 @@ class SimpleKGPipeline:
                 "file_path": file_path,
                 "text": text,
                 "document_metadata": document_metadata,
+                "entity_metadata": entity_metadata,
             }
         )

--- a/tests/unit/components/test_entity_relation_extractor.py
+++ b/tests/unit/components/test_entity_relation_extractor.py
@@ -15,10 +15,10 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
-from neo4j_graphrag.exceptions import LLMGenerationError
+
 from neo4j_graphrag.components.entity_relation_extractor import (
     LLMEntityRelationExtractor,
     OnError,
@@ -31,10 +31,9 @@ from neo4j_graphrag.components.types import (
     TextChunk,
     TextChunks,
 )
+from neo4j_graphrag.exceptions import LLMGenerationError
 from neo4j_graphrag.experimental.pipeline.exceptions import InvalidJSONError
-from neo4j_graphrag.llm import LLMInterface, LLMResponse
-from neo4j_graphrag.llm import OpenAILLM, VertexAILLM
-from unittest.mock import patch
+from neo4j_graphrag.llm import LLMInterface, LLMResponse, OpenAILLM, VertexAILLM
 
 
 @pytest.mark.asyncio
@@ -491,3 +490,38 @@ async def test_extractor_structured_output_false_uses_v1() -> None:
     call_args = llm.ainvoke.call_args
     assert isinstance(call_args[0][0], str)  # First arg is string prompt
     assert "response_format" not in call_args[1]  # No response_format kwarg
+
+
+@pytest.mark.asyncio
+async def test_extractor_with_entity_metadata() -> None:
+    """Test that entity_metadata is merged into every extracted node and relationship,
+    and that caller-supplied keys take precedence over LLM-produced keys."""
+    llm = MagicMock(spec=LLMInterface)
+    llm.ainvoke.return_value = LLMResponse(
+        content='{"nodes": [{"id": "0", "label": "Person", "properties": {"name": "Alice", "source": "llm_source"}}, {"id": "1", "label": "Person", "properties": {"name": "Bob"}}], "relationships": [{"start_node_id": "0", "end_node_id": "1", "type": "KNOWS", "properties": {}}]}'
+    )
+
+    extractor = LLMEntityRelationExtractor(
+        llm=llm,
+        create_lexical_graph=False,
+    )
+    chunks = TextChunks(chunks=[TextChunk(text="some text", index=0)])
+    entity_metadata = {"tenant_id": "acme", "source": "caller_source"}
+    res = await extractor.run(chunks=chunks, entity_metadata=entity_metadata)
+
+    assert len(res.nodes) == 2
+    assert res.nodes[0].properties == {
+        "name": "Alice",
+        "tenant_id": "acme",
+        "source": "caller_source",
+    }
+    assert res.nodes[1].properties == {
+        "name": "Bob",
+        "tenant_id": "acme",
+        "source": "caller_source",
+    }
+    assert len(res.relationships) == 1
+    assert res.relationships[0].properties == {
+        "tenant_id": "acme",
+        "source": "caller_source",
+    }

--- a/tests/unit/experimental/pipeline/test_kg_builder.py
+++ b/tests/unit/experimental/pipeline/test_kg_builder.py
@@ -17,9 +17,10 @@ from unittest.mock import MagicMock, Mock, patch
 
 import neo4j
 import pytest
-from neo4j_graphrag.embeddings import Embedder
+
 from neo4j_graphrag.components.data_loader import PdfLoader
 from neo4j_graphrag.components.types import LexicalGraphConfig
+from neo4j_graphrag.embeddings import Embedder
 from neo4j_graphrag.experimental.pipeline.exceptions import PipelineDefinitionError
 from neo4j_graphrag.experimental.pipeline.kg_builder import SimpleKGPipeline
 from neo4j_graphrag.experimental.pipeline.pipeline import PipelineResult
@@ -268,3 +269,38 @@ async def test_knowledge_graph_builder_with_lexical_graph_config(_: Mock) -> Non
         assert pipe_inputs["extractor"]["lexical_graph_config"] == lexical_graph_config
         assert pipe_inputs["extractor"]["document_info"] is not None
         assert pipe_inputs["extractor"]["document_info"]["path"] == "document.txt"
+
+
+@mock.patch(
+    "neo4j_graphrag.components.kg_writer.get_version",
+    return_value=((5, 23, 0), False, False),
+)
+@pytest.mark.asyncio
+async def test_run_async_passes_entity_metadata_to_the_pipeline(_: Mock) -> None:
+    llm = MagicMock(spec=LLMInterface)
+    driver = MagicMock(spec=neo4j.Driver)
+    embedder = MagicMock(spec=Embedder)
+
+    kg_builder = SimpleKGPipeline(
+        llm=llm,
+        driver=driver,
+        embedder=embedder,
+        from_file=False,
+    )
+
+    text_input = "May thy knife chip and shatter."
+    entity_metadata = {"created_by": "unit_test", "version": 1}
+
+    with patch.object(
+        kg_builder.runner.pipeline,
+        "run",
+        return_value=PipelineResult(run_id="test_run", result=None),
+    ) as mock_run:
+        await kg_builder.run_async(
+            text=text_input,
+            entity_metadata=entity_metadata,
+        )
+
+        pipe_inputs = mock_run.call_args[1]["data"]
+        assert "extractor" in pipe_inputs
+        assert pipe_inputs["extractor"]["entity_metadata"] == entity_metadata


### PR DESCRIPTION
Closes #588

The issue lays out the asymmetry precisely, so I will not restate it beyond the summary: document nodes take caller metadata via `document_metadata`, chunk nodes take it via `TextChunk.metadata`, and extracted entity nodes and relationships have no equivalent — their properties come only from LLM output. The lexical bookkeeping layer is enrichable while the entity layer, the part the library exists to produce, is not.

This adds an `entity_metadata` parameter threaded from `SimpleKGPipeline.run_async()` through `SimpleKGPipelineConfig` to the extractor, where `post_process_chunk()` merges it into the properties of every extracted node and relationship.

Caller-supplied keys take precedence over LLM-produced ones. That is documented on the parameter: if the model happens to emit a `tenant_id`, the caller's value is the one that lands, since the whole point is an authoritative application-level marker.

`EntityRelationExtractor.run()` gains the parameter on the abstract signature, so the example custom extractor in `examples/customize/build_graph/components/extractors/custom_extractor.py` is updated to match. The parameter is optional throughout and nothing is passed when it is `None`, so existing pipelines are unaffected.

Verified the new tests fail against unmodified `main` (2 failed) and pass with the change. `tests/unit/experimental/pipeline/test_kg_builder.py` and `tests/unit/components/test_entity_relation_extractor.py` together: 44 passed. `mypy` clean on both touched source files, `ruff check` clean on every file in the diff.

One note on the wider suite: `tests/unit` shows 27 failures on this branch, but `main` shows the same 27 (they come from a `mistralai` SDK mismatch in my environment), and this branch adds 2 passes on top.

If you would rather this lived on a pluggable writer than on the pipeline signature, I am happy to rework it — the reporter sketched a `Neo4jWriter` subclass as the current workaround, and I can see the argument either way.
