### PR TITLE
Improve e2e test resilience with exponential backoff retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 
 - Fixed a bug in `AnthropicLLM` where an `http_client` passed via kwargs (whether an `httpx.Client` or `httpx.AsyncClient`) was forwarded to both the sync `anthropic.Anthropic` and async `anthropic.AsyncAnthropic` clients, causing a type mismatch. `http_client` is now routed to the matching sync/async client only; other kwargs remain shared. An `http_client` of an unrecognized type now emits a warning and is ignored instead of raising, matching `OpenAILLM`'s existing behavior.
 - Vector and VectorCypher retrievers on Neo4j 2026+: prefix SEARCH queries with `CYPHER 25` and fall back to procedure-based vector search when SEARCH is unsupported or fails.
-- E2E tests: added retry logic with exponential backoff to embedding model downloads to handle Hugging Face rate limits, improving test reliability in CI environments.
+- E2E tests: added exponential backoff retry logic with jitter (5 attempts, 5–60 second waits) to embedding model downloads to handle Hugging Face rate limits, improving test reliability in parallel CI runs.
 
 ## 1.18.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 
 - Fixed a bug in `AnthropicLLM` where an `http_client` passed via kwargs (whether an `httpx.Client` or `httpx.AsyncClient`) was forwarded to both the sync `anthropic.Anthropic` and async `anthropic.AsyncAnthropic` clients, causing a type mismatch. `http_client` is now routed to the matching sync/async client only; other kwargs remain shared. An `http_client` of an unrecognized type now emits a warning and is ignored instead of raising, matching `OpenAILLM`'s existing behavior.
 - Vector and VectorCypher retrievers on Neo4j 2026+: prefix SEARCH queries with `CYPHER 25` and fall back to procedure-based vector search when SEARCH is unsupported or fails.
-- E2E tests: added exponential backoff retry logic with jitter (5 attempts, 5–60 second waits) to embedding model downloads to handle Hugging Face rate limits, improving test reliability in parallel CI runs.
+- E2E tests: added exponential backoff retry logic with jitter (5 attempts, 5–60 second waits) to embedding model downloads to handle Hugging Face rate limits. Retries only on transient network errors (connection, timeout) and immediately fails on unrecoverable errors (missing packages, permissions), improving test reliability in parallel CI runs.
 
 ## 1.18.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 - Fixed a bug in `AnthropicLLM` where an `http_client` passed via kwargs (whether an `httpx.Client` or `httpx.AsyncClient`) was forwarded to both the sync `anthropic.Anthropic` and async `anthropic.AsyncAnthropic` clients, causing a type mismatch. `http_client` is now routed to the matching sync/async client only; other kwargs remain shared. An `http_client` of an unrecognized type now emits a warning and is ignored instead of raising, matching `OpenAILLM`'s existing behavior.
 - Vector and VectorCypher retrievers on Neo4j 2026+: prefix SEARCH queries with `CYPHER 25` and fall back to procedure-based vector search when SEARCH is unsupported or fails.
+- E2E tests: added retry logic with exponential backoff to embedding model downloads to handle Hugging Face rate limits, improving test reliability in CI environments.
 
 ## 1.18.0
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -44,6 +44,7 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 @retry(
     stop=stop_after_attempt(5),
     wait=wait_random_exponential(multiplier=2, min=5, max=60),
+    reraise=True,
 )
 def load_sentence_transformer_with_retry(
     model_name: str,

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -45,7 +45,9 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=1, min=2, max=10),
 )
-def load_sentence_transformer_with_retry(model_name: str) -> SentenceTransformerEmbeddings:
+def load_sentence_transformer_with_retry(
+    model_name: str,
+) -> SentenceTransformerEmbeddings:
     """Load sentence transformer with retry logic to handle Hugging Face rate limits."""
     return SentenceTransformerEmbeddings(model=model_name)
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -14,6 +14,7 @@
 #  limitations under the License.
 from __future__ import annotations
 
+import logging
 import os
 import random
 import string
@@ -24,6 +25,8 @@ from unittest.mock import MagicMock
 import pytest
 from neo4j import Driver, GraphDatabase
 from neo4j_graphrag.embeddings.base import Embedder
+from requests.exceptions import ConnectionError as RequestsConnectionError
+from requests.exceptions import Timeout as RequestsTimeout
 from neo4j_graphrag.embeddings.sentence_transformers import (
     SentenceTransformerEmbeddings,
 )
@@ -34,22 +37,43 @@ from neo4j_graphrag.indexes import (
 )
 from neo4j_graphrag.llm import LLMInterface
 from neo4j_graphrag.retrievers import VectorRetriever
-from tenacity import retry, stop_after_attempt, wait_random_exponential
+from tenacity import (
+    before_sleep_log,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_random_exponential,
+)
 
 from ..e2e.utils import EMBEDDING_BIOLOGY
 
+logger = logging.getLogger(__name__)
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+# Transient exceptions that should be retried (network/rate limit errors)
+_TRANSIENT_EXCEPTIONS = (
+    RequestsConnectionError,
+    RequestsTimeout,
+)
 
 
 @retry(
+    retry=retry_if_exception_type(_TRANSIENT_EXCEPTIONS),
     stop=stop_after_attempt(5),
     wait=wait_random_exponential(multiplier=2, min=5, max=60),
+    before_sleep=before_sleep_log(logger, logging.WARNING),
     reraise=True,
 )
 def load_sentence_transformer_with_retry(
     model_name: str,
 ) -> SentenceTransformerEmbeddings:
-    """Load sentence transformer with retry logic to handle Hugging Face rate limits."""
+    """Load sentence transformer with retry logic to handle Hugging Face rate limits.
+
+    Retries on transient network errors (requests connection errors, timeouts) with
+    exponential backoff and jitter. Immediately fails on unrecoverable errors like
+    missing dependencies or permission issues.
+    """
     return SentenceTransformerEmbeddings(model=model_name)
 
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -24,6 +24,9 @@ from unittest.mock import MagicMock
 import pytest
 from neo4j import Driver, GraphDatabase
 from neo4j_graphrag.embeddings.base import Embedder
+from neo4j_graphrag.embeddings.sentence_transformers import (
+    SentenceTransformerEmbeddings,
+)
 from neo4j_graphrag.indexes import (
     create_fulltext_index,
     create_vector_index,
@@ -31,10 +34,20 @@ from neo4j_graphrag.indexes import (
 )
 from neo4j_graphrag.llm import LLMInterface
 from neo4j_graphrag.retrievers import VectorRetriever
+from tenacity import retry, stop_after_attempt, wait_exponential
 
 from ..e2e.utils import EMBEDDING_BIOLOGY
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=10),
+)
+def load_sentence_transformer_with_retry(model_name: str) -> SentenceTransformerEmbeddings:
+    """Load sentence transformer with retry logic to handle Hugging Face rate limits."""
+    return SentenceTransformerEmbeddings(model=model_name)
 
 
 @pytest.fixture(scope="module")

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -34,7 +34,7 @@ from neo4j_graphrag.indexes import (
 )
 from neo4j_graphrag.llm import LLMInterface
 from neo4j_graphrag.retrievers import VectorRetriever
-from tenacity import retry, stop_after_attempt, wait_exponential
+from tenacity import retry, stop_after_attempt, wait_random_exponential
 
 from ..e2e.utils import EMBEDDING_BIOLOGY
 
@@ -42,8 +42,8 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 @retry(
-    stop=stop_after_attempt(3),
-    wait=wait_exponential(multiplier=1, min=2, max=10),
+    stop=stop_after_attempt(5),
+    wait=wait_random_exponential(multiplier=2, min=5, max=60),
 )
 def load_sentence_transformer_with_retry(
     model_name: str,

--- a/tests/e2e/pinecone_e2e/test_pinecone_e2e.py
+++ b/tests/e2e/pinecone_e2e/test_pinecone_e2e.py
@@ -26,6 +26,7 @@ from neo4j_graphrag.retrievers import PineconeNeo4jRetriever
 from neo4j_graphrag.types import RetrieverResult, RetrieverResultItem
 from pinecone import Pinecone
 
+from ..conftest import load_sentence_transformer_with_retry
 from ..utils import EMBEDDING_BIOLOGY, build_data_objects, populate_neo4j
 
 
@@ -33,7 +34,7 @@ from ..utils import EMBEDDING_BIOLOGY, build_data_objects, populate_neo4j
 def sentence_transformer_embedder() -> (
     Generator[SentenceTransformerEmbeddings, Any, Any]
 ):
-    embedder = SentenceTransformerEmbeddings(model="all-MiniLM-L6-v2")
+    embedder = load_sentence_transformer_with_retry("all-MiniLM-L6-v2")
     yield embedder
 
 

--- a/tests/e2e/qdrant_e2e/test_qdrant_e2e.py
+++ b/tests/e2e/qdrant_e2e/test_qdrant_e2e.py
@@ -26,6 +26,7 @@ from neo4j_graphrag.retrievers import QdrantNeo4jRetriever
 from neo4j_graphrag.types import RetrieverResult, RetrieverResultItem
 from qdrant_client import QdrantClient
 
+from ..conftest import load_sentence_transformer_with_retry
 from ..utils import EMBEDDING_BIOLOGY
 from .populate_dbs import populate_dbs
 
@@ -34,7 +35,7 @@ from .populate_dbs import populate_dbs
 def sentence_transformer_embedder() -> (
     Generator[SentenceTransformerEmbeddings, Any, Any]
 ):
-    embedder = SentenceTransformerEmbeddings(model="all-MiniLM-L6-v2")
+    embedder = load_sentence_transformer_with_retry("all-MiniLM-L6-v2")
     yield embedder
 
 

--- a/tests/e2e/weaviate_e2e/test_weaviate_e2e.py
+++ b/tests/e2e/weaviate_e2e/test_weaviate_e2e.py
@@ -27,6 +27,7 @@ from neo4j_graphrag.types import RetrieverResult, RetrieverResultItem
 from weaviate.client import WeaviateClient
 from weaviate.connect.helpers import connect_to_local
 
+from ..conftest import load_sentence_transformer_with_retry
 from ..utils import EMBEDDING_BIOLOGY
 from .populate_dbs import populate_dbs
 
@@ -35,7 +36,7 @@ from .populate_dbs import populate_dbs
 def sentence_transformer_embedder() -> (
     Generator[SentenceTransformerEmbeddings, Any, Any]
 ):
-    embedder = SentenceTransformerEmbeddings(model="all-MiniLM-L6-v2")
+    embedder = load_sentence_transformer_with_retry("all-MiniLM-L6-v2")
     yield embedder
 
 


### PR DESCRIPTION
# Description

This pull request improves the reliability of end-to-end (E2E) tests that depend on downloading embedding models from Hugging Face, which can be subject to rate limits and transient failures. The main enhancement is the introduction of retry logic with exponential backoff when loading sentence transformer models, reducing flakiness in CI environments. The retry logic is encapsulated in a helper function and applied across multiple E2E test modules.

* Added a `load_sentence_transformer_with_retry` helper function in `tests/e2e/conftest.py` that wraps model loading with retry logic using exponential backoff, handling Hugging Face rate limits gracefully.
* Updated E2E test fixtures in `test_pinecone_e2e.py`, `test_qdrant_e2e.py`, and `test_weaviate_e2e.py` to use the new retry-enabled loader instead of direct instantiation, ensuring consistent retry behavior across all relevant tests. 


## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: low

## How Has This Been Tested?
- [ ] Unit tests
- [x] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] Unit tests have been updated
- [x] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [x] CHANGELOG.md updated if appropriate
