### PR TITLE
feat(scripts): model what each example under examples/ requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,9 @@ packages = ["src/neo4j_graphrag"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+# scripts/ is not a package and is not installed. Put it on the path under the
+# same top-level module names mypy already resolves it under.
+pythonpath = ["scripts"]
 filterwarnings = [
     "",
 ]

--- a/scripts/example_requirements.py
+++ b/scripts/example_requirements.py
@@ -1,0 +1,523 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""What each file under ``examples/`` needs in order to run.
+
+One source of truth for the tooling around the examples: what to report as
+missing, what to install, and what is safe to run.
+
+Requirements come from three places, in decreasing order of how well they can be
+inferred:
+
+1. **Packages.** An example rarely imports a provider SDK directly - it imports
+   ``OpenAILLM`` from ``neo4j_graphrag.llm`` and the SDK dependency hides behind
+   that. So the import scan maps *library symbols* to extras, not just top-level
+   modules, via :data:`SYMBOL_EXTRAS`.
+2. **Env vars and datastores.** Read out of the source: ``os.getenv`` calls, and
+   connection URIs appearing as string literals.
+3. **Everything else** - APOC, a pre-existing index, outbound internet - leaves
+   no reliable trace in the source, so it is declared per path in
+   :data:`SERVICE_RULES`.
+
+Nothing here imports a third-party package: it must run before ``uv sync``.
+"""
+
+from __future__ import annotations
+
+import ast
+import fnmatch
+import re
+import sys
+from functools import cache
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EXAMPLES_DIR = REPO_ROOT / "examples"
+
+# --------------------------------------------------------------------------
+# Providers
+# --------------------------------------------------------------------------
+
+# neo4j_graphrag symbols whose use implies an optional dependency. Keyed by the
+# symbol as an example would import it; the value is the pyproject extra.
+SYMBOL_EXTRAS: dict[str, str] = {
+    # LLMs
+    "OpenAILLM": "openai",
+    "AzureOpenAILLM": "openai",
+    "AnthropicLLM": "anthropic",
+    "BedrockLLM": "bedrock",
+    "CohereLLM": "cohere",
+    "GeminiLLM": "google-genai",
+    "MistralAILLM": "mistralai",
+    "OllamaLLM": "ollama",
+    "VertexAILLM": "google",
+    # Embedders
+    "OpenAIEmbeddings": "openai",
+    "AzureOpenAIEmbeddings": "openai",
+    "BedrockEmbeddings": "bedrock",
+    "CohereEmbeddings": "cohere",
+    "GeminiEmbedder": "google-genai",
+    "MistralAIEmbeddings": "mistralai",
+    "OllamaEmbeddings": "ollama",
+    "VertexAIEmbeddings": "google",
+    "SentenceTransformerEmbeddings": "sentence-transformers",
+    # External retrievers
+    "WeaviateNeo4jRetriever": "weaviate",
+    "PineconeNeo4jRetriever": "pinecone",
+    "QdrantNeo4jRetriever": "qdrant",
+    # Components with optional backends
+    "SpaCySemanticMatchResolver": "nlp",
+    "FuzzyMatchResolver": "fuzzy-matching",
+}
+
+# The provider each symbol talks to. Distinct from the extra because one extra
+# can front two services (``openai`` covers both OpenAI and Azure OpenAI) and
+# one provider can need two extras.
+SYMBOL_PROVIDERS: dict[str, str] = {
+    "OpenAILLM": "openai",
+    "OpenAIEmbeddings": "openai",
+    "AzureOpenAILLM": "azure",
+    "AzureOpenAIEmbeddings": "azure",
+    "AnthropicLLM": "anthropic",
+    "BedrockLLM": "bedrock",
+    "BedrockEmbeddings": "bedrock",
+    "CohereLLM": "cohere",
+    "CohereEmbeddings": "cohere",
+    "GeminiLLM": "gemini",
+    "GeminiEmbedder": "gemini",
+    "MistralAILLM": "mistral",
+    "MistralAIEmbeddings": "mistral",
+    "OllamaLLM": "ollama",
+    "OllamaEmbeddings": "ollama",
+    "VertexAILLM": "vertexai",
+    "VertexAIEmbeddings": "vertexai",
+    "SentenceTransformerEmbeddings": "sentence-transformers",
+    "WeaviateNeo4jRetriever": "weaviate",
+    "PineconeNeo4jRetriever": "pinecone",
+    "QdrantNeo4jRetriever": "qdrant",
+    "SpaCySemanticMatchResolver": "spacy",
+    "FuzzyMatchResolver": "rapidfuzz",
+}
+
+# Third-party modules an example may import directly, mapped to their extra.
+MODULE_EXTRAS: dict[str, str] = {
+    "openai": "openai",
+    "anthropic": "anthropic",
+    "boto3": "bedrock",
+    "botocore": "bedrock",
+    "cohere": "cohere",
+    "mistralai": "mistralai",
+    "ollama": "ollama",
+    "google": "google-genai",
+    "vertexai": "google",
+    "weaviate": "weaviate",
+    "pinecone": "pinecone",
+    "qdrant_client": "qdrant",
+    "sentence_transformers": "sentence-transformers",
+    "spacy": "nlp",
+    "rapidfuzz": "fuzzy-matching",
+    "neo4j_viz": "kg_creation_tools",
+    "langchain_openai": "examples",
+    "langchain_huggingface": "examples",
+    "langchain_text_splitters": "experimental",
+    "llama_index": "experimental",
+    "pyarrow": "experimental",
+    "litellm": "litellm",
+    "dotenv": "examples",
+    "requests": "examples",
+}
+
+# Providers reached by importing the module directly rather than via a symbol.
+MODULE_PROVIDERS: dict[str, str] = {
+    "vertexai": "vertexai",
+    "weaviate": "weaviate",
+    "pinecone": "pinecone",
+    "qdrant_client": "qdrant",
+    "sentence_transformers": "sentence-transformers",
+    "spacy": "spacy",
+    "langchain_openai": "openai",
+    "langchain_huggingface": "sentence-transformers",
+}
+
+# The library itself, plus the import names of its core dependencies in
+# pyproject.toml. Present in any environment that has neo4j-graphrag at all, so
+# never worth an install hint.
+ALWAYS_INSTALLED = {
+    "neo4j_graphrag",
+    "neo4j",
+    "pydantic",
+    "fsspec",
+    "pypdf",
+    "json_repair",
+    "yaml",
+    "numpy",
+    "scipy",
+    "tenacity",
+}
+
+# --------------------------------------------------------------------------
+# Services
+# --------------------------------------------------------------------------
+
+NEO4J_LOCAL = "neo4j-local"
+NEO4J_DEMO = "neo4j-demo"
+APOC = "apoc"
+INTERNET = "internet"
+OLLAMA_SERVER = "ollama-server"
+WEAVIATE_SERVER = "weaviate-server"
+QDRANT_SERVER = "qdrant-server"
+PINECONE_SERVER = "pinecone-server"
+
+SERVICE_LABELS: dict[str, str] = {
+    NEO4J_LOCAL: "local Neo4j on bolt://localhost:7687",
+    NEO4J_DEMO: "the demo.neo4jlabs.com recommendations database",
+    APOC: "the APOC plugin in the local Neo4j",
+    INTERNET: "outbound internet access",
+    OLLAMA_SERVER: "a running Ollama server on :11434",
+    WEAVIATE_SERVER: "a running Weaviate on :8080",
+    QDRANT_SERVER: "a running Qdrant on :6333",
+    PINECONE_SERVER: "a running Pinecone (or Pinecone Local on :5080)",
+}
+
+# Requirements that leave no reliable trace in the source. Keyed by a glob
+# relative to examples/; every matching glob contributes.
+#
+# `indexes` names a Neo4j index the example expects to already exist. `extras`,
+# `providers` and `env_vars` add to what the import scan found, for examples whose
+# real dependencies live in a config file rather than in their imports.
+#
+# Keep this to what an example *needs*, not to what is wrong with it: known defects
+# belong in examples/SETUP.md, where they can be read without running anything.
+SERVICE_RULES: list[tuple[str, dict[str, object]]] = [
+    ("kg_builder.py", {"services": [APOC]}),
+    ("build_graph/**", {"services": [APOC]}),
+    ("customize/build_graph/pipeline/kg_builder_*.py", {"services": [APOC]}),
+    (
+        "customize/build_graph/pipeline/text_to_lexical_graph_to_entity_graph_*.py",
+        {"services": [APOC]},
+    ),
+    (
+        "build_graph/from_config_files/simple_kg_pipeline_from_config_file_with_url.py",
+        {"services": [INTERNET]},
+    ),
+    (
+        "customize/build_graph/components/loaders/pdf_loader_from_url.py",
+        {"services": [INTERNET]},
+    ),
+    ("retrieve/tools/tools_retriever_example.py", {"services": [INTERNET]}),
+    ("retrieve/similarity_search_for_*.py", {"indexes": ["moviePlotsEmbedding"]}),
+    ("retrieve/vector_cypher_retriever.py", {"indexes": ["moviePlotsEmbedding"]}),
+    ("retrieve/hybrid_*.py", {"indexes": ["moviePlotsEmbedding", "movieFulltext"]}),
+    (
+        "customize/retrievers/result_formatter_*.py",
+        {"indexes": ["moviePlotsEmbedding"]},
+    ),
+    ("customize/retrievers/use_pre_filters.py", {"indexes": ["moviePlotsEmbedding"]}),
+    ("customize/answer/custom_prompt.py", {"indexes": ["moviePlotsEmbedding"]}),
+    (
+        "customize/answer/langchain_compatiblity.py",
+        {"indexes": ["moviePlotsEmbedding"]},
+    ),
+    ("customize/retrievers/external/weaviate/*.py", {"services": [WEAVIATE_SERVER]}),
+    ("customize/retrievers/external/qdrant/*.py", {"services": [QDRANT_SERVER]}),
+    ("customize/retrievers/external/pinecone/*.py", {"services": [PINECONE_SERVER]}),
+    (
+        "build_graph/from_config_files/simple_kg_pipeline_from_config_file*.py",
+        {"extras": ["openai"], "providers": ["openai"], "env_vars": ["OPENAI_API_KEY"]},
+    ),
+    (
+        "customize/build_graph/pipeline/from_config_files/pipeline_from_config_file.py",
+        {"extras": ["openai"], "providers": ["openai"], "env_vars": ["OPENAI_API_KEY"]},
+    ),
+]
+
+_LOCAL_URI = re.compile(r"^(bolt|neo4j)(\+s|\+ssc)?://(localhost|127\.0\.0\.1)")
+_DEMO_HOST = "demo.neo4jlabs.com"
+
+
+@dataclass
+class ExampleRequirements:
+    """Everything needed to run one example file."""
+
+    path: Path
+    extras: set[str] = field(default_factory=set)
+    providers: set[str] = field(default_factory=set)
+    modules: set[str] = field(default_factory=set)
+    env_vars: set[str] = field(default_factory=set)
+    services: set[str] = field(default_factory=set)
+    indexes: set[str] = field(default_factory=set)
+    notes: list[str] = field(default_factory=list)
+    runnable: bool = True
+    # Sibling modules under examples/data/ that are importable only if that
+    # directory is on sys.path.
+    sibling_modules: set[str] = field(default_factory=set)
+
+    @property
+    def rel(self) -> str:
+        return str(self.path.relative_to(REPO_ROOT))
+
+    def install_hints(self) -> list[str]:
+        """Packages this example needs that no extra provides."""
+        return sorted(
+            module
+            for module in self.modules
+            if module not in MODULE_EXTRAS and module not in ALWAYS_INSTALLED
+        )
+
+
+def iter_example_files() -> list[Path]:
+    return sorted(p for p in EXAMPLES_DIR.rglob("*.py") if "__pycache__" not in p.parts)
+
+
+def _imported_names(tree: ast.Module) -> tuple[set[str], set[str]]:
+    """Return (top-level modules imported, symbols imported by name)."""
+    modules: set[str] = set()
+    symbols: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                modules.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:  # relative import, never a third-party package
+                continue
+            if node.module:
+                modules.add(node.module.split(".")[0])
+            for alias in node.names:
+                symbols.add(alias.name)
+    return modules, symbols
+
+
+def _env_vars(tree: ast.Module) -> set[str]:
+    """Env var names read via os.getenv / os.environ."""
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            name = _dotted(node.func)
+            if name in {"os.getenv", "os.environ.get", "environ.get", "getenv"}:
+                if node.args and isinstance(node.args[0], ast.Constant):
+                    if isinstance(node.args[0].value, str):
+                        found.add(node.args[0].value)
+        elif isinstance(node, ast.Subscript):
+            if _dotted(node.value) in {"os.environ", "environ"}:
+                if isinstance(node.slice, ast.Constant) and isinstance(
+                    node.slice.value, str
+                ):
+                    found.add(node.slice.value)
+    return found
+
+
+def _dotted(node: ast.AST) -> str:
+    """Render an attribute chain as ``a.b.c``, or "" if it is not one."""
+    parts: list[str] = []
+    current: ast.AST = node
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if isinstance(current, ast.Name):
+        parts.append(current.id)
+        return ".".join(reversed(parts))
+    return ""
+
+
+def _string_constants(tree: ast.Module) -> list[str]:
+    return [
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    ]
+
+
+def _is_main_guard(node: ast.stmt) -> bool:
+    if not isinstance(node, ast.If):
+        return False
+    return any(
+        isinstance(child, ast.Constant) and child.value == "__main__"
+        for child in ast.walk(node.test)
+    )
+
+
+def _is_runnable(tree: ast.Module) -> bool:
+    """Whether the file does something when executed.
+
+    Many examples under ``customize/`` are illustrative snippets - a class or a
+    function and nothing else. Running them is a no-op, so the doctor should not
+    report them as blocked on credentials they never use.
+
+    Note that plenty of examples have no ``__main__`` guard and simply run at
+    module level, several of them inside a top-level ``with`` block, so the guard
+    alone is not the test.
+    """
+    for node in tree.body:
+        if _is_main_guard(node):
+            return True
+        if isinstance(node, (ast.With, ast.AsyncWith, ast.For, ast.While, ast.Try)):
+            return True
+        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
+            return True
+        # A module-level `llm = OpenAILLM(...)` builds a client on import, and
+        # `res = llm.invoke(...)` calls out. Both count as running.
+        if isinstance(node, (ast.Assign, ast.AnnAssign)) and isinstance(
+            node.value, ast.Call
+        ):
+            return True
+    return False
+
+
+def _sibling_modules(modules: set[str]) -> set[str]:
+    """Imports that resolve only against examples/data/.
+
+    A few examples do ``from embedding_avatar import ...``, which fails from the
+    repo root because that module lives in examples/data/ rather than beside the
+    example. Detected rather than listed, so a new one is caught for free.
+    """
+    data_dir = EXAMPLES_DIR / "data"
+    return {name for name in modules if (data_dir / f"{name}.py").exists()}
+
+
+def _uses_mock_driver(modules: set[str], symbols: set[str]) -> bool:
+    return "MagicMock" in symbols or "unittest" in modules
+
+
+def _datastore_services(
+    literals: list[str], env_vars: set[str], mocked: bool
+) -> set[str]:
+    if mocked:
+        return set()
+    services: set[str] = set()
+    if any(_DEMO_HOST in value for value in literals):
+        services.add(NEO4J_DEMO)
+    if any(_LOCAL_URI.match(value) for value in literals):
+        services.add(NEO4J_LOCAL)
+    # Driven entirely by NEO4J_URI, which every template points at localhost.
+    if not services and "NEO4J_URI" in env_vars:
+        services.add(NEO4J_LOCAL)
+    return services
+
+
+def _apply_rules(path: Path, requirements: ExampleRequirements) -> None:
+    rel = path.relative_to(EXAMPLES_DIR).as_posix()
+    for pattern, spec in SERVICE_RULES:
+        if not fnmatch.fnmatch(rel, pattern):
+            continue
+        for key, target in (
+            ("services", requirements.services),
+            ("indexes", requirements.indexes),
+            ("extras", requirements.extras),
+            ("providers", requirements.providers),
+            ("env_vars", requirements.env_vars),
+        ):
+            values = spec.get(key)
+            if isinstance(values, list):
+                target.update(str(v) for v in values)
+
+
+def analyse(path: Path) -> ExampleRequirements:
+    """Work out what one example needs. Never raises on a broken file."""
+    requirements = ExampleRequirements(path=path)
+    source = path.read_text()
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        requirements.runnable = False
+        requirements.notes.append("does not parse")
+        return requirements
+
+    modules, symbols = _imported_names(tree)
+    requirements.sibling_modules = _sibling_modules(modules)
+    # Everything the example imports that it will not already have. Narrowing this
+    # to the modules we happen to know about would hide the interesting case: a
+    # third-party import that no extra declares, which is exactly what
+    # install_hints() exists to report.
+    requirements.modules = {
+        m
+        for m in modules
+        if m not in sys.stdlib_module_names
+        and m not in ALWAYS_INSTALLED
+        and m not in requirements.sibling_modules
+    }
+
+    for symbol in symbols:
+        if symbol in SYMBOL_EXTRAS:
+            requirements.extras.add(SYMBOL_EXTRAS[symbol])
+        if symbol in SYMBOL_PROVIDERS:
+            requirements.providers.add(SYMBOL_PROVIDERS[symbol])
+    for module in modules:
+        if module in MODULE_EXTRAS:
+            requirements.extras.add(MODULE_EXTRAS[module])
+        if module in MODULE_PROVIDERS:
+            requirements.providers.add(MODULE_PROVIDERS[module])
+
+    requirements.env_vars = _env_vars(tree)
+    requirements.runnable = _is_runnable(tree)
+    requirements.sibling_modules = _sibling_modules(modules)
+
+    literals = _string_constants(tree)
+    mocked = _uses_mock_driver(modules, symbols)
+    requirements.services = _datastore_services(literals, requirements.env_vars, mocked)
+    if "ollama" in requirements.providers:
+        requirements.services.add(OLLAMA_SERVER)
+
+    _apply_rules(path, requirements)
+
+    # APOC and an index are only meaningful alongside a database.
+    if not requirements.services & {NEO4J_LOCAL, NEO4J_DEMO}:
+        requirements.services.discard(APOC)
+    return requirements
+
+
+def analyse_all() -> list[ExampleRequirements]:
+    return [analyse(path) for path in iter_example_files()]
+
+
+# --------------------------------------------------------------------------
+# Availability probes
+# --------------------------------------------------------------------------
+
+# host, port for each service that listens on one.
+SERVICE_ENDPOINTS: dict[str, tuple[str, int]] = {
+    NEO4J_LOCAL: ("localhost", 7687),
+    OLLAMA_SERVER: ("localhost", 11434),
+    WEAVIATE_SERVER: ("localhost", 8080),
+    QDRANT_SERVER: ("localhost", 6333),
+    PINECONE_SERVER: ("localhost", 5080),
+}
+
+
+def port_open(host: str, port: int, timeout: float = 1.0) -> bool:
+    import socket
+
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+@cache
+def service_available(service: str) -> bool:
+    """Cheap liveness probe, memoised for the life of the process.
+
+    APOC and index requirements are not probed here - they need an authenticated
+    session, so the doctor checks them separately once it has a driver. Treating
+    them as available keeps a caller from skipping on something it never tested.
+    """
+    if service == NEO4J_DEMO:
+        return port_open("demo.neo4jlabs.com", 7687, timeout=3.0)
+    if service == INTERNET:
+        return port_open("raw.githubusercontent.com", 443, timeout=3.0)
+    if service in SERVICE_ENDPOINTS:
+        host, port = SERVICE_ENDPOINTS[service]
+        return port_open(host, port)
+    return True

--- a/scripts/example_requirements.py
+++ b/scripts/example_requirements.py
@@ -42,6 +42,7 @@ import sys
 from functools import cache
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TypedDict
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 EXAMPLES_DIR = REPO_ROOT / "examples"
@@ -191,6 +192,7 @@ SERVICE_LABELS: dict[str, str] = {
     PINECONE_SERVER: "a running Pinecone (or Pinecone Local on :5080)",
 }
 
+
 # Requirements that leave no reliable trace in the source. Keyed by a glob
 # relative to examples/; every matching glob contributes.
 #
@@ -200,7 +202,19 @@ SERVICE_LABELS: dict[str, str] = {
 #
 # Keep this to what an example *needs*, not to what is wrong with it: known defects
 # belong in examples/SETUP.md, where they can be read without running anything.
-SERVICE_RULES: list[tuple[str, dict[str, object]]] = [
+class RuleSpec(TypedDict, total=False):
+    """What a rule may declare. Typed so mypy rejects the two ways a rule can
+    silently do nothing: a mistyped key, and a bare string where a list belongs.
+    """
+
+    services: list[str]
+    indexes: list[str]
+    extras: list[str]
+    providers: list[str]
+    env_vars: list[str]
+
+
+SERVICE_RULES: list[tuple[str, RuleSpec]] = [
     ("kg_builder.py", {"services": [APOC]}),
     ("build_graph/**", {"services": [APOC]}),
     ("customize/build_graph/pipeline/kg_builder_*.py", {"services": [APOC]}),
@@ -407,26 +421,26 @@ def _datastore_services(
 
 
 def _apply_rules(path: Path, requirements: ExampleRequirements) -> None:
+    if EXAMPLES_DIR not in path.parents:
+        # Nothing outside examples/ can match a rule, and analyse() promises not
+        # to raise. Returning here is also what lets analyse() be tested against
+        # a synthetic file rather than only against the real corpus.
+        return
     rel = path.relative_to(EXAMPLES_DIR).as_posix()
     for pattern, spec in SERVICE_RULES:
         if not fnmatch.fnmatch(rel, pattern):
             continue
-        for key, target in (
-            ("services", requirements.services),
-            ("indexes", requirements.indexes),
-            ("extras", requirements.extras),
-            ("providers", requirements.providers),
-            ("env_vars", requirements.env_vars),
-        ):
-            values = spec.get(key)
-            if isinstance(values, list):
-                target.update(str(v) for v in values)
+        requirements.services.update(spec.get("services", ()))
+        requirements.indexes.update(spec.get("indexes", ()))
+        requirements.extras.update(spec.get("extras", ()))
+        requirements.providers.update(spec.get("providers", ()))
+        requirements.env_vars.update(spec.get("env_vars", ()))
 
 
 def analyse(path: Path) -> ExampleRequirements:
     """Work out what one example needs. Never raises on a broken file."""
     requirements = ExampleRequirements(path=path)
-    source = path.read_text()
+    source = path.read_text(encoding="utf-8")
     try:
         tree = ast.parse(source, filename=str(path))
     except SyntaxError:
@@ -461,7 +475,6 @@ def analyse(path: Path) -> ExampleRequirements:
 
     requirements.env_vars = _env_vars(tree)
     requirements.runnable = _is_runnable(tree)
-    requirements.sibling_modules = _sibling_modules(modules)
 
     literals = _string_constants(tree)
     mocked = _uses_mock_driver(modules, symbols)
@@ -496,6 +509,9 @@ SERVICE_ENDPOINTS: dict[str, tuple[str, int]] = {
 
 
 def port_open(host: str, port: int, timeout: float = 1.0) -> bool:
+    # Imported here rather than at module scope: everything above this point is
+    # pure static analysis, and a caller that only wants that should not pay for
+    # the networking stack.
     import socket
 
     try:

--- a/tests/unit/scripts/__init__.py
+++ b/tests/unit/scripts/__init__.py
@@ -1,0 +1,14 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/tests/unit/scripts/test_example_requirements.py
+++ b/tests/unit/scripts/test_example_requirements.py
@@ -1,0 +1,205 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for the model of what each example needs.
+
+The scan is pure AST work over files already in the repository, so nothing here
+touches the network or a service.
+"""
+
+from __future__ import annotations
+
+import ast
+
+import example_requirements as reqs
+import pytest
+
+
+def analyse_rel(rel: str) -> reqs.ExampleRequirements:
+    return reqs.analyse(reqs.EXAMPLES_DIR / rel)
+
+
+# ---------------------------------------------------------------------------
+# Requirements declared in a config file rather than in the imports
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "rel",
+    [
+        "build_graph/from_config_files/simple_kg_pipeline_from_config_file.py",
+        "build_graph/from_config_files/simple_kg_pipeline_from_config_file_with_url.py",
+        "customize/build_graph/pipeline/from_config_files/pipeline_from_config_file.py",
+    ],
+)
+def test_config_file_examples_still_need_openai(rel: str) -> None:
+    """Their LLM is named in YAML/JSON, which the import scan cannot see.
+
+    Regression: these three were reported as needing nothing at all, so the
+    doctor counted them runnable with no key and no openai extra.
+    """
+    requirement = analyse_rel(rel)
+    assert "openai" in requirement.extras
+    assert "openai" in requirement.providers
+    assert "OPENAI_API_KEY" in requirement.env_vars
+
+
+# ---------------------------------------------------------------------------
+# Packages no extra provides
+# ---------------------------------------------------------------------------
+
+
+def test_install_hints_reports_a_package_behind_no_extra() -> None:
+    """Regression: install_hints() could only ever return [].
+
+    analyse() narrowed modules to the ones already known, which is precisely the
+    set install_hints() then filtered back out.
+    """
+    hinted = {
+        module
+        for requirement in reqs.analyse_all()
+        for module in requirement.install_hints()
+    }
+    assert hinted == set(), (
+        f"examples import packages no extra declares: {sorted(hinted)}. "
+        "Declare them in pyproject.toml, or map them in MODULE_EXTRAS."
+    )
+
+
+def test_install_hints_names_the_distribution_not_the_import() -> None:
+    requirement = reqs.ExampleRequirements(
+        path=reqs.EXAMPLES_DIR / "fake.py", modules={"cv2"}
+    )
+    assert requirement.install_hints() == ["cv2"]
+
+
+def test_core_dependencies_are_never_hinted() -> None:
+    """pydantic and friends ship with the library itself."""
+    requirement = reqs.ExampleRequirements(
+        path=reqs.EXAMPLES_DIR / "fake.py",
+        modules={m for m in reqs.ALWAYS_INSTALLED},
+    )
+    assert requirement.install_hints() == []
+
+
+# ---------------------------------------------------------------------------
+# The import scan
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "source,expected_module,expected_symbol",
+    [
+        ("import openai", "openai", None),
+        ("import openai as oai", "openai", None),
+        ("from openai import OpenAI", "openai", "OpenAI"),
+        ("from neo4j_graphrag.llm import OpenAILLM", "neo4j_graphrag", "OpenAILLM"),
+        (
+            "from neo4j_graphrag.llm import OpenAILLM as LLM",
+            "neo4j_graphrag",
+            "OpenAILLM",
+        ),
+        ("def f():\n    import cohere", "cohere", None),
+        ("if True:\n    import cohere", "cohere", None),
+    ],
+)
+def test_imported_names(
+    source: str, expected_module: str, expected_symbol: str | None
+) -> None:
+    modules, symbols = reqs._imported_names(ast.parse(source))
+    assert expected_module in modules
+    if expected_symbol is not None:
+        assert expected_symbol in symbols
+
+
+def test_relative_imports_are_not_third_party() -> None:
+    modules, _ = reqs._imported_names(ast.parse("from .thing import Thing"))
+    assert modules == set()
+
+
+def test_an_aliased_symbol_still_maps_to_its_extra() -> None:
+    """The extra follows the real name, not what the example called it."""
+    requirement = reqs.ExampleRequirements(path=reqs.EXAMPLES_DIR / "fake.py")
+    _, symbols = reqs._imported_names(
+        ast.parse("from neo4j_graphrag.llm import OpenAILLM as LLM")
+    )
+    assert "OpenAILLM" in symbols
+    assert reqs.SYMBOL_EXTRAS["OpenAILLM"] == "openai"
+    assert requirement.extras == set()
+
+
+# ---------------------------------------------------------------------------
+# Env vars and services
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "source,expected",
+    [
+        ('os.getenv("OPENAI_API_KEY")', {"OPENAI_API_KEY"}),
+        ('os.environ["NEO4J_URI"]', {"NEO4J_URI"}),
+        ('os.environ.get("COHERE_API_KEY")', {"COHERE_API_KEY"}),
+        ("os.getenv(name)", set()),
+    ],
+)
+def test_env_vars(source: str, expected: set[str]) -> None:
+    assert reqs._env_vars(ast.parse(source)) == expected
+
+
+def test_a_local_uri_means_a_local_neo4j() -> None:
+    services = reqs._datastore_services(["bolt://localhost:7687"], set(), mocked=False)
+    assert reqs.NEO4J_LOCAL in services
+
+
+def test_the_demo_host_means_the_demo_database() -> None:
+    services = reqs._datastore_services(
+        [f"neo4j+s://{reqs._DEMO_HOST}"], set(), mocked=False
+    )
+    assert reqs.NEO4J_DEMO in services
+
+
+def test_a_mocked_driver_needs_no_service() -> None:
+    assert (
+        reqs._datastore_services(["bolt://localhost:7687"], set(), mocked=True) == set()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Whole-corpus invariants
+# ---------------------------------------------------------------------------
+
+
+def test_every_example_is_analysable() -> None:
+    """analyse() promises never to raise on a file in examples/."""
+    unparsed = [
+        r.rel
+        for r in reqs.analyse_all()
+        if not r.runnable and "does not parse" in r.notes
+    ]
+    assert unparsed == []
+
+
+def test_service_rule_globs_all_match_something() -> None:
+    """A glob that matches nothing is a rule silently doing nothing."""
+    paths = [
+        p.relative_to(reqs.EXAMPLES_DIR).as_posix() for p in reqs.iter_example_files()
+    ]
+    import fnmatch
+
+    unmatched = [
+        pattern
+        for pattern, _ in reqs.SERVICE_RULES
+        if not any(fnmatch.fnmatch(path, pattern) for path in paths)
+    ]
+    assert unmatched == []

--- a/tests/unit/scripts/test_example_requirements.py
+++ b/tests/unit/scripts/test_example_requirements.py
@@ -21,6 +21,9 @@ touches the network or a service.
 from __future__ import annotations
 
 import ast
+import fnmatch
+import tempfile
+from pathlib import Path
 
 import example_requirements as reqs
 import pytest
@@ -60,12 +63,33 @@ def test_config_file_examples_still_need_openai(rel: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_install_hints_reports_a_package_behind_no_extra() -> None:
+def analyse_source(source: str) -> reqs.ExampleRequirements:
+    """Run the real analyse() over a synthetic file.
+
+    Exercising the whole pipeline rather than hand-building an
+    ExampleRequirements is the point: a hand-built object cannot tell you whether
+    analyse() populated it correctly.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "synthetic_example.py"
+        path.write_text(source, encoding="utf-8")
+        return reqs.analyse(path)
+
+
+def test_analyse_keeps_a_package_that_no_extra_declares() -> None:
     """Regression: install_hints() could only ever return [].
 
     analyse() narrowed modules to the ones already known, which is precisely the
-    set install_hints() then filtered back out.
+    set install_hints() then filters back out - so asserting the corpus reports
+    nothing passes either way. This pins the fixed behaviour directly.
     """
+    requirement = analyse_source("import cv2\n")
+    assert "cv2" in requirement.modules
+    assert requirement.install_hints() == ["cv2"]
+
+
+def test_no_example_imports_a_package_nothing_declares() -> None:
+    """The corpus invariant, now that the mechanism above is pinned separately."""
     hinted = {
         module
         for requirement in reqs.analyse_all()
@@ -77,7 +101,7 @@ def test_install_hints_reports_a_package_behind_no_extra() -> None:
     )
 
 
-def test_install_hints_names_the_distribution_not_the_import() -> None:
+def test_install_hints_reports_the_import_name() -> None:
     requirement = reqs.ExampleRequirements(
         path=reqs.EXAMPLES_DIR / "fake.py", modules={"cv2"}
     )
@@ -130,13 +154,9 @@ def test_relative_imports_are_not_third_party() -> None:
 
 def test_an_aliased_symbol_still_maps_to_its_extra() -> None:
     """The extra follows the real name, not what the example called it."""
-    requirement = reqs.ExampleRequirements(path=reqs.EXAMPLES_DIR / "fake.py")
-    _, symbols = reqs._imported_names(
-        ast.parse("from neo4j_graphrag.llm import OpenAILLM as LLM")
-    )
-    assert "OpenAILLM" in symbols
-    assert reqs.SYMBOL_EXTRAS["OpenAILLM"] == "openai"
-    assert requirement.extras == set()
+    requirement = analyse_source("from neo4j_graphrag.llm import OpenAILLM as LLM\n")
+    assert requirement.extras == {"openai"}
+    assert requirement.providers == {"openai"}
 
 
 # ---------------------------------------------------------------------------
@@ -195,11 +215,85 @@ def test_service_rule_globs_all_match_something() -> None:
     paths = [
         p.relative_to(reqs.EXAMPLES_DIR).as_posix() for p in reqs.iter_example_files()
     ]
-    import fnmatch
-
     unmatched = [
         pattern
         for pattern, _ in reqs.SERVICE_RULES
         if not any(fnmatch.fnmatch(path, pattern) for path in paths)
     ]
     assert unmatched == []
+
+
+# ---------------------------------------------------------------------------
+# Table invariants
+#
+# Each of these is one line, and each closes a way for a half-finished edit to
+# produce a plausible wrong answer instead of an error.
+# ---------------------------------------------------------------------------
+
+
+def test_every_symbol_maps_to_both_an_extra_and_a_provider() -> None:
+    """The two tables are halves of one fact and must stay in step.
+
+    Their *values* legitimately differ - AzureOpenAILLM needs the `openai` extra
+    but talks to the `azure` provider - so they cannot be merged. Their keys
+    cannot differ: a symbol in one but not the other means the doctor either
+    installs a package it never asks for a key for, or the reverse.
+    """
+    assert set(reqs.SYMBOL_EXTRAS) == set(reqs.SYMBOL_PROVIDERS)
+
+
+def test_every_module_provider_also_declares_an_extra() -> None:
+    """Subset, not equality: most modules imply an extra without implying a
+    provider, but a module that reaches a provider must also install something.
+    """
+    assert set(reqs.MODULE_PROVIDERS) <= set(reqs.MODULE_EXTRAS)
+
+
+def test_every_service_an_example_needs_has_a_label() -> None:
+    """service_available() returns True for anything it cannot probe, so a
+    typo'd service name would silently report as satisfied.
+    """
+    seen = {s for r in reqs.analyse_all() for s in r.services}
+    assert seen <= set(reqs.SERVICE_LABELS)
+
+
+# How many files each rule is expected to match. A bare "matches something"
+# assertion only protects the rules that match exactly one file; renaming one of
+# several matches leaves the pattern non-empty and the requirement silently lost.
+# Pinning the count also catches the opposite error - a glob widened until it
+# sweeps in a file that does not want the requirement.
+#
+# Update deliberately when examples/ gains or loses a file: that is exactly the
+# moment to confirm the rule still applies to what it now matches.
+EXPECTED_RULE_MATCHES = {
+    "kg_builder.py": 1,
+    "build_graph/**": 6,
+    "customize/build_graph/pipeline/kg_builder_*.py": 3,
+    "customize/build_graph/pipeline/text_to_lexical_graph_to_entity_graph_*.py": 2,
+    "build_graph/from_config_files/simple_kg_pipeline_from_config_file_with_url.py": 1,
+    "customize/build_graph/components/loaders/pdf_loader_from_url.py": 1,
+    "retrieve/tools/tools_retriever_example.py": 1,
+    "retrieve/similarity_search_for_*.py": 2,
+    "retrieve/vector_cypher_retriever.py": 1,
+    "retrieve/hybrid_*.py": 2,
+    "customize/retrievers/result_formatter_*.py": 2,
+    "customize/retrievers/use_pre_filters.py": 1,
+    "customize/answer/custom_prompt.py": 1,
+    "customize/answer/langchain_compatiblity.py": 1,
+    "customize/retrievers/external/weaviate/*.py": 3,
+    "customize/retrievers/external/qdrant/*.py": 3,
+    "customize/retrievers/external/pinecone/*.py": 2,
+    "build_graph/from_config_files/simple_kg_pipeline_from_config_file*.py": 2,
+    "customize/build_graph/pipeline/from_config_files/pipeline_from_config_file.py": 1,
+}
+
+
+def test_service_rules_match_the_files_they_are_meant_to() -> None:
+    paths = [
+        p.relative_to(reqs.EXAMPLES_DIR).as_posix() for p in reqs.iter_example_files()
+    ]
+    actual = {
+        pattern: sum(1 for path in paths if fnmatch.fnmatch(path, pattern))
+        for pattern, _ in reqs.SERVICE_RULES
+    }
+    assert actual == EXPECTED_RULE_MATCHES


### PR DESCRIPTION
First of four PRs. The order matches how the tools get used: **work out what each example needs (this) → report what is missing (#599) → walk through fixing it (#602) → run what the machine supports (#598)**.

Nothing knows what an example needs in order to run, so a contributor finds out by running it and reading the traceback. This adds one source of truth the rest of the tooling shares.

## Where requirements come from

- **Packages**, from an AST import scan that maps *library symbols* to extras. An example imports `OpenAILLM`, not `openai`, so the dependency is invisible from its imports alone. The substring scan this replaces treated any file containing the word "google" as a Vertex example and could not tell `OpenAIEmbeddings` from `AzureOpenAIEmbeddings`.
- **Env vars and datastores**, read from `os.getenv` calls and connection URIs in the source.
- **Everything else** — APOC, a pre-existing index, outbound internet, or a component named only in a YAML config — declared per path in `SERVICE_RULES`, because it leaves no trace in the source.

Stdlib-only by design: it has to run before `uv sync`, which is exactly when somebody most needs to be told what to install.

## Keeping the tables honest

The tables are hand-maintained, and a half-finished edit produced a plausible wrong answer rather than an error. Each of these is a one-line test:

- **`SYMBOL_EXTRAS` and `SYMBOL_PROVIDERS` are two halves of one fact.** Their values legitimately differ — `AzureOpenAILLM` needs the `openai` extra but talks to the `azure` provider — so they cannot be merged, but their keys must not drift. A symbol in one and not the other means the doctor installs a package it never asks for a key for, or the reverse.
- **Every service an example needs has a label.** `service_available()` returns `True` for anything it cannot probe, so a typo'd service name would otherwise report as satisfied.
- **`SERVICE_RULES` matches are pinned by count.** Asserting only that a pattern matches *something* protects the nine rules matching exactly one file; the other ten match several, so renaming one of them leaves the pattern non-empty and the requirement silently lost. The count also catches a glob widened until it sweeps in a file that does not want the requirement. Update it deliberately when `examples/` gains or loses a file — that is the moment to confirm the rule still applies.

`SERVICE_RULES` specs are a `TypedDict` rather than `dict[str, object]`. Read back through `spec.get()`, a mistyped key (`"service"`) or a scalar where a list belongs both silently did nothing. mypy already runs over `scripts/` in CI and now rejects both.

## The CI fixes have moved to #610

This PR previously carried two commits fixing a venv-cache failure in CI. At
reviewer request they are now #610, which is based directly on `main` and is
independent of this stack — so it can merge first and on its own.

## Scope

Deliberately just the model and its tests. The model has no consumer until #599 — which is what keeps this small enough to check by reading.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [x] Project configuration change

## Complexity

Complexity: Low

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [x] Manual tests

29 tests over the scan, the per-path rules and the table invariants. Each new invariant was confirmed to fail when the thing it guards is broken — dropping a symbol from one table, and simulating a rename against the rule counts — rather than merely passing today.

`scripts/` sits outside the coverage gate (`[tool.coverage.run] source = ["src"]`), so these tests are additive and cannot move the 90% number. They need one line of wiring, `pythonpath = ["scripts"]`.

# Checklist

- [ ] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
