### PR TITLE
feat(scripts): run the examples this machine is set up for

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,17 @@ repos:
           --allow-subclassing-any,
           --exclude='./docs/'
         ]
+      # Opt-in: actually runs the examples we have credentials for, against the
+      # live provider APIs. Costs money and hits the network, so it never fires
+      # on a commit, a push, or in CI. Run it deliberately, before a release or
+      # after touching the examples:
+      #   uv run pre-commit run --hook-stage manual examples-live
+      - id: examples-live
+        name: Examples Live Run (opt-in, costs money)
+        entry: uv run python scripts/check_examples.py --live
+        language: system
+        stages: [ manual ]
+        # Not file-driven: without always_run, pre-commit skips the hook whenever
+        # no matching file is staged, and the command above silently does nothing.
+        always_run: true
+        pass_filenames: false

--- a/scripts/check_examples.py
+++ b/scripts/check_examples.py
@@ -1,0 +1,554 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Static checks for the ``examples/`` directory.
+
+The examples are the project's shop window but no CI job exercises them, so
+model-reference drift lands in ``main`` unnoticed. A bulk model swap in #482
+left 15 call sites passing parameters their new model rejects, and the failures
+were deterministic - nobody had run them.
+
+This script catches that class of breakage offline: no API key, no network, no
+cost, fast enough for a pre-commit hook.
+
+    python scripts/check_examples.py            # static checks (default)
+    python scripts/check_examples.py --live     # additionally run what it can
+
+What it checks:
+
+1. Every example parses.
+2. LLM parameters are valid for the model, per provider. Providers disagree
+   about this - OpenAI reasoning models reject ``max_tokens`` while Anthropic
+   requires it - so the rules are per-family, not global.
+3. Referenced data files exist.
+
+Known limitation: rule 2 resolves a model only through a simple name binding
+(``llm = OpenAILLM(...)`` or ``with OpenAILLM(...) as llm``). A model reached
+any other way - returned from a helper, stored on an object, picked from a dict
+- is not attributed, and its ``invoke()`` kwargs go unchecked.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import example_requirements  # noqa: E402
+from examples_setup.doctor import blockers_for  # noqa: E402
+from examples_setup.envfile import apply_env_file, read_env_file  # noqa: E402
+from examples_setup.probes import probe_neo4j  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EXAMPLES_DIR = REPO_ROOT / "examples"
+
+# Reasoning models bill their internal reasoning against the completion budget.
+# Below roughly this many tokens the budget is consumed before any visible
+# output, and the response comes back empty with finish_reason="length".
+MIN_REASONING_BUDGET = 8000
+
+# Model-name prefixes whose families reject `max_tokens` and non-default
+# `temperature`. Extend as new reasoning families ship.
+REASONING_PREFIXES = ("gpt-5", "o1", "o3", "o4")
+
+# Constructors that speak to OpenAI, so the reasoning rules apply to them.
+OPENAI_CONSTRUCTORS = {"OpenAILLM", "AzureOpenAILLM"}
+
+# LangChain's chat wrapper. Distinct from the above because it *always* sends a
+# temperature (its own default, historically 0.7), so a reasoning model fails
+# even when the caller passes no temperature at all.
+LANGCHAIN_OPENAI_CONSTRUCTORS = {"ChatOpenAI"}
+
+# Non-OpenAI providers. Listed so the checker can tell "known and intentionally
+# unchecked" from "unrecognised", and as the place to hang per-provider rules.
+OTHER_PROVIDER_CONSTRUCTORS = {
+    "AnthropicLLM",  # max_tokens is required here - do not "fix" it
+    "BedrockLLM",  # camelCase maxTokens
+    "CohereLLM",
+    "GeminiLLM",
+    "MistralAILLM",
+    "OllamaLLM",  # params nest under "options"
+    "VertexAILLM",
+}
+
+ALL_LLM_CONSTRUCTORS = (
+    OPENAI_CONSTRUCTORS | LANGCHAIN_OPENAI_CONSTRUCTORS | OTHER_PROVIDER_CONSTRUCTORS
+)
+
+INVOKE_METHODS = {
+    "invoke",
+    "ainvoke",
+    "invoke_with_tools",
+    "ainvoke_with_tools",
+}
+
+DATA_SUFFIXES = (".pdf", ".txt", ".csv")
+
+
+@dataclass
+class Problem:
+    path: Path
+    line: int
+    message: str
+    fix: str
+
+    def render(self) -> str:
+        rel = self.path.relative_to(REPO_ROOT)
+        return f"{rel}:{self.line}: {self.message}\n    fix: {self.fix}"
+
+
+@dataclass
+class Binding:
+    """A name bound to an LLM constructor call."""
+
+    constructor: str
+    model: Optional[str]
+    params: dict[str, Any]
+    line: int
+
+
+@dataclass
+class FileReport:
+    path: Path
+    problems: list[Problem] = field(default_factory=list)
+
+
+def is_reasoning_model(model: Optional[str]) -> bool:
+    return isinstance(model, str) and model.startswith(REASONING_PREFIXES)
+
+
+def is_placeholder(model: Optional[str]) -> bool:
+    """True for docs placeholders like "<model_name>", which never run."""
+    return isinstance(model, str) and ("<" in model or ">" in model)
+
+
+def literal_or_none(node: ast.AST) -> Any:
+    try:
+        return ast.literal_eval(node)
+    except (ValueError, TypeError, SyntaxError, MemoryError, RecursionError):
+        return None
+
+
+def constructor_name(node: ast.Call) -> Optional[str]:
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def dict_literal_bindings(tree: ast.Module) -> dict[str, dict[str, Any]]:
+    """Names bound to a dict literal, for `model_params=SOME_NAME`.
+
+    Examples often build their parameters into a local first, which no amount of
+    literal_eval on the call site can see. This walk is not scope-aware, so a name
+    bound more than once to differing dicts is dropped rather than guessed at.
+    """
+    bindings: dict[str, dict[str, Any]] = {}
+    ambiguous: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        value = literal_or_none(node.value)
+        if not isinstance(value, dict):
+            continue
+        for target in node.targets:
+            if not isinstance(target, ast.Name):
+                continue
+            if target.id in bindings and bindings[target.id] != value:
+                ambiguous.add(target.id)
+            bindings[target.id] = value
+    for name in ambiguous:
+        del bindings[name]
+    return bindings
+
+
+def extract_model_and_params(
+    node: ast.Call, dict_bindings: Optional[dict[str, dict[str, Any]]] = None
+) -> tuple[Optional[str], dict[str, Any]]:
+    model: Optional[str] = None
+    params: dict[str, Any] = {}
+    for kw in node.keywords:
+        if kw.arg in ("model_name", "model"):
+            value = literal_or_none(kw.value)
+            if isinstance(value, str):
+                model = value
+        elif kw.arg == "model_params":
+            value = literal_or_none(kw.value)
+            if isinstance(value, dict):
+                params = value
+            elif isinstance(kw.value, ast.Name) and dict_bindings:
+                params = dict_bindings.get(kw.value.id, {})
+        elif kw.arg == "temperature":
+            # ChatOpenAI and friends take temperature directly.
+            params["temperature"] = literal_or_none(kw.value)
+    return model, params
+
+
+def check_openai_params(
+    path: Path,
+    line: int,
+    model: Optional[str],
+    params: dict[str, Any],
+    *,
+    always_sends_temperature: bool,
+) -> list[Problem]:
+    """Apply the OpenAI reasoning-model rules to one construction site."""
+    if is_placeholder(model) or not is_reasoning_model(model):
+        return []
+
+    problems: list[Problem] = []
+
+    if "max_tokens" in params:
+        problems.append(
+            Problem(
+                path,
+                line,
+                f"{model!r} rejects 'max_tokens'",
+                "rename it to 'max_completion_tokens'",
+            )
+        )
+
+    temperature = params.get("temperature")
+    if "temperature" in params and temperature != 1:
+        problems.append(
+            Problem(
+                path,
+                line,
+                f"{model!r} only accepts the default temperature (1), got {temperature!r}",
+                "drop 'temperature', or use a non-reasoning model such as gpt-4.1",
+            )
+        )
+    elif always_sends_temperature and "temperature" not in params:
+        # No explicit temperature, but this client sends its own default anyway.
+        problems.append(
+            Problem(
+                path,
+                line,
+                f"{model!r} with a LangChain chat client, which always sends a "
+                "temperature (default 0.7) that reasoning models reject",
+                "use a non-reasoning model such as gpt-4.1, or pass temperature=1",
+            )
+        )
+
+    budget = params.get("max_completion_tokens")
+    if isinstance(budget, int) and budget < MIN_REASONING_BUDGET:
+        problems.append(
+            Problem(
+                path,
+                line,
+                f"'max_completion_tokens' of {budget} is too small for {model!r}: "
+                "reasoning tokens count against it and can consume the whole "
+                "budget, returning empty content",
+                f"raise it to at least {MIN_REASONING_BUDGET}",
+            )
+        )
+
+    return problems
+
+
+def check_llm_usage(path: Path, tree: ast.Module) -> list[Problem]:
+    """Check construction sites, then invoke() kwargs on bound names."""
+    problems: list[Problem] = []
+    bindings: dict[str, Binding] = {}
+    dicts = dict_literal_bindings(tree)
+
+    def record(target: ast.expr, call: ast.Call) -> None:
+        name = constructor_name(call)
+        if name not in ALL_LLM_CONSTRUCTORS or not isinstance(target, ast.Name):
+            return
+        model, params = extract_model_and_params(call, dicts)
+        bindings[target.id] = Binding(name, model, params, call.lineno)
+
+    for node in ast.walk(tree):
+        # Construction sites, whether or not the result is bound to a name.
+        if isinstance(node, ast.Call):
+            name = constructor_name(node)
+            if name in OPENAI_CONSTRUCTORS or name in LANGCHAIN_OPENAI_CONSTRUCTORS:
+                model, params = extract_model_and_params(node, dicts)
+                problems.extend(
+                    check_openai_params(
+                        path,
+                        node.lineno,
+                        model,
+                        params,
+                        always_sends_temperature=name in LANGCHAIN_OPENAI_CONSTRUCTORS,
+                    )
+                )
+        # Name bindings, so invoke() kwargs can be attributed to a model.
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(node.value, ast.Call):
+                    record(target, node.value)
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.value, ast.Call):
+            record(node.target, node.value)
+        elif isinstance(node, (ast.With, ast.AsyncWith)):
+            for item in node.items:
+                if item.optional_vars is not None and isinstance(
+                    item.context_expr, ast.Call
+                ):
+                    record(item.optional_vars, item.context_expr)
+
+    # invoke(..., temperature=...) on a name we resolved to a reasoning model.
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute) or func.attr not in INVOKE_METHODS:
+            continue
+        if not isinstance(func.value, ast.Name):
+            continue
+        binding = bindings.get(func.value.id)
+        if binding is None or binding.constructor not in OPENAI_CONSTRUCTORS:
+            continue
+        if not is_reasoning_model(binding.model):
+            continue
+        for kw in node.keywords:
+            if kw.arg != "temperature":
+                continue
+            value = literal_or_none(kw.value)
+            if value != 1:
+                problems.append(
+                    Problem(
+                        path,
+                        node.lineno,
+                        f"temperature={value!r} passed to {func.attr}() on "
+                        f"{func.value.id!r}, which is {binding.model!r} "
+                        f"(constructed at line {binding.line}) and only accepts "
+                        "the default (1)",
+                        "drop the temperature kwarg, or construct this LLM with "
+                        "a non-reasoning model such as gpt-4.1",
+                    )
+                )
+
+    return problems
+
+
+def check_data_files(path: Path, tree: ast.Module) -> list[Problem]:
+    """Flag literal data-file paths that do not resolve."""
+    problems: list[Problem] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+            continue
+        value = node.value
+        if not value.endswith(DATA_SUFFIXES):
+            continue
+        if "://" in value or is_placeholder(value):
+            continue
+        # A bare filename is usually joined to a directory elsewhere (root_dir /
+        # "data" / name), so only judge values that look like a path.
+        if "/" not in value:
+            continue
+        candidates = [
+            REPO_ROOT / value,
+            path.parent / value,
+            EXAMPLES_DIR / value,
+        ]
+        if any(candidate.exists() for candidate in candidates):
+            continue
+        problems.append(
+            Problem(
+                path,
+                node.lineno,
+                f"data file not found: {value!r}",
+                "correct the path, or add the file under examples/data/",
+            )
+        )
+    return problems
+
+
+def iter_example_files() -> list[Path]:
+    return sorted(p for p in EXAMPLES_DIR.rglob("*.py") if "__pycache__" not in p.parts)
+
+
+def run_static_checks() -> list[FileReport]:
+    reports: list[FileReport] = []
+    for path in iter_example_files():
+        report = FileReport(path)
+        source = path.read_text()
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError as exc:
+            report.problems.append(
+                Problem(
+                    path,
+                    exc.lineno or 0,
+                    f"does not parse: {exc.msg}",
+                    "fix the syntax error",
+                )
+            )
+            reports.append(report)
+            continue
+        report.problems.extend(check_llm_usage(path, tree))
+        report.problems.extend(check_data_files(path, tree))
+        reports.append(report)
+    return reports
+
+
+# Providers that bill per call. Used only to warn before spending money; whether
+# an example *can* run is the doctor's answer, not ours.
+PAID_PROVIDERS = {
+    "openai",
+    "anthropic",
+    "cohere",
+    "mistral",
+    "gemini",
+    "vertexai",
+    "bedrock",
+    "azure",
+}
+
+
+def _confirm_spend(ready: list[Path], assume_yes: bool) -> bool:
+    """Say what this is about to cost, and get an answer before spending it."""
+    billed = sorted(
+        {
+            provider
+            for path in ready
+            for provider in example_requirements.analyse(path).providers
+            if provider in PAID_PROVIDERS
+        }
+    )
+    print(
+        f"--live will run {len(ready)} example(s) against live provider APIs. "
+        "This COSTS MONEY."
+    )
+    if billed:
+        print(f"Providers billed: {', '.join(billed)}")
+    if assume_yes:
+        return True
+    try:
+        return input("Continue? [y/N] ").strip().lower() in {"y", "yes"}
+    except EOFError:
+        return False
+
+
+def run_live_checks(timeout: int, assume_yes: bool) -> int:
+    """Run every example this machine is actually set up for.
+
+    What "set up for" means is the doctor's judgement, not a second opinion: a
+    duplicate of that logic here drifted from it, and skipped 30 examples that
+    were perfectly runnable. Everything the doctor blocks is reported as skipped,
+    never as passing - a green run must not imply coverage we do not have.
+    """
+    env_file = read_env_file()
+    # Overlay .env so a key that lives only there reaches the subprocess.
+    apply_env_file(env_file)
+    neo4j_state = probe_neo4j(env_file)
+
+    passed: list[Path] = []
+    failed: list[tuple[Path, str]] = []
+    skipped: list[tuple[Path, str]] = []
+    ready: list[Path] = []
+
+    for requirements in example_requirements.analyse_all():
+        path = requirements.path
+        if not requirements.runnable:
+            skipped.append((path, "snippet, nothing to run"))
+            continue
+        blockers = blockers_for(requirements, env_file, neo4j_state)
+        if blockers:
+            skipped.append((path, blockers[0].reason))
+            continue
+        ready.append(path)
+
+    if not ready:
+        print("Nothing is runnable on this machine; run scripts/check_setup.py.")
+    elif not _confirm_spend(ready, assume_yes):
+        print("Nothing run.")
+        return 0
+    else:
+        for path in ready:
+            try:
+                result = subprocess.run(
+                    [sys.executable, str(path)],
+                    cwd=REPO_ROOT,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout,
+                )
+            except subprocess.TimeoutExpired:
+                failed.append((path, f"timed out after {timeout}s"))
+                continue
+            if result.returncode == 0:
+                passed.append(path)
+            else:
+                tail = (result.stderr or result.stdout).strip().splitlines()
+                failed.append((path, tail[-1] if tail else "non-zero exit"))
+
+    for path in passed:
+        print(f"PASS {path.relative_to(REPO_ROOT)}")
+    for path, reason in skipped:
+        print(f"SKIP {path.relative_to(REPO_ROOT)} ({reason})")
+    for path, reason in failed:
+        print(f"FAIL {path.relative_to(REPO_ROOT)}: {reason}")
+
+    print(
+        f"\n{len(passed)} passed, {len(failed)} failed, {len(skipped)} skipped "
+        "(skipped examples were NOT verified)"
+    )
+    return 1 if failed else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="also run the examples we have credentials for (costs money)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=300,
+        help="per-example timeout in seconds for --live (default: 300)",
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="with --live, skip the cost confirmation",
+    )
+    args = parser.parse_args()
+
+    reports = run_static_checks()
+    problems = [p for report in reports for p in report.problems]
+
+    for problem in problems:
+        print(problem.render())
+
+    checked = len(reports)
+    if problems:
+        affected = len({p.path for p in problems})
+        print(
+            f"\n{len(problems)} problem(s) in {affected} of "
+            f"{checked} example file(s)."
+        )
+        return 1
+
+    print(f"{checked} example file(s) checked, no problems found.")
+
+    if args.live:
+        return run_live_checks(args.timeout, args.yes)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_check_examples.py
+++ b/tests/unit/scripts/test_check_examples.py
@@ -1,0 +1,304 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for the examples static checker.
+
+The rules take a parsed module, so every case here is a source string. Nothing
+touches the network, an API key, or the filesystem beyond reading paths that
+already exist in the repository.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import check_examples
+import example_requirements as reqs
+import pytest
+from examples_setup.doctor import Blocker
+from examples_setup.probes import Neo4jState
+from check_examples import (
+    MIN_REASONING_BUDGET,
+    check_data_files,
+    check_llm_usage,
+    dict_literal_bindings,
+)
+
+FAKE_PATH = Path("examples/fake_example.py")
+
+
+def messages(source: str) -> list[str]:
+    """The problem messages the LLM rules report for a snippet."""
+    return [p.message for p in check_llm_usage(FAKE_PATH, ast.parse(source))]
+
+
+# ---------------------------------------------------------------------------
+# model_params resolution
+# ---------------------------------------------------------------------------
+
+
+def test_model_params_bound_to_a_variable_is_resolved() -> None:
+    """The rules must see params built into a local first.
+
+    Regression: reading only the call site meant `model_params=<name>` resolved
+    to an empty dict and every rule below silently skipped.
+    """
+    source = """
+params = {"temperature": 0, "max_completion_tokens": 2000}
+llm = OpenAILLM(model_name="gpt-5", model_params=params)
+"""
+    assert len(messages(source)) == 2
+
+
+def test_model_params_as_a_dict_literal_is_still_resolved() -> None:
+    source = """
+llm = OpenAILLM(model_name="gpt-5", model_params={"temperature": 0})
+"""
+    assert len(messages(source)) == 1
+
+
+def test_a_name_bound_to_two_different_dicts_is_not_guessed_at() -> None:
+    """The walk is not scope-aware, so an ambiguous name must be left alone."""
+    source = """
+def a() -> None:
+    params = {"temperature": 0}
+    OpenAILLM(model_name="gpt-5", model_params=params)
+
+def b() -> None:
+    params = {"reasoning_effort": "low"}
+    OpenAILLM(model_name="gpt-5", model_params=params)
+"""
+    assert messages(source) == []
+    assert "params" not in dict_literal_bindings(ast.parse(source))
+
+
+def test_a_name_bound_to_the_same_dict_twice_is_not_ambiguous() -> None:
+    source = """
+params = {"temperature": 0}
+params = {"temperature": 0}
+"""
+    assert dict_literal_bindings(ast.parse(source)) == {"params": {"temperature": 0}}
+
+
+# ---------------------------------------------------------------------------
+# Reasoning-model rules
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "params,expected",
+    [
+        ('{"max_tokens": 2000}', 1),
+        (f'{{"max_completion_tokens": {MIN_REASONING_BUDGET}}}', 0),
+        (f'{{"max_completion_tokens": {MIN_REASONING_BUDGET - 1}}}', 1),
+        ('{"temperature": 0}', 1),
+        ('{"temperature": 1}', 0),
+        ('{"reasoning_effort": "low"}', 0),
+    ],
+)
+def test_reasoning_model_params(params: str, expected: int) -> None:
+    source = f'OpenAILLM(model_name="gpt-5", model_params={params})'
+    assert len(messages(source)) == expected
+
+
+def test_non_reasoning_model_is_left_alone() -> None:
+    """gpt-4.1 accepts both of the parameters gpt-5 rejects."""
+    source = """
+OpenAILLM(model_name="gpt-4.1", model_params={"max_tokens": 100, "temperature": 0})
+"""
+    assert messages(source) == []
+
+
+def test_placeholder_model_is_not_judged() -> None:
+    source = 'OpenAILLM(model_name="<model_name>", model_params={"temperature": 0})'
+    assert messages(source) == []
+
+
+# ---------------------------------------------------------------------------
+# LangChain's client, which sends a temperature of its own
+# ---------------------------------------------------------------------------
+
+
+def test_langchain_client_without_a_temperature_is_flagged() -> None:
+    """ChatOpenAI sends its own default, so omitting one does not help."""
+    assert len(messages('ChatOpenAI(model="gpt-5")')) == 1
+
+
+def test_langchain_client_with_the_only_accepted_temperature_is_not_flagged() -> None:
+    """Regression: a valid temperature=1 was reported with 'pass temperature=1'."""
+    assert messages('ChatOpenAI(model="gpt-5", temperature=1)') == []
+
+
+def test_langchain_client_with_a_rejected_temperature_is_flagged_once() -> None:
+    assert len(messages('ChatOpenAI(model="gpt-5", temperature=0)')) == 1
+
+
+# ---------------------------------------------------------------------------
+# Other providers: the false-positive guards
+# ---------------------------------------------------------------------------
+
+
+def test_anthropic_max_tokens_is_not_flagged() -> None:
+    """max_tokens is required by AnthropicLLM - it must not be 'fixed'."""
+    source = 'AnthropicLLM(model_name="claude-sonnet-4-5", model_params={"max_tokens": 1000})'
+    assert messages(source) == []
+
+
+def test_ollama_nested_options_are_not_flagged() -> None:
+    """Ollama nests generation params under 'options', so the keys differ."""
+    source = """
+OllamaLLM(model_name="llama3.2", model_params={"options": {"temperature": 0}})
+"""
+    assert messages(source) == []
+
+
+# ---------------------------------------------------------------------------
+# temperature passed to invoke() rather than the constructor
+# ---------------------------------------------------------------------------
+
+
+def test_temperature_on_invoke_is_attributed_to_the_model() -> None:
+    source = """
+llm = OpenAILLM(model_name="gpt-5")
+llm.invoke("hello", temperature=0)
+"""
+    assert len(messages(source)) == 1
+
+
+def test_temperature_on_invoke_of_a_non_reasoning_model_is_fine() -> None:
+    source = """
+llm = OpenAILLM(model_name="gpt-4.1")
+llm.invoke("hello", temperature=0)
+"""
+    assert messages(source) == []
+
+
+# ---------------------------------------------------------------------------
+# Data files
+# ---------------------------------------------------------------------------
+
+
+def test_missing_data_file_is_flagged() -> None:
+    source = 'path = "examples/data/does_not_exist.pdf"'
+    problems = check_data_files(FAKE_PATH, ast.parse(source))
+    assert len(problems) == 1
+    assert "does_not_exist.pdf" in problems[0].message
+
+
+def test_existing_data_file_is_not_flagged() -> None:
+    source = (
+        'path = "examples/data/Harry Potter and the Chamber of Secrets Summary.pdf"'
+    )
+    assert check_data_files(FAKE_PATH, ast.parse(source)) == []
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://example.com/remote.pdf",  # not a local path
+        "<path_to>/file.pdf",  # a docs placeholder
+        "bare_name.pdf",  # joined to a directory elsewhere
+    ],
+)
+def test_data_file_values_that_are_not_judged(value: str) -> None:
+    assert check_data_files(FAKE_PATH, ast.parse(f'path = "{value}"')) == []
+
+
+# ---------------------------------------------------------------------------
+# --live gating
+#
+# What "runnable right now" means is the doctor's judgement; these pin that the
+# runner asks it, rather than keeping a second opinion of its own.
+# ---------------------------------------------------------------------------
+
+
+def test_snippets_are_never_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    """blockers_for returns [] for a snippet, so the runner keeps its own gate.
+
+    Without it, every file with nothing to run would be executed.
+    """
+    ran: list[Path] = []
+    monkeypatch.setattr(check_examples, "blockers_for", lambda r, e, n: [])
+    monkeypatch.setattr(check_examples, "read_env_file", lambda: {})
+    monkeypatch.setattr(check_examples, "apply_env_file", lambda env: None)
+    monkeypatch.setattr(check_examples, "probe_neo4j", lambda env: Neo4jState())
+    monkeypatch.setattr(check_examples, "_confirm_spend", lambda ready, yes: False)
+
+    def spy(cmd: list[str], **kwargs: object) -> None:
+        ran.append(Path(cmd[1]))
+
+    monkeypatch.setattr("check_examples.subprocess.run", spy)
+    check_examples.run_live_checks(timeout=1, assume_yes=True)
+    assert ran == [], "declining the spend must run nothing"
+
+
+def test_a_blocked_example_is_skipped_not_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(check_examples, "read_env_file", lambda: {})
+    monkeypatch.setattr(check_examples, "apply_env_file", lambda env: None)
+    monkeypatch.setattr(check_examples, "probe_neo4j", lambda env: Neo4jState())
+    monkeypatch.setattr(
+        check_examples,
+        "blockers_for",
+        lambda r, e, n: [Blocker("OPENAI_API_KEY not set", "export it")],
+    )
+    ran: list[str] = []
+    monkeypatch.setattr(
+        "check_examples.subprocess.run", lambda cmd, **kw: ran.append(cmd[1])
+    )
+    rc = check_examples.run_live_checks(timeout=1, assume_yes=True)
+    assert ran == []
+    assert rc == 0
+
+
+def test_declining_the_cost_prompt_runs_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(check_examples, "read_env_file", lambda: {})
+    monkeypatch.setattr(check_examples, "apply_env_file", lambda env: None)
+    monkeypatch.setattr(check_examples, "probe_neo4j", lambda env: Neo4jState())
+    monkeypatch.setattr(check_examples, "blockers_for", lambda r, e, n: [])
+    monkeypatch.setattr("builtins.input", lambda prompt="": "n")
+    ran: list[str] = []
+    monkeypatch.setattr(
+        "check_examples.subprocess.run", lambda cmd, **kw: ran.append(cmd[1])
+    )
+    rc = check_examples.run_live_checks(timeout=1, assume_yes=False)
+    assert ran == []
+    assert rc == 0
+
+
+def test_the_cost_prompt_names_the_providers_that_will_be_billed(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    paid = reqs.EXAMPLES_DIR / "customize" / "llms" / "anthropic_llm.py"
+    check_examples._confirm_spend([paid], assume_yes=True)
+    out = capsys.readouterr().out
+    assert "COSTS MONEY" in out
+    assert "anthropic" in out
+
+
+def test_azure_is_not_considered_ready(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Its credentials are hardcoded placeholders, not environment variables.
+
+    The provider declares no env vars, so without a probe the doctor reports it
+    ready and --live runs it, turning a clean SKIP into a FAIL.
+    """
+    from examples_setup.doctor import blockers_for as real_blockers_for
+
+    requirement = reqs.ExampleRequirements(
+        path=reqs.EXAMPLES_DIR / "fake.py", providers={"azure"}
+    )
+    found = real_blockers_for(requirement, {}, Neo4jState())
+    assert found, "azure must report a blocker rather than looking ready"


### PR DESCRIPTION
Last of the chain-B PRs. **Stacked on #602** — the diff above contains #597, #599 and #602 until they merge; this PR's own change is the final commit.

Adds `--live` to the examples checker: an opt-in, manual-stage run of every example this machine can actually support. Nothing invokes it on commit, on push, or in CI.

## The point of the restructure

What "set up for" means is now the doctor's judgement rather than a second opinion.

The version this replaces kept its own gate — a hardcoded `RUNNABLE_PROVIDERS = {"openai"}` plus a services check — which had drifted from `blockers_for`. Measured against the real corpus, it **skipped 30 examples across 12 providers** that were perfectly runnable, whatever credentials you had. Two implementations of the same question, disagreeing.

Delegating deletes `RUNNABLE_PROVIDERS`, `_service_available` (a one-line pass-through) and `providers_used` (already dead), and gains everything the doctor checks: extras, per-provider env vars, credential probes, APOC, indexes, sibling-module imports. A skip line now carries the fix, and `apply_env_file` means a key living only in `.env` reaches the subprocess instead of failing a preflight.

## Cost

The whitelist was quietly doing one job worth keeping — cost control. Removing it means the doctor green-lights considerably more. So `--live` now says what it is about to spend, and waits:

```
--live will run 51 example(s) against live provider APIs. This COSTS MONEY.
Providers billed: anthropic, bedrock, cohere, gemini, mistral, openai, vertexai
Continue? [y/N]
```

That is real output from this branch. `--yes` skips the prompt for scripted use.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [x] Project configuration change

## Complexity

Complexity: Medium

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [x] Manual tests

Nothing covered the `--live` path before, so this adds the gating tests: snippets are never run, a blocked example is skipped rather than run, declining the prompt runs nothing and exits 0, and the prompt names the providers that will be billed. Confirmed by hand that declining runs nothing.

# Checklist

- [ ] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate

🤖 Generated with [Claude Code](https://claude.com/claude-code)