### PR TITLE
feat(scripts): report what is stopping each example from running

### DIFF
--- a/scripts/check_setup.py
+++ b/scripts/check_setup.py
@@ -1,0 +1,65 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Report what is stopping each example under ``examples/`` from running.
+
+    python scripts/check_setup.py             # what is missing
+    python scripts/check_setup.py --verbose    # and list every example
+    python scripts/check_setup.py --strict     # exit non-zero if anything is blocked
+
+Resolves every example against the requirement model in
+``example_requirements.py``, then probes this machine: which extras are
+installed, which env vars are set, which credentials resolve, which services
+answer, and what the local Neo4j actually contains.
+
+Reports the single first thing blocking each example, grouped so the biggest
+wins come first, with the command that fixes it. Writes nothing, and needs no
+credentials of its own. Network use is limited to TCP connects, except that
+resolving Google credentials shells out to ``gcloud`` to mint an access token.
+
+``examples/SETUP.md`` covers the same ground as prose, for reading rather than
+running.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from examples_setup.doctor import run_doctor  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="exit non-zero if any example is blocked",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="list every example rather than the first few per reason",
+    )
+    args = parser.parse_args()
+    return run_doctor(strict=args.strict, verbose=args.verbose)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/examples_setup/__init__.py
+++ b/scripts/examples_setup/__init__.py
@@ -1,0 +1,36 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Setup tooling for running the examples.
+
+The command-line entry point is ``scripts/check_setup.py``; this package holds
+the pieces it drives. Split by concern so each part can be read on its own:
+providers and their credentials, the .env file, environment probes, and the
+report itself.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# example_requirements sits beside this package rather than inside it, because
+# check_examples.py imports it too. Importing any submodule runs this first, so
+# the path is in place before anything reaches for it.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import example_requirements as reqs  # noqa: E402
+
+REPO_ROOT = reqs.REPO_ROOT
+ENV_FILE = REPO_ROOT / ".env"

--- a/scripts/examples_setup/console.py
+++ b/scripts/examples_setup/console.py
@@ -1,0 +1,33 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Terminal output and prompts."""
+
+from __future__ import annotations
+
+import sys
+
+
+GREEN = "\033[32m"
+YELLOW = "\033[33m"
+RED = "\033[31m"
+DIM = "\033[2m"
+BOLD = "\033[1m"
+RESET = "\033[0m"
+
+
+def colour(text: str, code: str) -> str:
+    if not sys.stdout.isatty():
+        return text
+    return f"{code}{text}{RESET}"

--- a/scripts/examples_setup/doctor.py
+++ b/scripts/examples_setup/doctor.py
@@ -1,0 +1,236 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Report what is missing, and change nothing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import example_requirements as reqs
+
+from .console import BOLD, DIM, GREEN, RED, YELLOW, colour
+from .envfile import apply_env_file, env_value, read_env_file
+from .probes import (
+    Neo4jState,
+    extra_installed,
+    ollama_models,
+    package_installed,
+    probe_neo4j,
+)
+from .providers import OLLAMA_CHAT_MODEL, OLLAMA_EMBED_MODEL, PROVIDERS
+
+
+@dataclass
+class Blocker:
+    """Why one example cannot run right now."""
+
+    reason: str
+    fix: str
+
+
+def blockers_for(
+    requirement: reqs.ExampleRequirements,
+    env_file: dict[str, str],
+    neo4j_state: Neo4jState,
+) -> list[Blocker]:
+    found: list[Blocker] = []
+
+    for extra in sorted(requirement.extras):
+        if not extra_installed(extra):
+            found.append(
+                Blocker(f"extra '{extra}' not installed", "uv sync --all-extras")
+            )
+
+    for module in sorted(requirement.install_hints()):
+        if not package_installed(module.replace("-", "_")):
+            found.append(Blocker(f"package '{module}' missing", f"uv add {module}"))
+
+    for provider_key in sorted(requirement.providers):
+        provider = PROVIDERS.get(provider_key)
+        if provider is None:
+            continue
+        for name in provider.env_vars:
+            if not env_value(name, env_file):
+                found.append(
+                    Blocker(
+                        f"{name} not set",
+                        f"export {name}=..., or add it to .env",
+                    )
+                )
+        if provider.credential_probe is not None:
+            ok, fix = provider.credential_probe()
+            if not ok:
+                found.append(Blocker(f"{provider.label}: no usable credentials", fix))
+
+    for service in sorted(requirement.services):
+        if service in {reqs.APOC}:
+            continue
+        if not reqs.service_available(service):
+            found.append(
+                Blocker(
+                    f"{reqs.SERVICE_LABELS.get(service, service)} unreachable",
+                    _service_fix(service),
+                )
+            )
+
+    # A TCP connect proves something is listening, not that we can log in. Without
+    # this, a wrong NEO4J_PASSWORD reports no blockers at all - the APOC and index
+    # checks below both gate on `authenticated` and silently do nothing - and then
+    # every Neo4j example fails at runtime.
+    needs_neo4j = reqs.NEO4J_LOCAL in requirement.services
+    if needs_neo4j and neo4j_state.reachable and not neo4j_state.authenticated:
+        found.append(
+            Blocker(
+                f"Neo4j is running but rejected the connection: {neo4j_state.error}",
+                "check NEO4J_USER / NEO4J_PASSWORD in .env",
+            )
+        )
+
+    if reqs.APOC in requirement.services and neo4j_state.authenticated:
+        if not neo4j_state.has_apoc:
+            found.append(
+                Blocker(
+                    "APOC not installed in Neo4j",
+                    "start Neo4j from tests/e2e/docker-compose.yml, which ships APOC",
+                )
+            )
+
+    if requirement.indexes and reqs.NEO4J_LOCAL in requirement.services:
+        if neo4j_state.authenticated:
+            missing = sorted(set(requirement.indexes) - neo4j_state.indexes)
+            for name in missing:
+                found.append(
+                    Blocker(
+                        f"index '{name}' does not exist",
+                        "create it with examples/database_operations/"
+                        "create_vector_index.py",
+                    )
+                )
+
+    if requirement.sibling_modules:
+        names = ", ".join(sorted(requirement.sibling_modules))
+        found.append(
+            Blocker(
+                f"imports {names} from examples/data, which is not on sys.path",
+                "run it as PYTHONPATH=examples/data python <file>",
+            )
+        )
+
+    if reqs.OLLAMA_SERVER in requirement.services and reqs.service_available(
+        reqs.OLLAMA_SERVER
+    ):
+        pulled = ollama_models()
+        # The chat and embedding examples need different models, so "some model is
+        # pulled" is not enough to say either will run.
+        wanted = [OLLAMA_CHAT_MODEL, OLLAMA_EMBED_MODEL]
+        missing = [
+            m for m in wanted if not any(p.startswith(m.split(":")[0]) for p in pulled)
+        ]
+        for model in missing:
+            found.append(
+                Blocker(
+                    f"Ollama is running but {model} is not pulled",
+                    f"ollama pull {model}",
+                )
+            )
+
+    return found
+
+
+def _service_fix(service: str) -> str:
+    if service in {
+        reqs.NEO4J_LOCAL,
+        reqs.WEAVIATE_SERVER,
+        reqs.QDRANT_SERVER,
+        reqs.PINECONE_SERVER,
+    }:
+        profile = " --profile vectordb" if service != reqs.NEO4J_LOCAL else ""
+        return f"docker compose -f tests/e2e/docker-compose.yml{profile} up -d --wait"
+    if service == reqs.OLLAMA_SERVER:
+        return "ollama serve"
+    if service in {reqs.NEO4J_DEMO, reqs.INTERNET}:
+        return "check your network connection"
+    return ""
+
+
+def run_doctor(strict: bool, verbose: bool) -> int:
+    env_file = read_env_file()
+    apply_env_file(env_file)
+    neo4j_state = probe_neo4j(env_file)
+
+    print()
+    print(colour("Python extras", BOLD))
+    # Parses all 104 examples, so do it once and reuse it below.
+    everything = reqs.analyse_all()
+    used_extras = sorted({e for r in everything for e in r.extras})
+    for extra in used_extras:
+        installed = extra_installed(extra)
+        mark = colour("installed", GREEN) if installed else colour("missing", RED)
+        print(f"  {extra:<24} {mark}")
+
+    requirements = [r for r in everything if r.runnable]
+    results: list[tuple[reqs.ExampleRequirements, list[Blocker]]] = [
+        (r, blockers_for(r, env_file, neo4j_state)) for r in requirements
+    ]
+    ready = [r for r, b in results if not b]
+    blocked = [(r, b) for r, b in results if b]
+
+    print()
+    print(colour("Examples", BOLD))
+    print(
+        f"  {colour(str(len(ready)), GREEN)} runnable, "
+        f"{colour(str(len(blocked)), YELLOW)} blocked, "
+        f"{len(everything) - len(requirements)} snippets with nothing to run"
+    )
+
+    if blocked:
+        by_reason: dict[str, list[str]] = {}
+        for requirement, found in blocked:
+            key = f"{found[0].reason}  ->  {found[0].fix}"
+            by_reason.setdefault(key, []).append(requirement.rel)
+        print()
+        print(colour("  Blocked, grouped by the first thing missing", BOLD))
+        for reason in sorted(by_reason, key=lambda k: -len(by_reason[k])):
+            paths = by_reason[reason]
+            print(f"\n  {colour(reason, YELLOW)}  ({len(paths)} examples)")
+            shown = paths if verbose else paths[:4]
+            for path in shown:
+                print(f"      {path}")
+            if len(paths) > len(shown):
+                print("      " + colour(f"... and {len(paths) - len(shown)} more", DIM))
+
+    notes = [(r.rel, note) for r in everything for note in r.notes]
+    if notes and verbose:
+        print()
+        print(colour("Known issues in the examples themselves", BOLD))
+        for path, note in notes:
+            print(f"  {path}\n      {note}")
+    elif notes:
+        print()
+        print(
+            colour(
+                f"{len(notes)} examples carry known content issues; "
+                "re-run with --verbose to list them.",
+                DIM,
+            )
+        )
+
+    if ready:
+        print()
+        print(colour("Ready to run, for example:", BOLD))
+        for requirement in ready[:5]:
+            print(f"  python {requirement.rel}")
+
+    return 1 if (strict and blocked) else 0

--- a/scripts/examples_setup/envfile.py
+++ b/scripts/examples_setup/envfile.py
@@ -1,0 +1,58 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Reading and writing the .env file.
+
+Credentials live here and nowhere else: the file is gitignored, written at
+mode 0600, and its contents are never echoed back in full.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+from . import ENV_FILE
+
+
+def read_env_file(path: Path = ENV_FILE) -> dict[str, str]:
+    if not path.exists():
+        return {}
+    values: dict[str, str] = {}
+    for line in path.read_text().splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        name, _, value = stripped.partition("=")
+        values[name.strip()] = value.strip().strip("'\"")
+    return values
+
+
+def env_value(name: str, env_file: dict[str, str]) -> Optional[str]:
+    """Resolve an env var from the process first, then .env."""
+    return os.environ.get(name) or env_file.get(name) or None
+
+
+def apply_env_file(env_file: dict[str, str]) -> None:
+    """Overlay .env onto the process, without overriding what is already set.
+
+    Needed because probes that go through a third-party SDK - botocore resolving
+    AWS_PROFILE, for instance - read the real environment and cannot see a value
+    that only exists in .env. Without this the doctor would report "no
+    credentials" for a profile the user had correctly configured.
+    """
+    for name, value in env_file.items():
+        if value and name not in os.environ:
+            os.environ[name] = value

--- a/scripts/examples_setup/probes.py
+++ b/scripts/examples_setup/probes.py
@@ -1,0 +1,120 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Is a thing present - a package, a command, a database, a model."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+
+import example_requirements as reqs
+
+from .envfile import env_value
+
+
+def package_installed(module: str) -> bool:
+    import importlib.util
+
+    try:
+        return importlib.util.find_spec(module) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+# Extra -> a module that proves it is installed.
+# The import name to try for each extra. Derived from the requirement model so
+# the two cannot drift; only the extras whose probe module is not recoverable
+# from it are named here.
+_PROBE_OVERRIDES: dict[str, str] = {
+    "google-genai": "google.genai",
+}
+
+
+def _probe_module(extra: str) -> str | None:
+    if extra in _PROBE_OVERRIDES:
+        return _PROBE_OVERRIDES[extra]
+    for module, mapped in reqs.MODULE_EXTRAS.items():
+        if mapped == extra:
+            return module
+    return None
+
+
+def extra_installed(extra: str) -> bool:
+    module = _probe_module(extra)
+    return package_installed(module) if module else True
+
+
+def command_exists(name: str) -> bool:
+    return shutil.which(name) is not None
+
+
+def ollama_models() -> list[str]:
+    """Models already pulled, or [] if the server is not up."""
+    try:
+        with urllib.request.urlopen("http://localhost:11434/api/tags", timeout=2) as r:
+            payload = json.loads(r.read().decode())
+    except (urllib.error.URLError, OSError, json.JSONDecodeError):
+        return []
+    models = payload.get("models", [])
+    if not isinstance(models, list):
+        return []
+    return [str(m.get("name", "")) for m in models if isinstance(m, dict)]
+
+
+@dataclass
+class Neo4jState:
+    reachable: bool = False
+    authenticated: bool = False
+    has_apoc: bool = False
+    indexes: set[str] = field(default_factory=set)
+    error: str = ""
+
+
+def probe_neo4j(env_file: dict[str, str]) -> Neo4jState:
+    """Inspect the local database. Degrades gracefully before `uv sync`."""
+    state = Neo4jState()
+    if not reqs.service_available(reqs.NEO4J_LOCAL):
+        state.error = "nothing listening on localhost:7687"
+        return state
+    state.reachable = True
+
+    try:
+        import neo4j
+    except ImportError:
+        state.error = "neo4j driver not installed yet; run uv sync"
+        return state
+
+    uri = env_value("NEO4J_URI", env_file) or "bolt://localhost:7687"
+    user = env_value("NEO4J_USER", env_file) or "neo4j"
+    password = env_value("NEO4J_PASSWORD", env_file) or "password"
+    try:
+        with neo4j.GraphDatabase.driver(uri, auth=(user, password)) as driver:
+            driver.verify_connectivity()
+            state.authenticated = True
+            records, _, _ = driver.execute_query(
+                "SHOW PROCEDURES YIELD name WHERE name STARTS WITH 'apoc' "
+                "RETURN count(*) AS c"
+            )
+            state.has_apoc = bool(records) and records[0]["c"] > 0
+            index_records, _, _ = driver.execute_query(
+                "SHOW INDEXES YIELD name RETURN name"
+            )
+            state.indexes = {record["name"] for record in index_records}
+    except Exception as exc:  # driver raises a wide range of auth/config errors
+        state.error = f"{type(exc).__name__}: {exc}"
+    return state

--- a/scripts/examples_setup/providers.py
+++ b/scripts/examples_setup/providers.py
@@ -1,0 +1,246 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""The services the examples talk to, and how to tell whether they are usable.
+
+Each provider carries the env vars its examples read, what it costs and where to
+get a key. Providers whose credentials do not live in an env var - a cloud CLI
+login, an AWS named profile - carry a probe instead.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from functools import cache
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+from .probes import command_exists
+
+
+@dataclass(frozen=True)
+class Provider:
+    """A credential-bearing service one or more examples talk to."""
+
+    key: str
+    label: str
+    tier: int
+    env_vars: tuple[str, ...]
+    signup_url: Optional[str] = None
+    free_tier: str = ""
+    manual: str = ""
+    # For providers whose credentials do not live in an env var (a cloud CLI
+    # login, a named profile). Returns (ok, how to fix it).
+    credential_probe: Optional[Callable[[], tuple[bool, str]]] = None
+
+
+@cache
+def _probe_aws() -> tuple[bool, str]:
+    """Whether boto3 can resolve credentials at all.
+
+    A successful SSO login often writes a *named profile*, which boto3 ignores
+    unless AWS_PROFILE points at it - so "logged in" and "usable" differ here.
+    """
+    try:
+        import botocore.session
+    except ImportError:
+        return False, "uv sync --all-extras"
+    if botocore.session.get_session().get_credentials() is None:
+        return False, "aws sso login, then export AWS_PROFILE=<your profile>"
+    return True, ""
+
+
+@cache
+def _probe_gcloud_adc() -> tuple[bool, str]:
+    """Whether Vertex can authenticate. The project alone is not enough."""
+    if not command_exists("gcloud"):
+        return False, "install the gcloud CLI"
+    result = subprocess.run(
+        ["gcloud", "auth", "application-default", "print-access-token"],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        return False, "gcloud auth application-default login"
+    return True, ""
+
+
+@cache
+def _probe_azure() -> tuple[bool, str]:
+    """Azure's example carries no credentials we can detect.
+
+    Its endpoint, key and API version are hardcoded placeholders in the file
+    itself rather than read from the environment, so there is nothing to probe -
+    and reporting "ready" would send a caller off to run something that cannot
+    work. Say so instead.
+    """
+    return False, (
+        "edit the endpoint, key and API version into "
+        "examples/customize/embeddings/azure_openai_embeddings.py (do not commit it)"
+    )
+
+
+PROVIDERS: dict[str, Provider] = {
+    "openai": Provider(
+        key="openai",
+        label="OpenAI",
+        tier=1,
+        env_vars=("OPENAI_API_KEY",),
+        signup_url="https://platform.openai.com/api-keys",
+        free_tier="No free tier - the key is billed per token.",
+    ),
+    "gemini": Provider(
+        key="gemini",
+        label="Google Gemini (AI Studio)",
+        tier=1,
+        env_vars=("GOOGLE_API_KEY",),
+        signup_url="https://aistudio.google.com/apikey",
+        free_tier=(
+            "Free, no credit card: about 1,500 requests/day and 15 rpm on 2.5 "
+            "Flash. Pro models are paid-only. Free-tier prompts may be used to "
+            "improve Google's products - do not send anything confidential."
+        ),
+    ),
+    "cohere": Provider(
+        key="cohere",
+        label="Cohere",
+        tier=1,
+        env_vars=("CO_API_KEY",),
+        signup_url="https://dashboard.cohere.com/api-keys",
+        free_tier=(
+            "Free trial key, no credit card: 1,000 calls/month, 20 rpm chat and "
+            "5 rpm embed. Not licensed for production use."
+        ),
+    ),
+    "mistral": Provider(
+        key="mistral",
+        label="Mistral AI",
+        tier=1,
+        env_vars=("MISTRAL_API_KEY",),
+        signup_url="https://console.mistral.ai/api-keys",
+        free_tier=(
+            "Free 'Experiment' tier, no credit card but phone verification is "
+            "required. Roughly 1 request/second."
+        ),
+    ),
+    "anthropic": Provider(
+        key="anthropic",
+        label="Anthropic",
+        tier=1,
+        env_vars=("ANTHROPIC_API_KEY",),
+        signup_url="https://console.anthropic.com/settings/keys",
+        free_tier="No free tier - the account needs purchased credits.",
+    ),
+    "ollama": Provider(
+        key="ollama",
+        label="Ollama (local)",
+        tier=2,
+        env_vars=(),
+        free_tier="Free and fully local. No account, no key, no network.",
+    ),
+    "sentence-transformers": Provider(
+        key="sentence-transformers",
+        label="sentence-transformers (local)",
+        tier=2,
+        env_vars=(),
+        free_tier="Free and local; downloads model weights on first use.",
+    ),
+    "spacy": Provider(
+        key="spacy",
+        label="spaCy (local)",
+        tier=2,
+        env_vars=(),
+        free_tier="Free and local; en_core_web_lg is about 560 MB.",
+    ),
+    "rapidfuzz": Provider(
+        key="rapidfuzz",
+        label="rapidfuzz (local)",
+        tier=2,
+        env_vars=(),
+        free_tier="Free and local, pure Python dependency.",
+    ),
+    "weaviate": Provider(
+        key="weaviate",
+        label="Weaviate",
+        tier=2,
+        env_vars=(),
+        free_tier="Run it locally with Docker - no account needed.",
+    ),
+    "qdrant": Provider(
+        key="qdrant",
+        label="Qdrant",
+        tier=2,
+        env_vars=(),
+        free_tier="Run it locally with Docker - no account needed.",
+    ),
+    "pinecone": Provider(
+        key="pinecone",
+        label="Pinecone",
+        tier=2,
+        env_vars=(),
+        free_tier=(
+            "Pinecone Local is an in-memory Docker emulator that ignores API "
+            "keys entirely, so no account is needed. The hosted service also "
+            "has a free Starter tier."
+        ),
+    ),
+    "vertexai": Provider(
+        key="vertexai",
+        label="Google Vertex AI",
+        tier=3,
+        env_vars=("GOOGLE_CLOUD_PROJECT",),
+        credential_probe=_probe_gcloud_adc,
+        free_tier=(
+            "No standing free tier; new GCP accounts get $300 in credits. "
+            "Gemini via AI Studio reaches the same model family for "
+            "free, so only set this up if you specifically need Vertex."
+        ),
+        manual="gcloud auth application-default login",
+    ),
+    "bedrock": Provider(
+        key="bedrock",
+        label="AWS Bedrock",
+        tier=3,
+        # The examples hardcode region_name, so AWS_REGION is not required.
+        # What matters is whether boto3 can resolve credentials.
+        env_vars=(),
+        credential_probe=_probe_aws,
+        free_tier=(
+            "No standing free tier; accounts created after July 2025 get $200 "
+            "in credits that expire after 6 months."
+        ),
+        manual=(
+            "Serverless models are enabled by default, but Anthropic models on "
+            "Bedrock need a one-time use-case form submitted from the Bedrock "
+            "console before the first call."
+        ),
+    ),
+    "azure": Provider(
+        key="azure",
+        label="Azure OpenAI",
+        tier=3,
+        env_vars=(),
+        credential_probe=_probe_azure,
+        free_tier="No free tier; needs a deployed Azure OpenAI resource.",
+        manual=(
+            "examples/customize/embeddings/azure_openai_embeddings.py reads no "
+            "env vars - its endpoint and key are hardcoded placeholders you "
+            "must edit by hand. Never commit that edit."
+        ),
+    ),
+}
+
+# The models the Ollama examples default to, so a completed setup run leaves
+# them runnable with no arguments.
+OLLAMA_CHAT_MODEL = "llama3.2"
+OLLAMA_EMBED_MODEL = "nomic-embed-text"

--- a/tests/unit/scripts/test_doctor.py
+++ b/tests/unit/scripts/test_doctor.py
@@ -1,0 +1,189 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for the per-example blocker report.
+
+`blockers_for` reaches the outside world through four module-level names in
+`doctor` - `extra_installed`, `package_installed`, `env_value` and
+`reqs.service_available` - so every one of these runs with those patched. No
+network, no services, no credentials.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterator
+
+import example_requirements as reqs
+import pytest
+from examples_setup import doctor
+from examples_setup.probes import Neo4jState
+
+FAKE = Path(reqs.EXAMPLES_DIR) / "fake_example.py"
+
+
+@pytest.fixture(autouse=True)
+def everything_satisfied(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Default to a machine where nothing is missing.
+
+    Each test then breaks exactly one thing, so a blocker in the result can only
+    have come from the dimension under test.
+    """
+    monkeypatch.setattr(doctor, "extra_installed", lambda extra: True)
+    monkeypatch.setattr(doctor, "package_installed", lambda module: True)
+    monkeypatch.setattr(doctor, "env_value", lambda name, env_file: "set")
+    monkeypatch.setattr(reqs, "service_available", lambda service: True)
+    monkeypatch.setattr(
+        doctor, "ollama_models", lambda: ["llama3.2", "nomic-embed-text"]
+    )
+    yield
+
+
+def healthy_neo4j() -> Neo4jState:
+    return Neo4jState(
+        reachable=True,
+        authenticated=True,
+        has_apoc=True,
+        indexes={"moviePlotsEmbedding", "movieFulltext"},
+    )
+
+
+def reasons(requirement: reqs.ExampleRequirements, state: Neo4jState) -> list[str]:
+    return [b.reason for b in doctor.blockers_for(requirement, {}, state)]
+
+
+def test_a_satisfied_example_has_no_blockers() -> None:
+    requirement = reqs.ExampleRequirements(
+        path=FAKE, extras={"openai"}, providers={"openai"}, services={reqs.NEO4J_LOCAL}
+    )
+    assert reasons(requirement, healthy_neo4j()) == []
+
+
+def test_a_missing_extra_is_reported(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(doctor, "extra_installed", lambda extra: False)
+    requirement = reqs.ExampleRequirements(path=FAKE, extras={"openai"})
+    assert reasons(requirement, healthy_neo4j()) == ["extra 'openai' not installed"]
+
+
+def test_an_unset_env_var_is_reported(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(doctor, "env_value", lambda name, env_file: None)
+    requirement = reqs.ExampleRequirements(path=FAKE, providers={"openai"})
+    found = reasons(requirement, healthy_neo4j())
+    assert found == ["OPENAI_API_KEY not set"]
+
+
+def test_the_env_var_fix_does_not_name_a_command_that_does_not_exist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The installer is a separate tool; do not advise a flag we do not ship."""
+    monkeypatch.setattr(doctor, "env_value", lambda name, env_file: None)
+    requirement = reqs.ExampleRequirements(path=FAKE, providers={"openai"})
+    fixes = [b.fix for b in doctor.blockers_for(requirement, {}, healthy_neo4j())]
+    assert "--provider" not in " ".join(fixes)
+
+
+def test_an_unreachable_service_is_reported(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(reqs, "service_available", lambda service: False)
+    requirement = reqs.ExampleRequirements(path=FAKE, services={reqs.NEO4J_LOCAL})
+    found = reasons(requirement, Neo4jState())
+    assert any("unreachable" in reason for reason in found)
+
+
+# ---------------------------------------------------------------------------
+# Neo4j reachable but not authenticated
+# ---------------------------------------------------------------------------
+
+
+def test_a_rejected_neo4j_login_is_reported() -> None:
+    """Regression: a wrong password used to produce a clean bill of health.
+
+    service_available only opens a TCP socket, and the APOC and index checks both
+    gate on `authenticated`, so every check silently passed while every Neo4j
+    example failed at runtime.
+    """
+    state = Neo4jState(reachable=True, authenticated=False, error="unauthorized")
+    requirement = reqs.ExampleRequirements(
+        path=FAKE,
+        services={reqs.NEO4J_LOCAL, reqs.APOC},
+        indexes={"moviePlotsEmbedding"},
+    )
+    found = reasons(requirement, state)
+    assert found, "a reachable but unauthenticated Neo4j must be reported"
+    assert any("rejected the connection" in reason for reason in found)
+
+
+def test_a_healthy_neo4j_does_not_report_a_login_problem() -> None:
+    requirement = reqs.ExampleRequirements(path=FAKE, services={reqs.NEO4J_LOCAL})
+    assert reasons(requirement, healthy_neo4j()) == []
+
+
+# ---------------------------------------------------------------------------
+# Neo4j contents
+# ---------------------------------------------------------------------------
+
+
+def test_missing_apoc_is_reported() -> None:
+    state = Neo4jState(reachable=True, authenticated=True, has_apoc=False)
+    requirement = reqs.ExampleRequirements(
+        path=FAKE, services={reqs.NEO4J_LOCAL, reqs.APOC}
+    )
+    assert "APOC not installed in Neo4j" in reasons(requirement, state)
+
+
+def test_a_missing_index_is_reported_without_naming_a_dead_flag() -> None:
+    state = Neo4jState(reachable=True, authenticated=True, has_apoc=True, indexes=set())
+    requirement = reqs.ExampleRequirements(
+        path=FAKE, services={reqs.NEO4J_LOCAL}, indexes={"moviePlotsEmbedding"}
+    )
+    blockers = doctor.blockers_for(requirement, {}, state)
+    assert any("does not exist" in b.reason for b in blockers)
+    assert "--tier" not in " ".join(b.fix for b in blockers)
+
+
+# ---------------------------------------------------------------------------
+# Other dimensions
+# ---------------------------------------------------------------------------
+
+
+def test_a_sibling_module_import_is_reported() -> None:
+    requirement = reqs.ExampleRequirements(
+        path=FAKE, sibling_modules={"embedding_avatar"}
+    )
+    found = reasons(requirement, healthy_neo4j())
+    assert any("examples/data" in reason for reason in found)
+
+
+@pytest.mark.parametrize(
+    "pulled,expected",
+    [(["llama3.2"], 1), ([], 2), (["llama3.2", "nomic-embed-text"], 0)],
+)
+def test_ollama_reports_each_model_the_examples_need(
+    monkeypatch: pytest.MonkeyPatch, pulled: list[str], expected: int
+) -> None:
+    """The chat and embedding examples need different models."""
+    monkeypatch.setattr(doctor, "ollama_models", lambda: pulled)
+    requirement = reqs.ExampleRequirements(path=FAKE, services={reqs.OLLAMA_SERVER})
+    found = [r for r in reasons(requirement, healthy_neo4j()) if "Ollama" in r]
+    assert len(found) == expected
+
+
+def test_azure_reports_a_blocker_rather_than_looking_ready() -> None:
+    """Its endpoint and key are hardcoded placeholders, not env vars.
+
+    With no env vars declared and no probe there is nothing to detect, so the
+    example would be reported ready and then fail the moment it ran.
+    """
+    requirement = reqs.ExampleRequirements(path=FAKE, providers={"azure"})
+    found = reasons(requirement, healthy_neo4j())
+    assert any("Azure" in reason for reason in found)

--- a/tests/unit/scripts/test_envfile.py
+++ b/tests/unit/scripts/test_envfile.py
@@ -1,0 +1,86 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for reading the examples' .env file.
+
+Every test passes an explicit path. The module's defaults point at the
+developer's real .env, and a test that forgot would read it.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+from examples_setup.envfile import apply_env_file, env_value, read_env_file
+
+
+def test_read_env_file_ignores_comments_and_blanks() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / ".env"
+        path.write_text("# a comment\n\nNEO4J_USER=neo4j\nnot-a-pair\n")
+        assert read_env_file(path) == {"NEO4J_USER": "neo4j"}
+
+
+def test_read_env_file_on_a_missing_file_is_empty() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        assert read_env_file(Path(tmpdir) / "nope") == {}
+
+
+def test_read_env_file_strips_surrounding_quotes() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / ".env"
+        path.write_text("A='single'\nB=\"double\"\n")
+        assert read_env_file(path) == {"A": "single", "B": "double"}
+
+
+def test_env_value_prefers_the_process_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A value exported in the shell wins over one sitting in .env."""
+    monkeypatch.setenv("OPENAI_API_KEY", "from-shell")
+    assert (
+        env_value("OPENAI_API_KEY", {"OPENAI_API_KEY": "from-dotenv"}) == "from-shell"
+    )
+
+
+def test_env_value_falls_back_to_the_env_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    assert (
+        env_value("OPENAI_API_KEY", {"OPENAI_API_KEY": "from-dotenv"}) == "from-dotenv"
+    )
+
+
+def test_env_value_is_none_when_set_nowhere(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NOT_SET_ANYWHERE", raising=False)
+    assert env_value("NOT_SET_ANYWHERE", {}) is None
+
+
+def test_apply_env_file_does_not_override_the_shell(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Probes that go through a third-party SDK read the real environment.
+
+    Overlaying .env lets them see it, but a value the user exported deliberately
+    must still win.
+    """
+    monkeypatch.setenv("ALREADY_SET", "from-shell")
+    monkeypatch.delenv("ONLY_IN_DOTENV", raising=False)
+
+    apply_env_file({"ALREADY_SET": "from-dotenv", "ONLY_IN_DOTENV": "value"})
+
+    assert os.environ["ALREADY_SET"] == "from-shell"
+    assert os.environ["ONLY_IN_DOTENV"] == "value"


### PR DESCRIPTION
Second of the chain-B PRs. **Stacked on #597** — the diff above contains it until it merges; this PR's own change is the final commit.

Adds `scripts/check_setup.py`: resolves every example against the requirement model, probes this machine, and reports the single first thing in the way of each one — grouped so the biggest wins surface first, and carrying the command that fixes it.

```bash
python scripts/check_setup.py            # what is missing
python scripts/check_setup.py --strict   # exit non-zero if anything is blocked
```

Writes nothing and needs no credentials of its own. Network use is limited to TCP connects, except that resolving Google credentials shells out to `gcloud`.

## Four defects found while building it, fixed here

1. **A wrong `NEO4J_PASSWORD` produced a clean bill of health.** `service_available` only opens a TCP socket, and the APOC and index checks both gate on `authenticated` — so all three silently passed while every Neo4j example failed at runtime. A reachable-but-unauthenticated database is now a blocker in its own right, which also gives `Neo4jState.reachable` and `.error` their first reader.
2. **The missing-index fix advised `setup_examples.py --tier 0`** — a flag that exists nowhere in the repo. Following it gets you `unrecognized arguments`. It now points at the example that creates the index.
3. **The Ollama check only ever suggested pulling the chat model**, though the embedding examples need a different one, so `nomic-embed-text` was never mentioned. Both are reported now.
4. **Azure looked ready when it cannot be.** It declares no env vars and had no probe, so the doctor reported nothing blocking it — but its endpoint and key are hardcoded placeholders in the example file. It now says so.

Each of the four is pinned by a test; the first was confirmed to fail against the code without the fix.

## Type of Change
- [x] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Medium

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [x] Manual tests

13 tests over `blockers_for`, driven through the four probe seams so nothing touches the network or a service. Run against this machine with Neo4j stopped and confirmed it reports blocked rather than passing.

# Checklist

- [ ] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate

🤖 Generated with [Claude Code](https://claude.com/claude-code)