### PR TITLE
Fix e2e tests by waiting for indexes to come online

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -45,7 +45,7 @@ from tenacity import (
     wait_random_exponential,
 )
 
-from ..e2e.utils import EMBEDDING_BIOLOGY
+from ..e2e.utils import EMBEDDING_BIOLOGY, await_index_online
 
 logger = logging.getLogger(__name__)
 
@@ -179,6 +179,9 @@ def setup_neo4j_for_retrieval(driver: Driver) -> None:
         node_properties=["short_text_property"],
     )
 
+    await_index_online(driver, vector_index_name)
+    await_index_online(driver, fulltext_index_name)
+
     # Insert 10 vectors and authors
     vector = [random.random() for _ in range(1536)]
 
@@ -251,6 +254,7 @@ def setup_neo4j_for_kg_construction(driver: Driver) -> None:
         dimensions=3,
         similarity_fn="euclidean",
     )
+    await_index_online(driver, vector_index_name)
 
 
 @pytest.fixture(scope="module")

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -179,6 +179,9 @@ def setup_neo4j_for_retrieval(driver: Driver) -> None:
         node_properties=["short_text_property"],
     )
 
+    # Index creation returns as soon as the schema change commits, but
+    # population runs in the background; querying while still POPULATING
+    # fails, so wait for ONLINE before inserting data or running queries.
     await_index_online(driver, vector_index_name)
     await_index_online(driver, fulltext_index_name)
 
@@ -254,6 +257,7 @@ def setup_neo4j_for_kg_construction(driver: Driver) -> None:
         dimensions=3,
         similarity_fn="euclidean",
     )
+    # wait for ONLINE before the pipeline under test writes to and queries the index
     await_index_online(driver, vector_index_name)
 
 

--- a/tests/e2e/test_search_clause_e2e.py
+++ b/tests/e2e/test_search_clause_e2e.py
@@ -113,7 +113,8 @@ def setup_search_clause_data(driver: Driver) -> None:
             },
         )
 
-    # Wait for the index to come online
+    # index was created before these nodes existed, so it started out
+    # POPULATING; wait for ONLINE before the tests below query it
     await_index_online(driver, INDEX_NAME)
 
 

--- a/tests/e2e/test_search_clause_e2e.py
+++ b/tests/e2e/test_search_clause_e2e.py
@@ -20,7 +20,6 @@ Requires Neo4j 2026.02+ running via:
 
 from __future__ import annotations
 
-import time
 from typing import Any, Generator
 
 import pytest
@@ -30,6 +29,8 @@ from neo4j_graphrag.indexes import create_vector_index, drop_index_if_exists
 from neo4j_graphrag.retrievers import VectorRetriever
 from neo4j_graphrag.types import RetrieverResult, RetrieverResultItem
 from neo4j_graphrag.utils.version_utils import clear_version_cache
+
+from tests.e2e.utils import await_index_online
 
 DIMENSIONS = 5
 INDEX_NAME = "search-clause-e2e-index"
@@ -113,16 +114,7 @@ def setup_search_clause_data(driver: Driver) -> None:
         )
 
     # Wait for the index to come online
-    for _ in range(60):
-        result = driver.execute_query(
-            "SHOW INDEXES YIELD name, state WHERE name = $name RETURN state",
-            {"name": INDEX_NAME},
-        )
-        if result.records and result.records[0]["state"] == "ONLINE":
-            break
-        time.sleep(1)
-    else:
-        raise RuntimeError(f"Index {INDEX_NAME} did not come online within 60s")
+    await_index_online(driver, INDEX_NAME)
 
 
 # -- Tests --

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -17,12 +17,39 @@ from __future__ import annotations
 import hashlib
 import json
 import os.path
+import time
 from typing import Any, Literal
 
 import neo4j
 from neo4j_graphrag.indexes import create_vector_index, drop_index_if_exists
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def await_index_online(
+    neo4j_driver: neo4j.Driver, index_name: str, timeout: int = 60
+) -> None:
+    """Block until ``index_name`` reaches the ONLINE state.
+
+    Index population is asynchronous: creating an index over existing data
+    returns before the index is queryable, and querying it while it is still
+    POPULATING fails with ``Neo.ClientError.Schema.IndexNotFound`` (51N63).
+    Any fixture that creates an index must wait for it before running queries.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        records, _, _ = neo4j_driver.execute_query(
+            "SHOW INDEXES YIELD name, state WHERE name = $name RETURN state",
+            {"name": index_name},
+        )
+        if records and records[0]["state"] == "ONLINE":
+            return
+        if time.monotonic() >= deadline:
+            raise RuntimeError(
+                f"Index {index_name} did not come online within {timeout}s"
+            )
+        time.sleep(0.5)
+
 
 # biology
 EMBEDDING_BIOLOGY = [
@@ -460,6 +487,9 @@ def populate_neo4j(
             dimensions=384,
             similarity_fn="cosine",
         )
+        # the index is created over the nodes inserted above, so it starts out
+        # POPULATING and is not queryable yet
+        await_index_online(neo4j_driver, vector_index_name)
 
     return res
 

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -29,13 +29,7 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 def await_index_online(
     neo4j_driver: neo4j.Driver, index_name: str, timeout: int = 60
 ) -> None:
-    """Block until ``index_name`` reaches the ONLINE state.
-
-    Index population is asynchronous: creating an index over existing data
-    returns before the index is queryable, and querying it while it is still
-    POPULATING fails with ``Neo.ClientError.Schema.IndexNotFound`` (51N63).
-    Any fixture that creates an index must wait for it before running queries.
-    """
+    """Wait until ``index_name`` reaches the ONLINE state."""
     deadline = time.monotonic() + timeout
     while True:
         records, _, _ = neo4j_driver.execute_query(


### PR DESCRIPTION
# Description

Fixes a flaky e2e test: `test_graphrag_v2_e2e.py::test_graphrag_v2_happy_path` intermittently fails with
`Neo.ClientError.Schema.IndexNotFound` — `51N63: Index 'vector-index-name' is not ready yet.`

**Root cause:** `populate_neo4j` in `tests/e2e/utils.py` inserts the Question nodes first, then creates the
vector index over them. `CREATE VECTOR INDEX` returns as soon as the schema transaction commits, but
population runs in the background, so the index is still in `POPULATING` state. The first query against it —
the first test in the module — fails. Nothing waited for the index to reach `ONLINE`. The same latent race
exists in `test_graphrag_e2e.py`, which uses an identical fixture and has just been getting lucky.

**Fix:** added a shared `await_index_online()` helper to `tests/e2e/utils.py` that polls
`SHOW INDEXES ... WHERE name = $name` until the index reports `ONLINE`, raising after a 60s timeout. It is
now called at every point an e2e fixture creates an index:

- `populate_neo4j` (the failing path)
- `setup_neo4j_for_retrieval` - vector + fulltext indexes
- `setup_neo4j_for_kg_construction`

`test_search_clause_e2e.py` already contained this exact wait loop inline; it now uses the shared helper, so
the polling query is unchanged from code already passing in CI.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Low

## How Has This Been Tested?
- [ ] Unit tests
- [x] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] Unit tests have been updated
- [x] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate