### PR TITLE
feat(scripts): add an installer that walks through the missing pieces

### DIFF
--- a/scripts/examples_setup/__init__.py
+++ b/scripts/examples_setup/__init__.py
@@ -34,3 +34,5 @@ import example_requirements as reqs  # noqa: E402
 
 REPO_ROOT = reqs.REPO_ROOT
 ENV_FILE = REPO_ROOT / ".env"
+ENV_TEMPLATE = REPO_ROOT / "examples" / ".env.example"
+COMPOSE_FILE = REPO_ROOT / "tests" / "e2e" / "docker-compose.yml"

--- a/scripts/examples_setup/cloud.py
+++ b/scripts/examples_setup/cloud.py
@@ -1,0 +1,86 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Vertex AI, Bedrock and Azure OpenAI: the cloud logins.
+
+Each vendor's CLI owns its own login flow, so this only offers to run it and
+records the one value the examples read from the environment, the GCP project.
+"""
+
+from __future__ import annotations
+
+from .console import BOLD, GREEN, colour, confirm, heading, run_command
+from .envfile import write_env_var
+from .probes import command_exists
+from .providers import PROVIDERS
+
+
+def cloud_logins(assume_yes: bool) -> None:
+    heading("Cloud providers")
+    print(
+        "Vertex AI, Bedrock and Azure OpenAI all need a cloud account. If you "
+        "only want Gemini models, an AI Studio key is free and simpler."
+    )
+    print()
+    for key in ("vertexai", "bedrock", "azure"):
+        print(f"   {PROVIDERS[key].label}: {PROVIDERS[key].free_tier}")
+
+    if confirm("   Set up Google Cloud (Vertex AI) now?", False, assume_yes):
+        _google(assume_yes)
+
+    if confirm("   Set up AWS (Bedrock) now?", False, assume_yes):
+        if command_exists("aws"):
+            run_command(["aws", "configure"])
+            run_command(["aws", "sts", "get-caller-identity"])
+        else:
+            print("   install the AWS CLI: https://aws.amazon.com/cli/")
+
+    if confirm("   Set up Azure now?", False, assume_yes):
+        if command_exists("az"):
+            run_command(["az", "login"])
+            run_command(["az", "account", "show"])
+        else:
+            print("   install the Azure CLI: https://learn.microsoft.com/cli/azure/")
+
+    for key in ("bedrock", "azure"):
+        provider = PROVIDERS[key]
+        if provider.manual:
+            print()
+            print(colour(f"-- {provider.label}: manual step", BOLD))
+            print(f"   {provider.manual}")
+
+
+def _google(assume_yes: bool) -> None:
+    if not command_exists("gcloud"):
+        print("   install the gcloud CLI: https://cloud.google.com/sdk/docs/install")
+        return
+
+    run_command(["gcloud", "auth", "application-default", "login"])
+    if assume_yes:
+        # --non-interactive promises never to prompt, and there is no sensible
+        # default for a project id.
+        return
+    try:
+        project = input("   GCP project id: ").strip()
+    except EOFError:
+        return
+    if not project:
+        return
+
+    run_command(["gcloud", "config", "set", "project", project])
+    run_command(["gcloud", "auth", "application-default", "set-quota-project", project])
+    # A project id is not a secret, but it is environment-specific; store it in
+    # .env rather than anywhere tracked.
+    write_env_var("GOOGLE_CLOUD_PROJECT", project)
+    print(colour("   wrote GOOGLE_CLOUD_PROJECT to .env", GREEN))

--- a/scripts/examples_setup/console.py
+++ b/scripts/examples_setup/console.py
@@ -16,6 +16,11 @@
 
 from __future__ import annotations
 
+import subprocess
+from typing import Sequence
+
+from . import REPO_ROOT
+
 import sys
 
 
@@ -31,3 +36,29 @@ def colour(text: str, code: str) -> str:
     if not sys.stdout.isatty():
         return text
     return f"{code}{text}{RESET}"
+
+
+def confirm(question: str, default: bool = True, assume_yes: bool = False) -> bool:
+    if assume_yes:
+        return default
+    suffix = "[Y/n]" if default else "[y/N]"
+    try:
+        answer = input(f"{question} {suffix} ").strip().lower()
+    except EOFError:
+        return default
+    if not answer:
+        return default
+    return answer.startswith("y")
+
+
+def run_command(command: Sequence[str], check: bool = False) -> int:
+    print(colour(f"  $ {' '.join(command)}", DIM))
+    result = subprocess.run(list(command), cwd=REPO_ROOT)
+    if check and result.returncode != 0:
+        print(colour(f"  command failed ({result.returncode})", RED))
+    return result.returncode
+
+
+def heading(text: str) -> None:
+    print()
+    print(colour(f"== {text}", BOLD))

--- a/scripts/examples_setup/doctor.py
+++ b/scripts/examples_setup/doctor.py
@@ -66,7 +66,7 @@ def blockers_for(
                 found.append(
                     Blocker(
                         f"{name} not set",
-                        f"export {name}=..., or add it to .env",
+                        f"setup_examples.py --provider {provider_key}",
                     )
                 )
         if provider.credential_probe is not None:

--- a/scripts/examples_setup/envfile.py
+++ b/scripts/examples_setup/envfile.py
@@ -56,3 +56,54 @@ def apply_env_file(env_file: dict[str, str]) -> None:
     for name, value in env_file.items():
         if value and name not in os.environ:
             os.environ[name] = value
+
+
+def mask(value: str) -> str:
+    """Show just enough to recognise a key, never enough to use it."""
+    if len(value) <= 8:
+        return "*" * len(value)
+    return f"{'*' * 8}{value[-4:]}"
+
+
+def write_env_var(name: str, value: str, path: Path = ENV_FILE) -> None:
+    """Set one variable in .env, preserving everything else. Mode 0600.
+
+    Also matches the commented-out placeholder the template ships, so setting a
+    key replaces its placeholder in place rather than appending a duplicate.
+    """
+    lines = path.read_text().splitlines() if path.exists() else []
+    replaced = False
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        # One leading '#' is the template's own placeholder. More than one is a
+        # deliberate comment, so leave it alone rather than overwrite it.
+        commented = stripped[1:].strip() if stripped.startswith("#") else stripped
+        if stripped.startswith(f"{name}=") or commented.startswith(f"{name}="):
+            lines[index] = f"{name}={value}"
+            replaced = True
+            break
+    if not replaced:
+        if lines and lines[-1].strip():
+            lines.append("")
+        lines.append(f"{name}={value}")
+
+    _write_private(path, "\n".join(lines) + "\n")
+
+
+def _write_private(path: Path, content: str) -> None:
+    """Replace path's contents, never leaving a secret readable by anyone else.
+
+    Written through a temp file in the same directory so an interrupted write
+    cannot truncate the credentials already in place, and created at 0600 up
+    front - creating first and chmod-ing after leaves the secret world-readable
+    for the window in between.
+    """
+    tmp = path.with_name(f".{path.name}.tmp")
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "w") as handle:
+            handle.write(content)
+        os.replace(tmp, path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise

--- a/scripts/examples_setup/installer.py
+++ b/scripts/examples_setup/installer.py
@@ -1,0 +1,202 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Walk through installing what is missing, in tiers."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from getpass import getpass
+from typing import Optional
+
+import example_requirements as reqs
+
+from . import COMPOSE_FILE, ENV_FILE, ENV_TEMPLATE
+from .console import BOLD, GREEN, RED, YELLOW, colour, confirm, heading, run_command
+from .envfile import env_value, mask, read_env_file, write_env_var
+from .probes import command_exists, probe_neo4j
+from .providers import (
+    LOCAL_FULLTEXT_INDEXES,
+    LOCAL_INDEXES,
+    PROVIDERS,
+    TIER_NAMES,
+    Provider,
+)
+
+
+def tier_0_base(assume_yes: bool) -> None:
+    heading(f"Tier 0: {TIER_NAMES[0]}")
+
+    if confirm(
+        "Install all Python extras with uv sync --all-extras?", True, assume_yes
+    ):
+        if command_exists("uv"):
+            run_command(["uv", "sync", "--all-extras", "--group", "dev"])
+        else:
+            print(colour("  uv not found - see https://docs.astral.sh/uv/", RED))
+
+    if not ENV_FILE.exists() and ENV_TEMPLATE.exists():
+        if confirm("Create .env from examples/.env.example?", True, assume_yes):
+            ENV_FILE.write_text(ENV_TEMPLATE.read_text())
+            ENV_FILE.chmod(0o600)
+            print(f"  wrote {ENV_FILE} (mode 0600, gitignored)")
+
+    if not reqs.service_available(reqs.NEO4J_LOCAL):
+        if confirm("Start local Neo4j with Docker Compose?", True, assume_yes):
+            if not command_exists("docker"):
+                print(colour("  docker not found", RED))
+            else:
+                run_command(
+                    ["docker", "compose", "-f", str(COMPOSE_FILE), "up", "-d", "neo4j"]
+                )
+                print("  waiting for Neo4j to accept connections...")
+                _wait_for(reqs.NEO4J_LOCAL, attempts=30)
+    else:
+        print("  local Neo4j already reachable")
+
+    env_file = read_env_file()
+    state = probe_neo4j(env_file)
+    if state.authenticated:
+        missing_vector = [i for i in LOCAL_INDEXES if i[0] not in state.indexes]
+        missing_fulltext = [
+            i for i in LOCAL_FULLTEXT_INDEXES if i[0] not in state.indexes
+        ]
+        if missing_vector or missing_fulltext:
+            names = [i[0] for i in missing_vector] + [i[0] for i in missing_fulltext]
+            if confirm(f"Create missing indexes {', '.join(names)}?", True, assume_yes):
+                _create_indexes(env_file, missing_vector, missing_fulltext)
+        else:
+            print("  all expected indexes already exist")
+    elif state.reachable:
+        print(colour(f"  could not authenticate: {state.error}", YELLOW))
+
+
+def _wait_for(service: str, attempts: int = 30, delay: float = 2.0) -> bool:
+    import time
+
+    host, port = reqs.SERVICE_ENDPOINTS[service]
+    for _ in range(attempts):
+        if reqs.port_open(host, port):
+            print(colour(f"  {service} is up", GREEN))
+            return True
+        time.sleep(delay)
+    print(colour(f"  {service} did not come up in time", RED))
+    return False
+
+
+def _create_indexes(
+    env_file: dict[str, str],
+    vector: list[tuple[str, str, str, int]],
+    fulltext: list[tuple[str, str, str]],
+) -> None:
+    """Create the indexes examples assume exist.
+
+    Uses the library's own helpers so the index definitions match what the
+    retrievers expect, rather than hand-written Cypher that could drift.
+    """
+    try:
+        import neo4j
+        from neo4j_graphrag.indexes import create_fulltext_index, create_vector_index
+    except ImportError as exc:
+        print(colour(f"  cannot create indexes yet ({exc}); run uv sync first", YELLOW))
+        return
+
+    uri = env_value("NEO4J_URI", env_file) or "bolt://localhost:7687"
+    user = env_value("NEO4J_USER", env_file) or "neo4j"
+    password = env_value("NEO4J_PASSWORD", env_file) or "password"
+    with neo4j.GraphDatabase.driver(uri, auth=(user, password)) as driver:
+        for name, label, prop, dimensions in vector:
+            create_vector_index(
+                driver,
+                name,
+                label=label,
+                embedding_property=prop,
+                dimensions=dimensions,
+                similarity_fn="cosine",
+                fail_if_exists=False,
+            )
+            print(colour(f"  created vector index {name}", GREEN))
+        for name, label, prop in fulltext:
+            create_fulltext_index(
+                driver, name, label=label, node_properties=[prop], fail_if_exists=False
+            )
+            print(colour(f"  created fulltext index {name}", GREEN))
+
+
+def configure_provider(provider: Provider, assume_yes: bool) -> None:
+    """Prompt for, validate and store one provider's key."""
+    env_file = read_env_file()
+    name = provider.env_vars[0]
+    existing = env_value(name, env_file)
+
+    print()
+    print(colour(f"-- {provider.label}", BOLD))
+    if provider.free_tier:
+        print(f"   {provider.free_tier}")
+    if provider.manual:
+        print(colour(f"   note: {provider.manual}", YELLOW))
+
+    if existing:
+        print(f"   {name} is already set ({mask(existing)})")
+        if provider.validator:
+            ok, detail = provider.validator(existing)
+            print(
+                f"   validation: {colour('ok', GREEN) if ok else colour(detail, RED)}"
+            )
+            if ok and not confirm("   Replace it anyway?", False, assume_yes):
+                return
+        elif not confirm("   Replace it?", False, assume_yes):
+            return
+    elif not confirm(f"   Set up {provider.label} now?", True, assume_yes):
+        return
+
+    if provider.signup_url:
+        print(f"   get a key at: {provider.signup_url}")
+        if not assume_yes and sys.platform == "darwin":
+            if confirm("   Open that page in your browser?", True, assume_yes):
+                subprocess.run(["open", provider.signup_url])
+
+    if assume_yes:
+        print("   non-interactive: cannot prompt for a key, skipping")
+        return
+
+    # No echo: the key must not land in scrollback or a screen recording.
+    key = getpass(f"   paste {name} (input hidden, blank to skip): ").strip()
+    if not key:
+        print("   skipped")
+        return
+
+    if provider.validator:
+        ok, detail = provider.validator(key)
+        if not ok:
+            # An invalid key is never written - a bad value in .env is worse
+            # than none, because it turns a clear "unset" into a confusing 401.
+            print(colour(f"   rejected: {detail} - not written to .env", RED))
+            return
+        print(colour("   validated", GREEN))
+
+    write_env_var(name, key)
+    print(colour(f"   wrote {name}={mask(key)} to .env (mode 0600)", GREEN))
+
+
+def tier_1_keys(assume_yes: bool, only: Optional[str]) -> None:
+    heading(f"Tier 1: {TIER_NAMES[1]}")
+    print("Free without a credit card: Gemini, Cohere, Mistral.")
+    for provider in PROVIDERS.values():
+        if provider.tier != 1 or not provider.env_vars:
+            continue
+        if only and provider.key != only:
+            continue
+        configure_provider(provider, assume_yes)

--- a/scripts/examples_setup/providers.py
+++ b/scripts/examples_setup/providers.py
@@ -22,6 +22,9 @@ login, an AWS named profile - carry a probe instead.
 from __future__ import annotations
 
 import subprocess
+import urllib.error
+import urllib.parse
+import urllib.request
 from functools import cache
 from dataclasses import dataclass
 from typing import Callable, Optional
@@ -40,6 +43,9 @@ class Provider:
     signup_url: Optional[str] = None
     free_tier: str = ""
     manual: str = ""
+    # Returns (ok, detail). Uses a list-models call: free, and it proves the key
+    # is live rather than merely well-formed.
+    validator: Optional[Callable[[str], tuple[bool, str]]] = None
     # For providers whose credentials do not live in an env var (a cloud CLI
     # login, a named profile). Returns (ok, how to fix it).
     credential_probe: Optional[Callable[[], tuple[bool, str]]] = None
@@ -90,12 +96,71 @@ def _probe_azure() -> tuple[bool, str]:
     )
 
 
+def _http_check(
+    url: str, headers: dict[str, str], timeout: float = 15.0
+) -> tuple[bool, str]:
+    request = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return response.status == 200, f"HTTP {response.status}"
+    except urllib.error.HTTPError as exc:
+        hint = {
+            401: "key rejected",
+            403: "key lacks permission",
+            429: "rate limited - the key is valid",
+        }.get(exc.code, f"HTTP {exc.code}")
+        # A rate limit still proves the key authenticates.
+        return exc.code == 429, hint
+    except urllib.error.URLError as exc:
+        # Host only, never the full URL: these strings are printed, and a URL can
+        # carry a credential in its query string.
+        host = urllib.parse.urlsplit(url).netloc
+        return False, f"could not reach {host}: {exc.reason}"
+    except OSError as exc:  # pragma: no cover - network shapes vary
+        return False, str(exc)
+
+
+def _validate_openai(key: str) -> tuple[bool, str]:
+    return _http_check(
+        "https://api.openai.com/v1/models", {"Authorization": f"Bearer {key}"}
+    )
+
+
+def _validate_anthropic(key: str) -> tuple[bool, str]:
+    return _http_check(
+        "https://api.anthropic.com/v1/models",
+        {"x-api-key": key, "anthropic-version": "2023-06-01"},
+    )
+
+
+def _validate_gemini(key: str) -> tuple[bool, str]:
+    # Header, not ?key=: a query string is logged by every proxy in the path and
+    # by Google's own front end.
+    return _http_check(
+        "https://generativelanguage.googleapis.com/v1beta/models",
+        {"x-goog-api-key": key},
+    )
+
+
+def _validate_cohere(key: str) -> tuple[bool, str]:
+    return _http_check(
+        "https://api.cohere.com/v1/models", {"Authorization": f"Bearer {key}"}
+    )
+
+
+def _validate_mistral(key: str) -> tuple[bool, str]:
+    return _http_check(
+        "https://api.mistral.ai/v1/models", {"Authorization": f"Bearer {key}"}
+    )
+
+
 PROVIDERS: dict[str, Provider] = {
     "openai": Provider(
         key="openai",
         label="OpenAI",
         tier=1,
         env_vars=("OPENAI_API_KEY",),
+        validator=_validate_openai,
         signup_url="https://platform.openai.com/api-keys",
         free_tier="No free tier - the key is billed per token.",
     ),
@@ -104,6 +169,7 @@ PROVIDERS: dict[str, Provider] = {
         label="Google Gemini (AI Studio)",
         tier=1,
         env_vars=("GOOGLE_API_KEY",),
+        validator=_validate_gemini,
         signup_url="https://aistudio.google.com/apikey",
         free_tier=(
             "Free, no credit card: about 1,500 requests/day and 15 rpm on 2.5 "
@@ -116,6 +182,7 @@ PROVIDERS: dict[str, Provider] = {
         label="Cohere",
         tier=1,
         env_vars=("CO_API_KEY",),
+        validator=_validate_cohere,
         signup_url="https://dashboard.cohere.com/api-keys",
         free_tier=(
             "Free trial key, no credit card: 1,000 calls/month, 20 rpm chat and "
@@ -127,6 +194,7 @@ PROVIDERS: dict[str, Provider] = {
         label="Mistral AI",
         tier=1,
         env_vars=("MISTRAL_API_KEY",),
+        validator=_validate_mistral,
         signup_url="https://console.mistral.ai/api-keys",
         free_tier=(
             "Free 'Experiment' tier, no credit card but phone verification is "
@@ -138,6 +206,7 @@ PROVIDERS: dict[str, Provider] = {
         label="Anthropic",
         tier=1,
         env_vars=("ANTHROPIC_API_KEY",),
+        validator=_validate_anthropic,
         signup_url="https://console.anthropic.com/settings/keys",
         free_tier="No free tier - the account needs purchased credits.",
     ),
@@ -244,3 +313,21 @@ PROVIDERS: dict[str, Provider] = {
 # them runnable with no arguments.
 OLLAMA_CHAT_MODEL = "llama3.2"
 OLLAMA_EMBED_MODEL = "nomic-embed-text"
+
+TIER_NAMES = {
+    0: "base - Python extras, local Neo4j, indexes",
+    1: "API keys - free tiers first",
+    2: "local runtimes - Ollama, local models, vector stores",
+    3: "cloud - Vertex AI, Bedrock, Azure OpenAI",
+}
+
+# Indexes the examples expect to already exist on the local database. Only the
+# ones nothing else creates: vector_index and fulltext_index are what
+# examples/database_operations/create_*_index.py exist to demonstrate.
+LOCAL_INDEXES: list[tuple[str, str, str, int]] = [
+    # (name, label, property, dimensions)
+    ("moviePlotsEmbedding", "Movie", "plotEmbedding", 1536),
+]
+LOCAL_FULLTEXT_INDEXES: list[tuple[str, str, str]] = [
+    ("movieFulltext", "Movie", "title"),
+]

--- a/scripts/setup_examples.py
+++ b/scripts/setup_examples.py
@@ -1,0 +1,102 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Walk through getting an environment together for running the examples.
+
+    python scripts/setup_examples.py                  # walk through everything
+    python scripts/setup_examples.py --provider gemini # just one provider's key
+    python scripts/check_setup.py                     # what is still missing
+
+Works in tiers, so the free and local providers work before any cloud account is
+involved: Python extras and a local Neo4j first, then API keys, then the cloud
+logins. Every step is skippable and safe to re-run.
+
+Keys are read with no terminal echo, validated against the provider with a free
+list-models call, and written only to a gitignored ``.env`` created at mode 0600.
+A key that does not validate is never written - a bad value there turns a clear
+"unset" into a confusing 401 later. Nothing is ever printed in full.
+
+``scripts/check_setup.py`` reports what is missing without changing anything;
+run it first if you only want to know where you stand.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from examples_setup import ENV_FILE  # noqa: E402
+from examples_setup.cloud import cloud_logins  # noqa: E402
+from examples_setup.console import BOLD, DIM, colour  # noqa: E402
+from examples_setup.installer import tier_0_base, tier_1_keys  # noqa: E402
+from examples_setup.providers import PROVIDERS  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--provider",
+        help="only configure this provider's API key, e.g. gemini",
+    )
+    parser.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="never prompt; take the default for every question",
+    )
+    args = parser.parse_args()
+
+    if args.provider and args.provider not in PROVIDERS:
+        print(f"unknown provider '{args.provider}'", file=sys.stderr)
+        print(f"choose from: {', '.join(sorted(PROVIDERS))}", file=sys.stderr)
+        return 2
+
+    assume_yes = bool(args.non_interactive)
+    print(colour("neo4j-graphrag examples setup", BOLD))
+    print(
+        colour(
+            f"Keys are written only to {ENV_FILE.name} (mode 0600, gitignored) "
+            "and never printed in full.",
+            DIM,
+        )
+    )
+
+    if args.provider:
+        # Narrowing to one provider only makes sense for the key step.
+        tier_1_keys(assume_yes, args.provider)
+    else:
+        tier_0_base(assume_yes)
+        tier_1_keys(assume_yes, None)
+        cloud_logins(assume_yes)
+
+    print()
+    print(colour("Done. Check the result with:", BOLD))
+    print("  python scripts/check_setup.py")
+    print()
+    print(
+        colour(
+            "Most examples read the environment directly, so export .env "
+            "before running one:\n  set -a; source .env; set +a",
+            DIM,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/test_doctor.py
+++ b/tests/unit/scripts/test_doctor.py
@@ -83,14 +83,18 @@ def test_an_unset_env_var_is_reported(monkeypatch: pytest.MonkeyPatch) -> None:
     assert found == ["OPENAI_API_KEY not set"]
 
 
-def test_the_env_var_fix_does_not_name_a_command_that_does_not_exist(
+def test_the_env_var_fix_points_at_the_installer(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The installer is a separate tool; do not advise a flag we do not ship."""
+    """Now that the installer ships, the doctor can hand the user straight to it.
+
+    Every fix string must name a command that exists - before the installer
+    landed this advised `--provider`, which nothing implemented.
+    """
     monkeypatch.setattr(doctor, "env_value", lambda name, env_file: None)
     requirement = reqs.ExampleRequirements(path=FAKE, providers={"openai"})
     fixes = [b.fix for b in doctor.blockers_for(requirement, {}, healthy_neo4j())]
-    assert "--provider" not in " ".join(fixes)
+    assert "setup_examples.py --provider openai" in " ".join(fixes)
 
 
 def test_an_unreachable_service_is_reported(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/scripts/test_envfile.py
+++ b/tests/unit/scripts/test_envfile.py
@@ -12,7 +12,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-"""Unit tests for reading the examples' .env file.
+"""Unit tests for the examples' .env file.
 
 Every test passes an explicit path. The module's defaults point at the
 developer's real .env, and a test that forgot would read it.
@@ -25,7 +25,13 @@ import tempfile
 from pathlib import Path
 
 import pytest
-from examples_setup.envfile import apply_env_file, env_value, read_env_file
+from examples_setup.envfile import (
+    apply_env_file,
+    env_value,
+    mask,
+    read_env_file,
+    write_env_var,
+)
 
 
 def test_read_env_file_ignores_comments_and_blanks() -> None:
@@ -84,3 +90,101 @@ def test_apply_env_file_does_not_override_the_shell(
 
     assert os.environ["ALREADY_SET"] == "from-shell"
     assert os.environ["ONLY_IN_DOTENV"] == "value"
+
+
+SECRET = "sk-test-0123456789abcdef"
+
+
+def test_a_new_env_file_is_never_world_readable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The secret must not exist on disk at default permissions, even briefly.
+
+    Regression: the file was created by write_text() and chmod-ed afterwards, so
+    a fresh .env held the key at 0644 until the next statement ran. Asserting the
+    final mode cannot see that window - both versions end at 0600 - so this
+    forbids the fixup instead: the mode has to be right at creation.
+    """
+
+    def no_chmod(*args: object, **kwargs: object) -> None:
+        raise AssertionError("mode must be set when the file is created")
+
+    monkeypatch.setattr(Path, "chmod", no_chmod)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / ".env"
+        write_env_var("OPENAI_API_KEY", SECRET, path)
+        assert path.stat().st_mode & 0o777 == 0o600
+        assert path.read_text().strip() == f"OPENAI_API_KEY={SECRET}"
+
+
+def test_an_existing_env_file_stays_private() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / ".env"
+        write_env_var("OPENAI_API_KEY", SECRET, path)
+        write_env_var("COHERE_API_KEY", "co-second", path)
+        assert path.stat().st_mode & 0o777 == 0o600
+
+
+def test_no_temp_file_is_left_behind() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        directory = Path(tmpdir)
+        write_env_var("OPENAI_API_KEY", SECRET, directory / ".env")
+        assert [p.name for p in directory.iterdir()] == [".env"]
+
+
+def test_other_variables_are_preserved() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / ".env"
+        path.write_text("NEO4J_URI=bolt://localhost:7687\nNEO4J_USER=neo4j\n")
+        write_env_var("OPENAI_API_KEY", SECRET, path)
+        values = read_env_file(path)
+        assert values["NEO4J_URI"] == "bolt://localhost:7687"
+        assert values["NEO4J_USER"] == "neo4j"
+        assert values["OPENAI_API_KEY"] == SECRET
+
+
+def test_the_commented_placeholder_is_replaced_in_place() -> None:
+    """The template ships '# OPENAI_API_KEY=', which must not be duplicated."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / ".env"
+        path.write_text("# OPENAI_API_KEY=\nNEO4J_USER=neo4j\n")
+        write_env_var("OPENAI_API_KEY", SECRET, path)
+        lines = path.read_text().splitlines()
+        assert lines == [f"OPENAI_API_KEY={SECRET}", "NEO4J_USER=neo4j"]
+
+
+def test_a_deliberately_commented_out_line_is_not_overwritten() -> None:
+    """One '#' is the template's placeholder; two is somebody's decision."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / ".env"
+        path.write_text("## OPENAI_API_KEY=do-not-use\n")
+        write_env_var("OPENAI_API_KEY", SECRET, path)
+        lines = path.read_text().splitlines()
+        assert "## OPENAI_API_KEY=do-not-use" in lines
+        assert f"OPENAI_API_KEY={SECRET}" in lines
+
+
+def test_setting_the_same_variable_twice_does_not_duplicate_it() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / ".env"
+        write_env_var("OPENAI_API_KEY", "first", path)
+        write_env_var("OPENAI_API_KEY", "second", path)
+        contents = path.read_text()
+        assert contents.count("OPENAI_API_KEY=") == 1
+        assert read_env_file(path)["OPENAI_API_KEY"] == "second"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "sk-proj-abcdefghijklmnop",
+        "short",
+        "",
+        "12345678",
+    ],
+)
+def test_mask_never_reveals_more_than_the_last_four_characters(value: str) -> None:
+    masked = mask(value)
+    assert value not in masked or value == ""
+    assert masked.replace("*", "") == (value[-4:] if len(value) > 8 else "")

--- a/tests/unit/scripts/test_providers.py
+++ b/tests/unit/scripts/test_providers.py
@@ -1,0 +1,141 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for provider key validation.
+
+The validators are the only place an API key is handled, so what they put in a
+returned string matters: the installer prints those strings. Nothing here
+performs real network I/O - urlopen is always replaced.
+"""
+
+from __future__ import annotations
+
+import urllib.error
+import urllib.request
+from typing import Any, Iterator
+
+import pytest
+from examples_setup import providers
+
+SECRET = "AIzaSy-super-secret-key-value"
+
+
+class _FakeResponse:
+    def __init__(self, status: int) -> None:
+        self.status = status
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        return None
+
+
+@pytest.fixture(autouse=True)
+def no_real_requests(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Fail loudly if a test reaches the network without saying so."""
+
+    def explode(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("test attempted real network I/O")
+
+    monkeypatch.setattr(urllib.request, "urlopen", explode)
+    yield
+
+
+def test_unreachable_host_never_leaks_the_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The installer prints this string verbatim.
+
+    Regression: the Gemini key travelled in the query string and the error
+    interpolated the whole URL, so any offline/DNS/proxy failure put the key in
+    the user's scrollback.
+    """
+    captured: dict[str, Any] = {}
+
+    def fake_urlopen(request: Any, timeout: float = 0) -> None:
+        captured["request"] = request
+        raise urllib.error.URLError("Name or service not known")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    ok, detail = providers._validate_gemini(SECRET)
+
+    assert ok is False
+    assert SECRET not in detail
+    assert "generativelanguage.googleapis.com" in detail
+
+
+def test_gemini_sends_the_key_as_a_header_not_in_the_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A key in a query string is logged by every proxy along the way."""
+    captured: dict[str, Any] = {}
+
+    def fake_urlopen(request: Any, timeout: float = 0) -> _FakeResponse:
+        captured["url"] = request.full_url
+        captured["headers"] = request.headers
+        return _FakeResponse(200)
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    ok, _ = providers._validate_gemini(SECRET)
+
+    assert ok is True
+    assert SECRET not in captured["url"]
+    assert SECRET in captured["headers"].values()
+
+
+@pytest.mark.parametrize(
+    "status,expected_ok",
+    [
+        (401, False),
+        (403, False),
+        (429, True),  # rate limited still proves the key authenticates
+        (500, False),
+    ],
+)
+def test_http_error_codes(
+    monkeypatch: pytest.MonkeyPatch, status: int, expected_ok: bool
+) -> None:
+    def fake_urlopen(request: Any, timeout: float = 0) -> None:
+        raise urllib.error.HTTPError("url", status, "err", {}, None)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    ok, detail = providers._validate_gemini(SECRET)
+
+    assert ok is expected_ok
+    assert SECRET not in detail
+
+
+def test_every_validator_keeps_the_key_out_of_its_detail_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Whatever a provider's validator returns, it gets printed."""
+
+    def fake_urlopen(request: Any, timeout: float = 0) -> None:
+        raise urllib.error.URLError("boom")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    validators = [
+        provider.validator
+        for provider in providers.PROVIDERS.values()
+        if provider.validator is not None
+    ]
+    assert validators, "expected at least one provider with a validator"
+    for validator in validators:
+        _, detail = validator(SECRET)
+        assert SECRET not in detail


### PR DESCRIPTION
Third of the chain-B PRs. **Stacked on #599** — the diff above contains #597 and #599 until they merge; this PR's own change is the final commit.

`check_setup.py` (#599) reports what is missing. This walks through providing it.

Works in tiers, so the free and local providers work before any cloud account is involved: Python extras and a local Neo4j first, then API keys, then the cloud logins. Every step is skippable and safe to re-run.

## Credentials

Keys are read with no terminal echo, validated against the provider with a free list-models call, and written only to a gitignored `.env`.

Two details worth calling out:

- **The file is created at mode 0600**, not created and then chmod-ed, so the secret never exists on disk world-readable — not even briefly. Asserting the *final* mode cannot catch that window, so the test forbids the chmod fixup instead.
- **It is written through a temp file and `os.replace`**, so an interrupted write cannot truncate the credentials already there.

A key that does not validate is never written: a bad value turns a clear "unset" into a confusing 401 later. Nothing is printed in full.

## Note on the diff

The doctor's unset-key fix string changes here, from `export NAME=...` to naming this installer — which is why the test pinning that string changes too. Every fix string the doctor prints has to name a command that actually exists at that point in the stack.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Medium

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [x] Manual tests

Confirmed the OpenAI validator rejects a bogus key and writes nothing, and that an unknown `--provider` exits 2. Green on ruff, mypy --strict and the unit suite.

# Checklist

- [ ] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate

🤖 Generated with [Claude Code](https://claude.com/claude-code)