### PR TITLE
ci: stop a half-installed venv cache from failing later runs

### DIFF
--- a/.github/workflows/pr-e2e-tests.yaml
+++ b/.github/workflows/pr-e2e-tests.yaml
@@ -89,19 +89,29 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Set up uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-      - name: Load cached venv
+      # restore/save rather than the combined cache action, so the save can be
+      # made conditional. The combined action saves in a post step that also runs
+      # when the job was cancelled or failed, which publishes a half-installed
+      # .venv under a key derived from uv.lock alone. Every later run with that
+      # lock then restores it, and an exact key hit suppresses the save, so the
+      # bad entry is never replaced - it has to be deleted by hand.
+      - name: Restore cached venv
         id: cached-venv
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .venv
           key: ${{ runner.os }}-venv-${{ matrix.python-version }}-${{ hashFiles('**/uv.lock') }}
-      # The install is deliberately not conditional on the cache. A restored .venv
-      # that is missing packages - from a cache saved by an interrupted install,
-      # say - would otherwise be used as-is, and the failure surfaces much later
-      # as an ImportError inside a test. uv sync takes a few seconds when the
-      # environment is already correct, and repairs it when it is not.
+      # Unconditional: a restored .venv that is missing packages would otherwise
+      # be trusted, and the failure surfaces much later as an ImportError inside
+      # a test. uv sync is quick when the environment is already correct.
       - name: Install dependencies
         run: uv sync --frozen --all-extras --group dev
+      - name: Save cached venv
+        if: steps.cached-venv.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .venv
+          key: ${{ runner.os }}-venv-${{ matrix.python-version }}-${{ hashFiles('**/uv.lock') }}
       - name: Show disk usage after dependency installation
         run: |
           df -h

--- a/.github/workflows/pr-e2e-tests.yaml
+++ b/.github/workflows/pr-e2e-tests.yaml
@@ -95,8 +95,12 @@ jobs:
         with:
           path: .venv
           key: ${{ runner.os }}-venv-${{ matrix.python-version }}-${{ hashFiles('**/uv.lock') }}
+      # The install is deliberately not conditional on the cache. A restored .venv
+      # that is missing packages - from a cache saved by an interrupted install,
+      # say - would otherwise be used as-is, and the failure surfaces much later
+      # as an ImportError inside a test. uv sync takes a few seconds when the
+      # environment is already correct, and repairs it when it is not.
       - name: Install dependencies
-        if: steps.cached-venv.outputs.cache-hit != 'true'
         run: uv sync --frozen --all-extras --group dev
       - name: Show disk usage after dependency installation
         run: |

--- a/.github/workflows/pr-e2e-tests.yaml
+++ b/.github/workflows/pr-e2e-tests.yaml
@@ -89,12 +89,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Set up uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-      # restore/save rather than the combined cache action, so the save can be
-      # made conditional. The combined action saves in a post step that also runs
-      # when the job was cancelled or failed, which publishes a half-installed
-      # .venv under a key derived from uv.lock alone. Every later run with that
-      # lock then restores it, and an exact key hit suppresses the save, so the
-      # bad entry is never replaced - it has to be deleted by hand.
+      # Split the combined cache action into restore here and a gated save
+      # below: the combined action's post step also ran when the job failed or
+      # was cancelled, publishing a half-installed .venv under an exact key
+      # derived from uv.lock alone that every later run restored.
       - name: Restore cached venv
         id: cached-venv
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -30,8 +30,12 @@ jobs:
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/uv.lock') }}
+      # The install is deliberately not conditional on the cache. A restored .venv
+      # that is missing packages - from a cache saved by an interrupted install,
+      # say - would otherwise be used as-is, and the failure surfaces much later
+      # as an ImportError inside a test. uv sync takes a few seconds when the
+      # environment is already correct, and repairs it when it is not.
       - name: Install dependencies
-        if: steps.cached-venv.outputs.cache-hit != 'true'
         run: uv sync --frozen --all-extras --group dev
       - name: Download SpaCy model
         if: matrix.python-version != '3.14'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -24,12 +24,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Set up uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-      # restore/save rather than the combined cache action, so the save can be
-      # made conditional. The combined action saves in a post step that also runs
-      # when the job was cancelled or failed, which publishes a half-installed
-      # .venv under a key derived from uv.lock alone. Every later run with that
-      # lock then restores it, and an exact key hit suppresses the save, so the
-      # bad entry is never replaced - it has to be deleted by hand.
+      # Split the combined cache action into restore here and a gated save
+      # below: the combined action's post step also ran when the job failed or
+      # was cancelled, publishing a half-installed .venv under an exact key
+      # derived from uv.lock alone that every later run restored.
       - name: Restore cached venv
         id: cached-venv
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -24,19 +24,29 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Set up uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-      - name: Load cached venv
+      # restore/save rather than the combined cache action, so the save can be
+      # made conditional. The combined action saves in a post step that also runs
+      # when the job was cancelled or failed, which publishes a half-installed
+      # .venv under a key derived from uv.lock alone. Every later run with that
+      # lock then restores it, and an exact key hit suppresses the save, so the
+      # bad entry is never replaced - it has to be deleted by hand.
+      - name: Restore cached venv
         id: cached-venv
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/uv.lock') }}
-      # The install is deliberately not conditional on the cache. A restored .venv
-      # that is missing packages - from a cache saved by an interrupted install,
-      # say - would otherwise be used as-is, and the failure surfaces much later
-      # as an ImportError inside a test. uv sync takes a few seconds when the
-      # environment is already correct, and repairs it when it is not.
+      # Unconditional: a restored .venv that is missing packages would otherwise
+      # be trusted, and the failure surfaces much later as an ImportError inside
+      # a test. uv sync is quick when the environment is already correct.
       - name: Install dependencies
         run: uv sync --frozen --all-extras --group dev
+      - name: Save cached venv
+        if: steps.cached-venv.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/uv.lock') }}
       - name: Download SpaCy model
         if: matrix.python-version != '3.14'
         run: uv pip install "en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl"

--- a/.github/workflows/scheduled-e2e-tests.yaml
+++ b/.github/workflows/scheduled-e2e-tests.yaml
@@ -92,19 +92,29 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Set up uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-      - name: Load cached venv
+      # restore/save rather than the combined cache action, so the save can be
+      # made conditional. The combined action saves in a post step that also runs
+      # when the job was cancelled or failed, which publishes a half-installed
+      # .venv under a key derived from uv.lock alone. Every later run with that
+      # lock then restores it, and an exact key hit suppresses the save, so the
+      # bad entry is never replaced - it has to be deleted by hand.
+      - name: Restore cached venv
         id: cached-venv
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .venv
           key: ${{ runner.os }}-venv-${{ matrix.python-version }}-${{ hashFiles('**/uv.lock') }}
-      # The install is deliberately not conditional on the cache. A restored .venv
-      # that is missing packages - from a cache saved by an interrupted install,
-      # say - would otherwise be used as-is, and the failure surfaces much later
-      # as an ImportError inside a test. uv sync takes a few seconds when the
-      # environment is already correct, and repairs it when it is not.
+      # Unconditional: a restored .venv that is missing packages would otherwise
+      # be trusted, and the failure surfaces much later as an ImportError inside
+      # a test. uv sync is quick when the environment is already correct.
       - name: Install dependencies
         run: uv sync --frozen --all-extras --group dev
+      - name: Save cached venv
+        if: steps.cached-venv.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .venv
+          key: ${{ runner.os }}-venv-${{ matrix.python-version }}-${{ hashFiles('**/uv.lock') }}
       - name: Show disk usage after dependency installation
         run: |
           df -h

--- a/.github/workflows/scheduled-e2e-tests.yaml
+++ b/.github/workflows/scheduled-e2e-tests.yaml
@@ -98,8 +98,12 @@ jobs:
         with:
           path: .venv
           key: ${{ runner.os }}-venv-${{ matrix.python-version }}-${{ hashFiles('**/uv.lock') }}
+      # The install is deliberately not conditional on the cache. A restored .venv
+      # that is missing packages - from a cache saved by an interrupted install,
+      # say - would otherwise be used as-is, and the failure surfaces much later
+      # as an ImportError inside a test. uv sync takes a few seconds when the
+      # environment is already correct, and repairs it when it is not.
       - name: Install dependencies
-        if: steps.cached-venv.outputs.cache-hit != 'true'
         run: uv sync --frozen --all-extras --group dev
       - name: Show disk usage after dependency installation
         run: |

--- a/.github/workflows/scheduled-e2e-tests.yaml
+++ b/.github/workflows/scheduled-e2e-tests.yaml
@@ -92,12 +92,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Set up uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-      # restore/save rather than the combined cache action, so the save can be
-      # made conditional. The combined action saves in a post step that also runs
-      # when the job was cancelled or failed, which publishes a half-installed
-      # .venv under a key derived from uv.lock alone. Every later run with that
-      # lock then restores it, and an exact key hit suppresses the save, so the
-      # bad entry is never replaced - it has to be deleted by hand.
+      # Split the combined cache action into restore here and a gated save
+      # below: the combined action's post step also ran when the job failed or
+      # was cancelled, publishing a half-installed .venv under an exact key
+      # derived from uv.lock alone that every later run restored.
       - name: Restore cached venv
         id: cached-venv
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0


### PR DESCRIPTION
## What

Two fixes to how CI caches the virtualenv. Independent of everything else — it
touches only `.github/workflows/`, and applies to `main` on its own.

Split out of #597 at reviewer request; the commits are unchanged.

## Why

A cache entry saved from an interrupted install is restored on every later run
with the same key, and the `uv sync` that would repair it was skipped precisely
because the key hit. Seen on #596, which changed `uv.lock` and so minted a fresh
key: four e2e jobs failed with `ImportError: cannot import name
'WeaviateNeo4jRetriever'`, and the same for Pinecone and Qdrant. The restored
`.venv` was missing the vector-store extras.

It is nastier than its cause suggests — it presents as a flaky test in code that
did not change, it survives re-runs, and it persists until the cache expires or
somebody deletes the entry by hand. Any PR touching `uv.lock` mints the new key
and so is first to hit it, which lands it on whoever is least likely to suspect
CI. This one cost a while to diagnose on #596; the entry had to be removed with
`gh cache delete`.

## The two changes

1. **Install unconditionally.** `uv sync` no longer skipped on an exact cache
   hit. It takes a few seconds when the environment is already correct, which is
   cheap next to the above.

2. **Never publish a half-installed venv.** `actions/cache` saves in a post step
   that runs even when the job was cancelled or failed. Replaced with
   `actions/cache/restore` + `actions/cache/save`, where the save is conditional
   on a cache miss — so a cancelled job cannot mint a bad entry, and an existing
   good entry is not overwritten.

Same pinned action SHA, split across the two entry points.

Applied to all three workflows: `pr.yaml`, `pr-e2e-tests.yaml`,
`scheduled-e2e-tests.yaml`.

## Verification

CI on this PR exercises the changed `pr.yaml` directly. Locally: `ruff check`,
`ruff format --check`, `mypy .`, and `pytest tests/unit` (1241 passed) all pass
on this branch standalone.
