### PR TITLE
Add lazily-evaluated pipeline DSL and local interpreter

### DIFF
--- a/src/neo4j_graphrag/pipeline/__init__.py
+++ b/src/neo4j_graphrag/pipeline/__init__.py
@@ -31,6 +31,16 @@ A pipeline built with :class:`Pipeline` is pure data — an operator graph.
 Nothing executes until the definition is evaluated by an
 :class:`Interpreter` (via :meth:`Pipeline.collect`,
 :meth:`Pipeline.to_sink`, iteration, or an explicit interpreter).
+
+.. note::
+    This is not :class:`neo4j_graphrag.experimental.pipeline.Pipeline`.
+    That class is a task-graph orchestrator built from ``Component``
+    instances, wired with ``add_component`` / ``connect`` and run with
+    ``await pipeline.run(...)``; it still backs ``SimpleKGPipeline`` and is
+    scheduled for removal in 2.0.  This :class:`Pipeline` is an unrelated
+    dataflow DSL over a stream of elements.  The two are never used
+    together, and neither is re-exported from the other's package, so an
+    import always names which one you mean.
 """
 
 from neo4j_graphrag.pipeline.interpreter import Interpreter, LocalInterpreter

--- a/src/neo4j_graphrag/pipeline/__init__.py
+++ b/src/neo4j_graphrag/pipeline/__init__.py
@@ -1,0 +1,52 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Lazily-evaluated dataflow pipelines as an embedded DSL.
+
+Quick start::
+
+    from neo4j_graphrag.pipeline import Pipeline
+
+    results = (
+        Pipeline.from_source(my_source)
+        .map(transform)
+        .flat_map(expand)
+        .map_async_chunked(async_transform)
+        .reduce(zero=identity, combine=merge)
+        .collect()
+    )
+
+A pipeline built with :class:`Pipeline` is pure data — an operator graph.
+Nothing executes until the definition is evaluated by an
+:class:`Interpreter` (via :meth:`Pipeline.collect`,
+:meth:`Pipeline.to_sink`, iteration, or an explicit interpreter).
+"""
+
+from neo4j_graphrag.pipeline.interpreter import Interpreter, LocalInterpreter
+from neo4j_graphrag.pipeline.pipeline import Pipeline, ResultPipeline
+from neo4j_graphrag.pipeline.result import Err, Ok, Result
+from neo4j_graphrag.pipeline.sink import Sink
+from neo4j_graphrag.pipeline.source import Source
+
+__all__ = [
+    "Interpreter",
+    "LocalInterpreter",
+    "Pipeline",
+    "ResultPipeline",
+    "Err",
+    "Ok",
+    "Result",
+    "Sink",
+    "Source",
+]

--- a/src/neo4j_graphrag/pipeline/interpreter.py
+++ b/src/neo4j_graphrag/pipeline/interpreter.py
@@ -76,6 +76,8 @@ from neo4j_graphrag.pipeline.operators import (
     TryMapOkAsyncChunked,
 )
 from neo4j_graphrag.pipeline.result import Err, Ok
+from neo4j_graphrag.pipeline.sink import Sink
+from neo4j_graphrag.pipeline.source import Source
 
 if TYPE_CHECKING:
     from neo4j_graphrag.pipeline.pipeline import Pipeline, ResultPipeline
@@ -98,8 +100,10 @@ class Interpreter(ABC):
     def evaluate(self, pipeline: Pipeline[Any] | ResultPipeline[Any]) -> Iterator[Any]:
         """Evaluate *pipeline* and return its output stream.
 
-        If the pipeline ends in a sink, the stream is consumed, written to
-        the sink, and an empty iterator is returned.
+        Implementations should not execute any user code before the
+        returned stream is consumed.  A pipeline ending in a sink returns a
+        stream that yields nothing but writes to the sink as it is drained,
+        so callers must exhaust it — :meth:`Pipeline.to_sink` does this.
         """
 
 
@@ -277,6 +281,34 @@ def _try_flat_map_ok(
                 yield Err(exception=e)
 
 
+def _read_source(source: Source[Any]) -> Iterator[Any]:
+    """Read *source*, deferred until the stream is consumed.
+
+    ``read()`` may open a file or a connection, so it must not run while
+    the generator chain is merely being built.
+    """
+    yield from source.read()
+
+
+def _reduce_lazy(
+    stream: Iterator[Any], zero: Any, combine: Callable[[Any, Any], Any]
+) -> Iterator[Any]:
+    """Fold *stream* into a single element, deferred until consumed.
+
+    The fold itself is not incremental — it drains the upstream — but it
+    does so on first ``next()`` rather than when the chain is built, so
+    ``evaluate()`` stays free of side effects.
+    """
+    yield _reduce(combine, stream, zero)
+
+
+def _to_sink(stream: Iterator[Any], sink: Sink[Any]) -> Iterator[Any]:
+    """Write every element of *stream* to *sink*, yielding nothing."""
+    for item in stream:
+        sink.write(item)
+    yield from ()
+
+
 def _on_error(stream: Iterator[Any], handler: Callable[[Err], None]) -> Iterator[Any]:
     for item in stream:
         if isinstance(item, Err):
@@ -293,10 +325,12 @@ def _on_error(stream: Iterator[Any], handler: Callable[[Err], None]) -> Iterator
 class LocalInterpreter(Interpreter):
     """Evaluate a pipeline in the current process with lazy generators.
 
-    Folds the operator list into a single generator chain.  Apart from
-    ``ReduceOp`` (which folds its upstream eagerly) and the blocking
-    chunked-async operators, no work happens until the returned stream is
-    consumed.
+    Folds the operator list into a single generator chain.  Building the
+    chain runs no user code: every operator — including ``ReduceOp`` and
+    ``SinkOp``, which both drain their upstream — defers its work until the
+    returned stream is consumed.  The chunked-async operators are the one
+    exception to incremental evaluation: each chunk blocks in
+    ``asyncio.run`` while it is being produced.
     """
 
     def evaluate(self, pipeline: Pipeline[Any] | ResultPipeline[Any]) -> Iterator[Any]:
@@ -304,7 +338,7 @@ class LocalInterpreter(Interpreter):
         for op in pipeline.pipeline_operators:
             match op:
                 case SourceOp(source=source):
-                    stream = iter(source.read())
+                    stream = _read_source(source)
                 case Map(func=func):
                     stream = map(func, stream)
                 case FlatMap(func=func):
@@ -320,7 +354,7 @@ class LocalInterpreter(Interpreter):
                 case Grouped(size=size):
                     stream = _batched(stream, size)
                 case ReduceOp(zero=zero, combine=combine):
-                    stream = iter([_reduce(combine, stream, zero)])
+                    stream = _reduce_lazy(stream, zero, combine)
                 case MapAsyncChunked(func=func, map_batch_size=batch_size):
                     stream = _iter_chunked_async(
                         stream, batch_size, _make_map_chunk_coro(func)
@@ -358,9 +392,7 @@ class LocalInterpreter(Interpreter):
                 case OnError(handler=handler):
                     stream = _on_error(stream, handler)
                 case SinkOp(sink=sink):
-                    for item in stream:
-                        sink.write(item)
-                    return iter(())
+                    stream = _to_sink(stream, sink)
                 case _:  # pragma: no cover
                     raise TypeError(f"Unknown operator: {op!r}")
         return stream

--- a/src/neo4j_graphrag/pipeline/interpreter.py
+++ b/src/neo4j_graphrag/pipeline/interpreter.py
@@ -53,8 +53,8 @@ from typing import TYPE_CHECKING, Any, TypeVar
 from neo4j_graphrag.pipeline.operators import (
     Filter,
     FilterOk,
+    FlattenOk,
     FlatMap,
-    FlatMapOk,
     Grouped,
     Map,
     MapAsyncChunked,
@@ -66,10 +66,6 @@ from neo4j_graphrag.pipeline.operators import (
     SourceOp,
     Take,
     TakeWhile,
-    TryFlatMap,
-    TryFlatMapAsyncChunked,
-    TryFlatMapOk,
-    TryFlatMapOkAsyncChunked,
     TryMap,
     TryMapAsyncChunked,
     TryMapOk,
@@ -170,26 +166,6 @@ def _make_try_chunk_coro(
     return _run_chunk
 
 
-def _make_try_flat_chunk_coro(
-    func: Callable[[_T], Awaitable[Iterable[_U]]],
-) -> Callable[[list[_T]], Coroutine[None, None, list[Ok[_U] | Err]]]:
-    async def _run_chunk(chunk: list[_T]) -> list[Ok[_U] | Err]:
-        raw = await asyncio.gather(
-            *[func(item) for item in chunk], return_exceptions=True
-        )
-        results: list[Ok[_U] | Err] = []
-        for r in raw:
-            if isinstance(r, Exception):
-                results.append(Err(exception=r))
-            elif isinstance(r, BaseException):
-                raise r
-            else:
-                results.extend(Ok(value=v) for v in r)
-        return results
-
-    return _run_chunk
-
-
 def _make_try_ok_chunk_coro(
     func: Callable[[Any], Awaitable[Any]],
 ) -> Callable[[list[Any]], Coroutine[None, None, list[Any]]]:
@@ -207,36 +183,10 @@ def _make_try_ok_chunk_coro(
     return _run_chunk
 
 
-def _make_try_flat_ok_chunk_coro(
-    func: Callable[[Any], Awaitable[Iterable[Any]]],
-) -> Callable[[list[Any]], Coroutine[None, None, list[Any]]]:
-    async def _process(item: Ok[Any] | Err) -> list[Ok[Any] | Err]:
-        if isinstance(item, Err):
-            return [item]
-        try:
-            return [Ok(value=v) for v in await func(item.value)]
-        except Exception as e:
-            return [Err(exception=e)]
-
-    async def _run_chunk(chunk: list[Any]) -> list[Any]:
-        nested = await asyncio.gather(*[_process(item) for item in chunk])
-        return [result for sublist in nested for result in sublist]
-
-    return _run_chunk
-
-
 def _try_map(stream: Iterator[Any], func: Callable[[Any], Any]) -> Iterator[Any]:
     for item in stream:
         try:
             yield Ok(value=func(item))
-        except Exception as e:
-            yield Err(exception=e)
-
-
-def _try_flat_map(stream: Iterator[Any], func: Callable[[Any], Any]) -> Iterator[Any]:
-    for item in stream:
-        try:
-            yield from (Ok(value=v) for v in func(item))
         except Exception as e:
             yield Err(exception=e)
 
@@ -249,14 +199,6 @@ def _map_ok(stream: Iterator[Any], func: Callable[[Any], Any]) -> Iterator[Any]:
             yield Ok(value=func(item.value))
 
 
-def _flat_map_ok(stream: Iterator[Any], func: Callable[[Any], Any]) -> Iterator[Any]:
-    for item in stream:
-        if isinstance(item, Err):
-            yield item
-        else:
-            yield from (Ok(value=v) for v in func(item.value))
-
-
 def _try_map_ok(stream: Iterator[Any], func: Callable[[Any], Any]) -> Iterator[Any]:
     for item in stream:
         if isinstance(item, Err):
@@ -264,19 +206,6 @@ def _try_map_ok(stream: Iterator[Any], func: Callable[[Any], Any]) -> Iterator[A
         else:
             try:
                 yield Ok(value=func(item.value))
-            except Exception as e:
-                yield Err(exception=e)
-
-
-def _try_flat_map_ok(
-    stream: Iterator[Any], func: Callable[[Any], Any]
-) -> Iterator[Any]:
-    for item in stream:
-        if isinstance(item, Err):
-            yield item
-        else:
-            try:
-                yield from (Ok(value=v) for v in func(item.value))
             except Exception as e:
                 yield Err(exception=e)
 
@@ -307,6 +236,14 @@ def _to_sink(stream: Iterator[Any], sink: Sink[Any]) -> Iterator[Any]:
     for item in stream:
         sink.write(item)
     yield from ()
+
+
+def _flatten_ok(stream: Iterator[Any]) -> Iterator[Any]:
+    for item in stream:
+        if isinstance(item, Err):
+            yield item
+        else:
+            yield from (Ok(value=v) for v in item.value)
 
 
 def _on_error(stream: Iterator[Any], handler: Callable[[Err], None]) -> Iterator[Any]:
@@ -361,31 +298,19 @@ class LocalInterpreter(Interpreter):
                     )
                 case TryMap(func=func):
                     stream = _try_map(stream, func)
-                case TryFlatMap(func=func):
-                    stream = _try_flat_map(stream, func)
                 case TryMapAsyncChunked(func=func, map_batch_size=batch_size):
                     stream = _iter_chunked_async(
                         stream, batch_size, _make_try_chunk_coro(func)
                     )
-                case TryFlatMapAsyncChunked(func=func, map_batch_size=batch_size):
-                    stream = _iter_chunked_async(
-                        stream, batch_size, _make_try_flat_chunk_coro(func)
-                    )
                 case MapOk(func=func):
                     stream = _map_ok(stream, func)
-                case FlatMapOk(func=func):
-                    stream = _flat_map_ok(stream, func)
+                case FlattenOk():
+                    stream = _flatten_ok(stream)
                 case TryMapOk(func=func):
                     stream = _try_map_ok(stream, func)
-                case TryFlatMapOk(func=func):
-                    stream = _try_flat_map_ok(stream, func)
                 case TryMapOkAsyncChunked(func=func, map_batch_size=batch_size):
                     stream = _iter_chunked_async(
                         stream, batch_size, _make_try_ok_chunk_coro(func)
-                    )
-                case TryFlatMapOkAsyncChunked(func=func, map_batch_size=batch_size):
-                    stream = _iter_chunked_async(
-                        stream, batch_size, _make_try_flat_ok_chunk_coro(func)
                     )
                 case FilterOk():
                     stream = (item.value for item in stream if isinstance(item, Ok))

--- a/src/neo4j_graphrag/pipeline/interpreter.py
+++ b/src/neo4j_graphrag/pipeline/interpreter.py
@@ -1,0 +1,436 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Interpreters evaluate pipeline definitions.
+
+A pipeline built with :class:`~neo4j_graphrag.pipeline.pipeline.Pipeline`
+is pure data — a linked list of
+:class:`~neo4j_graphrag.pipeline.operators.Operator` nodes.  An
+:class:`Interpreter` walks that list and executes it.
+
+:class:`LocalInterpreter` evaluates the pipeline in the current process
+using lazy generators: nothing executes until the returned stream is
+consumed (``collect()``, ``to_sink()``, or direct iteration).
+
+Async stages are evaluated **blocking**: each chunk of ``map_batch_size``
+items is dispatched with ``asyncio.gather`` inside its own
+``asyncio.run()`` call, and its results are yielded before the next chunk
+is fetched.  This bounds memory usage and keeps the interpreter
+synchronous, at the cost of two restrictions:
+
+* async operators must not be evaluated from within a running event loop
+  (use ``asyncio.to_thread`` at the call site if needed), and
+* async clients that bind to an event loop (``httpx.AsyncClient``,
+  ``aiohttp.ClientSession``) must be created *inside* the async function
+  rather than shared across chunks, because each chunk runs on a fresh
+  event loop.
+
+A future ``AsyncInterpreter`` (whole chain on a single event loop) would
+lift both restrictions; the operator-graph representation already supports
+it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import itertools
+from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable, Coroutine, Iterable, Iterator
+from functools import reduce as _reduce
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from neo4j_graphrag.pipeline.operators import (
+    Filter,
+    FilterOk,
+    Operator,
+    FlatMap,
+    FlatMapOk,
+    Grouped,
+    Map,
+    MapAsyncChunked,
+    MapOk,
+    OnError,
+    PartitionBranch,
+    PartitionState,
+    ReduceOp,
+    SinkOp,
+    Skip,
+    SourceOp,
+    Take,
+    TakeWhile,
+    TeeBranch,
+    TryFlatMap,
+    TryFlatMapAsyncChunked,
+    TryFlatMapOk,
+    TryFlatMapOkAsyncChunked,
+    TryMap,
+    TryMapAsyncChunked,
+    TryMapOk,
+    TryMapOkAsyncChunked,
+)
+from neo4j_graphrag.pipeline.result import Err, Ok
+
+if TYPE_CHECKING:
+    from neo4j_graphrag.pipeline.pipeline import Pipeline, ResultPipeline
+
+__all__ = ["Interpreter", "LocalInterpreter"]
+
+_T = TypeVar("_T")
+_U = TypeVar("_U")
+
+
+class Interpreter(ABC):
+    """Base class for pipeline interpreters.
+
+    An interpreter executes a pipeline definition and returns the resulting
+    stream.  Whether evaluation is lazy or eager, local or distributed, is
+    up to the implementation.
+    """
+
+    @abstractmethod
+    def evaluate(self, pipeline: Pipeline[Any] | ResultPipeline[Any]) -> Iterator[Any]:
+        """Evaluate *pipeline* and return its output stream.
+
+        If the pipeline ends in a sink, the stream is consumed, written to
+        the sink, and an empty iterator is returned.
+        """
+
+
+# ---------------------------------------------------------------------------
+# Evaluation helpers (shared generator building blocks)
+# ---------------------------------------------------------------------------
+
+
+def _batched(iterable: Iterable[_T], n: int) -> Iterator[list[_T]]:
+    """Yield successive non-overlapping lists of length *n* from *iterable*."""
+    it = iter(iterable)
+    while batch := list(itertools.islice(it, n)):
+        yield batch
+
+
+def _iter_chunked_async(
+    stream: Iterable[_T],
+    map_batch_size: int,
+    make_chunk_coro: Callable[[list[_T]], Coroutine[None, None, list[_U]]],
+) -> Iterator[_U]:
+    """Shared engine for chunked async operators.
+
+    Iterates *stream* in chunks of *map_batch_size* and, for each chunk,
+    calls ``asyncio.run(make_chunk_coro(chunk))``, yielding all results
+    before moving to the next chunk.
+
+    Raises:
+        ValueError: If *map_batch_size* < 1.  (Builders validate eagerly;
+            this is a backstop for hand-built operator graphs.)
+    """
+    if map_batch_size < 1:
+        raise ValueError(f"map_batch_size must be >= 1, got {map_batch_size!r}")
+    for chunk in _batched(stream, map_batch_size):
+        yield from asyncio.run(make_chunk_coro(chunk))
+
+
+def _make_map_chunk_coro(
+    func: Callable[[_T], Awaitable[_U]],
+) -> Callable[[list[_T]], Coroutine[None, None, list[_U]]]:
+    async def _run_chunk(chunk: list[_T]) -> list[_U]:
+        return list(await asyncio.gather(*[func(item) for item in chunk]))
+
+    return _run_chunk
+
+
+def _make_try_chunk_coro(
+    func: Callable[[_T], Awaitable[_U]],
+) -> Callable[[list[_T]], Coroutine[None, None, list[Ok[_U] | Err]]]:
+    async def _run_chunk(chunk: list[_T]) -> list[Ok[_U] | Err]:
+        raw = await asyncio.gather(
+            *[func(item) for item in chunk], return_exceptions=True
+        )
+        results: list[Ok[_U] | Err] = []
+        for r in raw:
+            if isinstance(r, Exception):
+                results.append(Err(exception=r))
+            elif isinstance(r, BaseException):
+                # SystemExit, KeyboardInterrupt, CancelledError: fatal, re-raise.
+                raise r
+            else:
+                results.append(Ok(value=r))
+        return results
+
+    return _run_chunk
+
+
+def _make_try_flat_chunk_coro(
+    func: Callable[[_T], Awaitable[Iterable[_U]]],
+) -> Callable[[list[_T]], Coroutine[None, None, list[Ok[_U] | Err]]]:
+    async def _run_chunk(chunk: list[_T]) -> list[Ok[_U] | Err]:
+        raw = await asyncio.gather(
+            *[func(item) for item in chunk], return_exceptions=True
+        )
+        results: list[Ok[_U] | Err] = []
+        for r in raw:
+            if isinstance(r, Exception):
+                results.append(Err(exception=r))
+            elif isinstance(r, BaseException):
+                raise r
+            else:
+                results.extend(Ok(value=v) for v in r)
+        return results
+
+    return _run_chunk
+
+
+def _make_try_ok_chunk_coro(
+    func: Callable[[Any], Awaitable[Any]],
+) -> Callable[[list[Any]], Coroutine[None, None, list[Any]]]:
+    async def _process(item: Ok[Any] | Err) -> Ok[Any] | Err:
+        if isinstance(item, Err):
+            return item
+        try:
+            return Ok(value=await func(item.value))
+        except Exception as e:
+            return Err(exception=e)
+
+    async def _run_chunk(chunk: list[Any]) -> list[Any]:
+        return list(await asyncio.gather(*[_process(item) for item in chunk]))
+
+    return _run_chunk
+
+
+def _make_try_flat_ok_chunk_coro(
+    func: Callable[[Any], Awaitable[Iterable[Any]]],
+) -> Callable[[list[Any]], Coroutine[None, None, list[Any]]]:
+    async def _process(item: Ok[Any] | Err) -> list[Ok[Any] | Err]:
+        if isinstance(item, Err):
+            return [item]
+        try:
+            return [Ok(value=v) for v in await func(item.value)]
+        except Exception as e:
+            return [Err(exception=e)]
+
+    async def _run_chunk(chunk: list[Any]) -> list[Any]:
+        nested = await asyncio.gather(*[_process(item) for item in chunk])
+        return [result for sublist in nested for result in sublist]
+
+    return _run_chunk
+
+
+def _try_map(stream: Iterator[Any], func: Callable[[Any], Any]) -> Iterator[Any]:
+    for item in stream:
+        try:
+            yield Ok(value=func(item))
+        except Exception as e:
+            yield Err(exception=e)
+
+
+def _try_flat_map(stream: Iterator[Any], func: Callable[[Any], Any]) -> Iterator[Any]:
+    for item in stream:
+        try:
+            yield from (Ok(value=v) for v in func(item))
+        except Exception as e:
+            yield Err(exception=e)
+
+
+def _map_ok(stream: Iterator[Any], func: Callable[[Any], Any]) -> Iterator[Any]:
+    for item in stream:
+        if isinstance(item, Err):
+            yield item
+        else:
+            yield Ok(value=func(item.value))
+
+
+def _flat_map_ok(stream: Iterator[Any], func: Callable[[Any], Any]) -> Iterator[Any]:
+    for item in stream:
+        if isinstance(item, Err):
+            yield item
+        else:
+            yield from (Ok(value=v) for v in func(item.value))
+
+
+def _try_map_ok(stream: Iterator[Any], func: Callable[[Any], Any]) -> Iterator[Any]:
+    for item in stream:
+        if isinstance(item, Err):
+            yield item
+        else:
+            try:
+                yield Ok(value=func(item.value))
+            except Exception as e:
+                yield Err(exception=e)
+
+
+def _try_flat_map_ok(
+    stream: Iterator[Any], func: Callable[[Any], Any]
+) -> Iterator[Any]:
+    for item in stream:
+        if isinstance(item, Err):
+            yield item
+        else:
+            try:
+                yield from (Ok(value=v) for v in func(item.value))
+            except Exception as e:
+                yield Err(exception=e)
+
+
+def _on_error(stream: Iterator[Any], handler: Callable[[Err], None]) -> Iterator[Any]:
+    for item in stream:
+        if isinstance(item, Err):
+            handler(item)
+        else:
+            yield item.value
+
+
+def _partition(
+    stream: Iterator[Any], state: PartitionState, want_ok: bool
+) -> Iterator[Any]:
+    """Return the success or failure branch of a partition.
+
+    Materialises the upstream on first use so both branches can be consumed
+    independently without double-iteration.
+    """
+    if state.ok_values is None or state.err_values is None:
+        ok_values: list[Any] = []
+        err_values: list[Err] = []
+        for item in stream:
+            if isinstance(item, Ok):
+                ok_values.append(item.value)
+            else:
+                err_values.append(item)
+        state.ok_values = ok_values
+        state.err_values = err_values
+        return iter(ok_values if want_ok else err_values)
+    assert state.ok_values is not None and state.err_values is not None
+    return iter(state.ok_values if want_ok else state.err_values)
+
+
+# ---------------------------------------------------------------------------
+# Local interpreter
+# ---------------------------------------------------------------------------
+
+
+class LocalInterpreter(Interpreter):
+    """Evaluate a pipeline in the current process with lazy generators.
+
+    Folds the operator list into a single generator chain.  Apart from
+    ``ReduceOp`` (which folds its upstream eagerly), ``PartitionBranch``
+    (which materialises its upstream) and the blocking chunked-async
+    operators, no work happens until the returned stream is consumed.
+    """
+
+    def evaluate(self, pipeline: Pipeline[Any] | ResultPipeline[Any]) -> Iterator[Any]:
+        operators = pipeline.pipeline_operators
+        start = self._resume_point(operators)
+        if start is None:
+            return iter(())
+        stream, start_index = start
+        for op in operators[start_index:]:
+            match op:
+                case SourceOp(source=source):
+                    stream = iter(source.read())
+                case Map(func=func):
+                    stream = map(func, stream)
+                case FlatMap(func=func):
+                    stream = itertools.chain.from_iterable(map(func, stream))
+                case Filter(predicate=predicate):
+                    stream = filter(predicate, stream)
+                case Take(n=n):
+                    stream = itertools.islice(stream, n)
+                case TakeWhile(predicate=predicate):
+                    stream = itertools.takewhile(predicate, stream)
+                case Skip(n=n):
+                    stream = itertools.islice(stream, n, None)
+                case Grouped(size=size):
+                    stream = _batched(stream, size)
+                case ReduceOp(zero=zero, combine=combine):
+                    stream = iter([_reduce(combine, stream, zero)])
+                case MapAsyncChunked(func=func, map_batch_size=batch_size):
+                    stream = _iter_chunked_async(
+                        stream, batch_size, _make_map_chunk_coro(func)
+                    )
+                case TryMap(func=func):
+                    stream = _try_map(stream, func)
+                case TryFlatMap(func=func):
+                    stream = _try_flat_map(stream, func)
+                case TryMapAsyncChunked(func=func, map_batch_size=batch_size):
+                    stream = _iter_chunked_async(
+                        stream, batch_size, _make_try_chunk_coro(func)
+                    )
+                case TryFlatMapAsyncChunked(func=func, map_batch_size=batch_size):
+                    stream = _iter_chunked_async(
+                        stream, batch_size, _make_try_flat_chunk_coro(func)
+                    )
+                case MapOk(func=func):
+                    stream = _map_ok(stream, func)
+                case FlatMapOk(func=func):
+                    stream = _flat_map_ok(stream, func)
+                case TryMapOk(func=func):
+                    stream = _try_map_ok(stream, func)
+                case TryFlatMapOk(func=func):
+                    stream = _try_flat_map_ok(stream, func)
+                case TryMapOkAsyncChunked(func=func, map_batch_size=batch_size):
+                    stream = _iter_chunked_async(
+                        stream, batch_size, _make_try_ok_chunk_coro(func)
+                    )
+                case TryFlatMapOkAsyncChunked(func=func, map_batch_size=batch_size):
+                    stream = _iter_chunked_async(
+                        stream, batch_size, _make_try_flat_ok_chunk_coro(func)
+                    )
+                case FilterOk():
+                    stream = (item.value for item in stream if isinstance(item, Ok))
+                case OnError(handler=handler):
+                    stream = _on_error(stream, handler)
+                case TeeBranch(state=state, index=index):
+                    if state.iterators is None:
+                        state.iterators = itertools.tee(stream, state.n)
+                    stream = state.iterators[index]
+                case PartitionBranch(state=state, want_ok=want_ok):
+                    stream = _partition(stream, state, want_ok)
+                case SinkOp(sink=sink):
+                    for item in stream:
+                        sink.write(item)
+                    return iter(())
+                case _:  # pragma: no cover
+                    raise TypeError(f"Unknown operator: {op!r}")
+        return stream
+
+    @staticmethod
+    def _resume_point(
+        operators: list[Operator],
+    ) -> tuple[Iterator[Any], int] | None:
+        """Find the latest already-initialised branch point, if any.
+
+        When evaluating one branch of a ``tee``/``partition`` *after*
+        another branch has already been (partially) evaluated, the shared
+        state token already holds the realised upstream.  Re-folding the
+        prefix would call ``source.read()`` again; instead, resume directly
+        from the shared state.
+
+        Returns ``(stream, start_index)`` — the stream to continue from and
+        the index of the first operator still to apply — or ``None`` if the
+        operator list is empty.
+        """
+        if not operators:
+            return None
+        stream: Iterator[Any] = iter(())
+        start_index = 0
+        for i, op in enumerate(operators):
+            if isinstance(op, TeeBranch) and op.state.iterators is not None:
+                stream = op.state.iterators[op.index]
+                start_index = i + 1
+            elif (
+                isinstance(op, PartitionBranch)
+                and op.state.ok_values is not None
+                and op.state.err_values is not None
+            ):
+                stream = iter(op.state.ok_values if op.want_ok else op.state.err_values)
+                start_index = i + 1
+        return stream, start_index

--- a/src/neo4j_graphrag/pipeline/interpreter.py
+++ b/src/neo4j_graphrag/pipeline/interpreter.py
@@ -53,7 +53,6 @@ from typing import TYPE_CHECKING, Any, TypeVar
 from neo4j_graphrag.pipeline.operators import (
     Filter,
     FilterOk,
-    Operator,
     FlatMap,
     FlatMapOk,
     Grouped,
@@ -61,15 +60,12 @@ from neo4j_graphrag.pipeline.operators import (
     MapAsyncChunked,
     MapOk,
     OnError,
-    PartitionBranch,
-    PartitionState,
     ReduceOp,
     SinkOp,
     Skip,
     SourceOp,
     Take,
     TakeWhile,
-    TeeBranch,
     TryFlatMap,
     TryFlatMapAsyncChunked,
     TryFlatMapOk,
@@ -289,29 +285,6 @@ def _on_error(stream: Iterator[Any], handler: Callable[[Err], None]) -> Iterator
             yield item.value
 
 
-def _partition(
-    stream: Iterator[Any], state: PartitionState, want_ok: bool
-) -> Iterator[Any]:
-    """Return the success or failure branch of a partition.
-
-    Materialises the upstream on first use so both branches can be consumed
-    independently without double-iteration.
-    """
-    if state.ok_values is None or state.err_values is None:
-        ok_values: list[Any] = []
-        err_values: list[Err] = []
-        for item in stream:
-            if isinstance(item, Ok):
-                ok_values.append(item.value)
-            else:
-                err_values.append(item)
-        state.ok_values = ok_values
-        state.err_values = err_values
-        return iter(ok_values if want_ok else err_values)
-    assert state.ok_values is not None and state.err_values is not None
-    return iter(state.ok_values if want_ok else state.err_values)
-
-
 # ---------------------------------------------------------------------------
 # Local interpreter
 # ---------------------------------------------------------------------------
@@ -321,18 +294,14 @@ class LocalInterpreter(Interpreter):
     """Evaluate a pipeline in the current process with lazy generators.
 
     Folds the operator list into a single generator chain.  Apart from
-    ``ReduceOp`` (which folds its upstream eagerly), ``PartitionBranch``
-    (which materialises its upstream) and the blocking chunked-async
-    operators, no work happens until the returned stream is consumed.
+    ``ReduceOp`` (which folds its upstream eagerly) and the blocking
+    chunked-async operators, no work happens until the returned stream is
+    consumed.
     """
 
     def evaluate(self, pipeline: Pipeline[Any] | ResultPipeline[Any]) -> Iterator[Any]:
-        operators = pipeline.pipeline_operators
-        start = self._resume_point(operators)
-        if start is None:
-            return iter(())
-        stream, start_index = start
-        for op in operators[start_index:]:
+        stream: Iterator[Any] = iter(())
+        for op in pipeline.pipeline_operators:
             match op:
                 case SourceOp(source=source):
                     stream = iter(source.read())
@@ -388,12 +357,6 @@ class LocalInterpreter(Interpreter):
                     stream = (item.value for item in stream if isinstance(item, Ok))
                 case OnError(handler=handler):
                     stream = _on_error(stream, handler)
-                case TeeBranch(state=state, index=index):
-                    if state.iterators is None:
-                        state.iterators = itertools.tee(stream, state.n)
-                    stream = state.iterators[index]
-                case PartitionBranch(state=state, want_ok=want_ok):
-                    stream = _partition(stream, state, want_ok)
                 case SinkOp(sink=sink):
                     for item in stream:
                         sink.write(item)
@@ -401,36 +364,3 @@ class LocalInterpreter(Interpreter):
                 case _:  # pragma: no cover
                     raise TypeError(f"Unknown operator: {op!r}")
         return stream
-
-    @staticmethod
-    def _resume_point(
-        operators: list[Operator],
-    ) -> tuple[Iterator[Any], int] | None:
-        """Find the latest already-initialised branch point, if any.
-
-        When evaluating one branch of a ``tee``/``partition`` *after*
-        another branch has already been (partially) evaluated, the shared
-        state token already holds the realised upstream.  Re-folding the
-        prefix would call ``source.read()`` again; instead, resume directly
-        from the shared state.
-
-        Returns ``(stream, start_index)`` — the stream to continue from and
-        the index of the first operator still to apply — or ``None`` if the
-        operator list is empty.
-        """
-        if not operators:
-            return None
-        stream: Iterator[Any] = iter(())
-        start_index = 0
-        for i, op in enumerate(operators):
-            if isinstance(op, TeeBranch) and op.state.iterators is not None:
-                stream = op.state.iterators[op.index]
-                start_index = i + 1
-            elif (
-                isinstance(op, PartitionBranch)
-                and op.state.ok_values is not None
-                and op.state.err_values is not None
-            ):
-                stream = iter(op.state.ok_values if op.want_ok else op.state.err_values)
-                start_index = i + 1
-        return stream, start_index

--- a/src/neo4j_graphrag/pipeline/operators.py
+++ b/src/neo4j_graphrag/pipeline/operators.py
@@ -1,0 +1,341 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Operator nodes for the embedded pipeline DSL.
+
+Operators are **pure data**: each node records the previous node (``prev``)
+and the parameters of the stage (the function to apply, batch size, …).
+They contain no evaluation logic — evaluating a pipeline is the job of an
+:class:`~neo4j_graphrag.pipeline.interpreter.Interpreter`.
+
+A pipeline definition is a singly-linked list of operators starting at a
+:class:`SourceOp` and ending at the pipeline's *tail* node.  Builders
+(:class:`~neo4j_graphrag.pipeline.pipeline.Pipeline` and
+:class:`~neo4j_graphrag.pipeline.pipeline.ResultPipeline`) append nodes;
+they never execute anything.
+
+Node naming conventions:
+
+- Plain names (``Map``, ``FlatMap``, …) apply a function directly;
+  exceptions propagate and abort the stream.
+- ``Try*`` nodes capture per-item exceptions as
+  :class:`~neo4j_graphrag.pipeline.result.Err` values, turning the stream
+  into a stream of :class:`~neo4j_graphrag.pipeline.result.Ok` /
+  :class:`~neo4j_graphrag.pipeline.result.Err`.
+- ``*Ok`` nodes operate on the inner value of ``Ok`` items in a result
+  stream, passing ``Err`` items through unchanged.
+- ``*AsyncChunked`` nodes apply an async function concurrently in chunks
+  of ``map_batch_size`` items.
+
+The only non-pure objects here are :class:`TeeState` and
+:class:`PartitionState`: runtime tokens shared between the branches created
+by ``tee`` / ``partition``.  They are created at build time and populated
+lazily by the interpreter on first evaluation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Iterable, Iterator
+from dataclasses import dataclass
+from typing import Any
+
+from neo4j_graphrag.pipeline.result import Err
+from neo4j_graphrag.pipeline.sink import Sink
+from neo4j_graphrag.pipeline.source import Source
+
+__all__ = [
+    "Operator",
+    "SourceOp",
+    "Map",
+    "FlatMap",
+    "Filter",
+    "Take",
+    "TakeWhile",
+    "Skip",
+    "Grouped",
+    "ReduceOp",
+    "MapAsyncChunked",
+    "TryMap",
+    "TryFlatMap",
+    "TryMapAsyncChunked",
+    "TryFlatMapAsyncChunked",
+    "MapOk",
+    "FlatMapOk",
+    "TryMapOk",
+    "TryFlatMapOk",
+    "TryMapOkAsyncChunked",
+    "TryFlatMapOkAsyncChunked",
+    "FilterOk",
+    "OnError",
+    "TeeBranch",
+    "PartitionBranch",
+    "SinkOp",
+    "TeeState",
+    "PartitionState",
+]
+
+
+@dataclass
+class Operator:
+    """Base class for all pipeline operators.
+
+    Attributes:
+        prev: The previous operator in the chain, or ``None`` for the
+            :class:`SourceOp` root.
+    """
+
+    prev: Operator | None
+
+
+@dataclass
+class SourceOp(Operator):
+    """Root of every pipeline: emits elements from a ``Source``."""
+
+    source: Source[Any]
+
+
+# ---------------------------------------------------------------------------
+# Synchronous operators
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Map(Operator):
+    """Apply ``func`` to every element (1-to-1)."""
+
+    func: Callable[[Any], Any]
+
+
+@dataclass
+class FlatMap(Operator):
+    """Apply ``func`` and flatten one level (1-to-many)."""
+
+    func: Callable[[Any], Iterable[Any]]
+
+
+@dataclass
+class Filter(Operator):
+    """Keep only elements for which ``predicate`` is ``True``."""
+
+    predicate: Callable[[Any], bool]
+
+
+@dataclass
+class Take(Operator):
+    """Take the first ``n`` elements."""
+
+    n: int
+
+
+@dataclass
+class TakeWhile(Operator):
+    """Take elements while ``predicate`` is ``True``, then stop."""
+
+    predicate: Callable[[Any], bool]
+
+
+@dataclass
+class Skip(Operator):
+    """Skip the first ``n`` elements."""
+
+    n: int
+
+
+@dataclass
+class Grouped(Operator):
+    """Collect elements into batches of up to ``size`` items."""
+
+    size: int
+
+
+@dataclass
+class ReduceOp(Operator):
+    """Fold all elements into a single value (emitted as one element)."""
+
+    zero: Any
+    combine: Callable[[Any, Any], Any]
+
+
+# ---------------------------------------------------------------------------
+# Async operators
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MapAsyncChunked(Operator):
+    """Apply async ``func`` concurrently in chunks of ``map_batch_size``."""
+
+    func: Callable[[Any], Awaitable[Any]]
+    map_batch_size: int
+
+
+# ---------------------------------------------------------------------------
+# Partial-failure safe operators (plain stream -> result stream)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TryMap(Operator):
+    """Like :class:`Map`, but per-item exceptions become ``Err`` values."""
+
+    func: Callable[[Any], Any]
+
+
+@dataclass
+class TryFlatMap(Operator):
+    """Like :class:`FlatMap`, but per-item exceptions become ``Err`` values."""
+
+    func: Callable[[Any], Iterable[Any]]
+
+
+@dataclass
+class TryMapAsyncChunked(Operator):
+    """Like :class:`MapAsyncChunked`, capturing per-item exceptions as ``Err``."""
+
+    func: Callable[[Any], Awaitable[Any]]
+    map_batch_size: int
+
+
+@dataclass
+class TryFlatMapAsyncChunked(Operator):
+    """Async chunked flat-mapping, capturing per-item exceptions as ``Err``."""
+
+    func: Callable[[Any], Awaitable[Iterable[Any]]]
+    map_batch_size: int
+
+
+# ---------------------------------------------------------------------------
+# Result-stream combinators (result stream -> result stream)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MapOk(Operator):
+    """Apply ``func`` to the value inside each ``Ok``; ``Err`` passes through."""
+
+    func: Callable[[Any], Any]
+
+
+@dataclass
+class FlatMapOk(Operator):
+    """Apply and flatten ``func`` on each ``Ok``; ``Err`` passes through."""
+
+    func: Callable[[Any], Iterable[Any]]
+
+
+@dataclass
+class TryMapOk(Operator):
+    """Like :class:`MapOk`, but new exceptions are captured as ``Err``."""
+
+    func: Callable[[Any], Any]
+
+
+@dataclass
+class TryFlatMapOk(Operator):
+    """Like :class:`FlatMapOk`, but new exceptions are captured as ``Err``."""
+
+    func: Callable[[Any], Iterable[Any]]
+
+
+@dataclass
+class TryMapOkAsyncChunked(Operator):
+    """Async chunked mapping of ``Ok`` values; ``Err`` passes through."""
+
+    func: Callable[[Any], Awaitable[Any]]
+    map_batch_size: int
+
+
+@dataclass
+class TryFlatMapOkAsyncChunked(Operator):
+    """Async chunked flat-mapping of ``Ok`` values; ``Err`` passes through."""
+
+    func: Callable[[Any], Awaitable[Iterable[Any]]]
+    map_batch_size: int
+
+
+# ---------------------------------------------------------------------------
+# Result-stream terminals (result stream -> plain stream)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FilterOk(Operator):
+    """Drop all ``Err`` values silently and unwrap the ``Ok`` values."""
+
+
+@dataclass
+class OnError(Operator):
+    """Call ``handler`` for each ``Err``, drop it, and unwrap ``Ok`` values."""
+
+    handler: Callable[[Err], None]
+
+
+# ---------------------------------------------------------------------------
+# Branching
+# ---------------------------------------------------------------------------
+
+
+class TeeState:
+    """Runtime token shared by the branches of a ``tee``.
+
+    Created when ``Pipeline.tee(n)`` is called.  On the first evaluation of
+    any branch, the interpreter populates ``iterators`` with
+    ``itertools.tee`` over the realised upstream stream; all branches then
+    share a single pass over the upstream, buffered lazily.
+    """
+
+    def __init__(self, n: int) -> None:
+        self.n = n
+        self.iterators: tuple[Iterator[Any], ...] | None = None
+
+
+class PartitionState:
+    """Runtime token shared by the two branches of a ``partition``.
+
+    On the first evaluation of either branch, the interpreter materialises
+    the upstream into ``ok_values`` / ``err_values`` so both branches can be
+    consumed independently.
+    """
+
+    def __init__(self) -> None:
+        self.ok_values: list[Any] | None = None
+        self.err_values: list[Err] | None = None
+
+
+@dataclass
+class TeeBranch(Operator):
+    """Marks this pipeline as branch ``index`` of a shared ``tee``."""
+
+    state: TeeState
+    index: int
+
+
+@dataclass
+class PartitionBranch(Operator):
+    """Marks this pipeline as the success or failure branch of a ``partition``."""
+
+    state: PartitionState
+    want_ok: bool
+
+
+# ---------------------------------------------------------------------------
+# Terminal
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SinkOp(Operator):
+    """Terminal node: write every element to ``sink``."""
+
+    sink: Sink[Any]

--- a/src/neo4j_graphrag/pipeline/operators.py
+++ b/src/neo4j_graphrag/pipeline/operators.py
@@ -62,15 +62,11 @@ __all__ = [
     "ReduceOp",
     "MapAsyncChunked",
     "TryMap",
-    "TryFlatMap",
     "TryMapAsyncChunked",
-    "TryFlatMapAsyncChunked",
     "MapOk",
-    "FlatMapOk",
+    "FlattenOk",
     "TryMapOk",
-    "TryFlatMapOk",
     "TryMapOkAsyncChunked",
-    "TryFlatMapOkAsyncChunked",
     "FilterOk",
     "OnError",
     "SinkOp",
@@ -184,25 +180,10 @@ class TryMap(Operator):
 
 
 @dataclass
-class TryFlatMap(Operator):
-    """Like :class:`FlatMap`, but per-item exceptions become ``Err`` values."""
-
-    func: Callable[[Any], Iterable[Any]]
-
-
-@dataclass
 class TryMapAsyncChunked(Operator):
     """Like :class:`MapAsyncChunked`, capturing per-item exceptions as ``Err``."""
 
     func: Callable[[Any], Awaitable[Any]]
-    map_batch_size: int
-
-
-@dataclass
-class TryFlatMapAsyncChunked(Operator):
-    """Async chunked flat-mapping, capturing per-item exceptions as ``Err``."""
-
-    func: Callable[[Any], Awaitable[Iterable[Any]]]
     map_batch_size: int
 
 
@@ -219,10 +200,8 @@ class MapOk(Operator):
 
 
 @dataclass
-class FlatMapOk(Operator):
-    """Apply and flatten ``func`` on each ``Ok``; ``Err`` passes through."""
-
-    func: Callable[[Any], Iterable[Any]]
+class FlattenOk(Operator):
+    """Expand each ``Ok`` holding an iterable into one ``Ok`` per item."""
 
 
 @dataclass
@@ -233,25 +212,10 @@ class TryMapOk(Operator):
 
 
 @dataclass
-class TryFlatMapOk(Operator):
-    """Like :class:`FlatMapOk`, but new exceptions are captured as ``Err``."""
-
-    func: Callable[[Any], Iterable[Any]]
-
-
-@dataclass
 class TryMapOkAsyncChunked(Operator):
     """Async chunked mapping of ``Ok`` values; ``Err`` passes through."""
 
     func: Callable[[Any], Awaitable[Any]]
-    map_batch_size: int
-
-
-@dataclass
-class TryFlatMapOkAsyncChunked(Operator):
-    """Async chunked flat-mapping of ``Ok`` values; ``Err`` passes through."""
-
-    func: Callable[[Any], Awaitable[Iterable[Any]]]
     map_batch_size: int
 
 

--- a/src/neo4j_graphrag/pipeline/operators.py
+++ b/src/neo4j_graphrag/pipeline/operators.py
@@ -37,16 +37,11 @@ Node naming conventions:
   stream, passing ``Err`` items through unchanged.
 - ``*AsyncChunked`` nodes apply an async function concurrently in chunks
   of ``map_batch_size`` items.
-
-The only non-pure objects here are :class:`TeeState` and
-:class:`PartitionState`: runtime tokens shared between the branches created
-by ``tee`` / ``partition``.  They are created at build time and populated
-lazily by the interpreter on first evaluation.
 """
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Iterable, Iterator
+from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass
 from typing import Any
 
@@ -78,11 +73,7 @@ __all__ = [
     "TryFlatMapOkAsyncChunked",
     "FilterOk",
     "OnError",
-    "TeeBranch",
-    "PartitionBranch",
     "SinkOp",
-    "TeeState",
-    "PartitionState",
 ]
 
 
@@ -279,54 +270,6 @@ class OnError(Operator):
     """Call ``handler`` for each ``Err``, drop it, and unwrap ``Ok`` values."""
 
     handler: Callable[[Err], None]
-
-
-# ---------------------------------------------------------------------------
-# Branching
-# ---------------------------------------------------------------------------
-
-
-class TeeState:
-    """Runtime token shared by the branches of a ``tee``.
-
-    Created when ``Pipeline.tee(n)`` is called.  On the first evaluation of
-    any branch, the interpreter populates ``iterators`` with
-    ``itertools.tee`` over the realised upstream stream; all branches then
-    share a single pass over the upstream, buffered lazily.
-    """
-
-    def __init__(self, n: int) -> None:
-        self.n = n
-        self.iterators: tuple[Iterator[Any], ...] | None = None
-
-
-class PartitionState:
-    """Runtime token shared by the two branches of a ``partition``.
-
-    On the first evaluation of either branch, the interpreter materialises
-    the upstream into ``ok_values`` / ``err_values`` so both branches can be
-    consumed independently.
-    """
-
-    def __init__(self) -> None:
-        self.ok_values: list[Any] | None = None
-        self.err_values: list[Err] | None = None
-
-
-@dataclass
-class TeeBranch(Operator):
-    """Marks this pipeline as branch ``index`` of a shared ``tee``."""
-
-    state: TeeState
-    index: int
-
-
-@dataclass
-class PartitionBranch(Operator):
-    """Marks this pipeline as the success or failure branch of a ``partition``."""
-
-    state: PartitionState
-    want_ok: bool
 
 
 # ---------------------------------------------------------------------------

--- a/src/neo4j_graphrag/pipeline/pipeline.py
+++ b/src/neo4j_graphrag/pipeline/pipeline.py
@@ -14,6 +14,16 @@
 #  limitations under the License.
 """Embedded pipeline DSL: fluent builders over a pure-data operator graph.
 
+.. note::
+    This is not :class:`neo4j_graphrag.experimental.pipeline.Pipeline`.
+    That class is a task-graph orchestrator built from ``Component``
+    instances, wired with ``add_component`` / ``connect`` and run with
+    ``await pipeline.run(...)``; it still backs ``SimpleKGPipeline`` and is
+    scheduled for removal in 2.0.  This :class:`Pipeline` is an unrelated
+    dataflow DSL over a stream of elements.  The two are never used
+    together, and neither is re-exported from the other's package, so an
+    import always names which one you mean.
+
 :class:`Pipeline` and :class:`ResultPipeline` are **builders**.  Every
 operator method appends an
 :class:`~neo4j_graphrag.pipeline.operators.Operator` node to the definition

--- a/src/neo4j_graphrag/pipeline/pipeline.py
+++ b/src/neo4j_graphrag/pipeline/pipeline.py
@@ -45,6 +45,7 @@ Example — partial-failure safe pipeline::
 
 from __future__ import annotations
 
+from collections import deque
 from collections.abc import Awaitable, Callable, Iterable, Iterator
 from typing import Any, Generic, TypeVar
 
@@ -321,7 +322,10 @@ class Pipeline(Generic[T]):
             sink: An object satisfying the
                 :class:`~neo4j_graphrag.pipeline.sink.Sink` protocol.
         """
-        LocalInterpreter().evaluate(self._wrap(ops.SinkOp(prev=self._tail, sink=sink)))
+        stream = LocalInterpreter().evaluate(
+            self._wrap(ops.SinkOp(prev=self._tail, sink=sink))
+        )
+        deque(stream, maxlen=0)  # drain: the writes happen as the stream is consumed
 
     def __iter__(self) -> Iterator[T]:
         return LocalInterpreter().evaluate(self)

--- a/src/neo4j_graphrag/pipeline/pipeline.py
+++ b/src/neo4j_graphrag/pipeline/pipeline.py
@@ -94,8 +94,8 @@ def _validate_batch_size(map_batch_size: int) -> None:
         raise ValueError(f"map_batch_size must be >= 1, got {map_batch_size!r}")
 
 
-class _IterableSource:
-    """Adapter wrapping any ``Iterable`` to satisfy the ``Source`` protocol."""
+class _IterableSource(Source[Any]):
+    """Adapter wrapping any ``Iterable`` as a :class:`Source`."""
 
     def __init__(self, iterable: Iterable[Any]) -> None:
         self._iterable = iterable
@@ -127,8 +127,8 @@ class Pipeline(Generic[T]):
         """Create a pipeline whose elements come from *source*.
 
         Args:
-            source: Any object satisfying the
-                :class:`~neo4j_graphrag.pipeline.source.Source` protocol.
+            source: A :class:`~neo4j_graphrag.pipeline.source.Source`
+                implementation.
 
         Returns:
             A new :class:`Pipeline` typed to the element type of *source*.
@@ -317,8 +317,8 @@ class Pipeline(Generic[T]):
         :class:`~neo4j_graphrag.pipeline.sink.Sink` for the rationale.
 
         Args:
-            sink: An object satisfying the
-                :class:`~neo4j_graphrag.pipeline.sink.Sink` protocol.
+            sink: A :class:`~neo4j_graphrag.pipeline.sink.Sink`
+                implementation.
         """
         stream = LocalInterpreter().evaluate(
             self._wrap(ops.SinkOp(prev=self._tail, sink=sink))

--- a/src/neo4j_graphrag/pipeline/pipeline.py
+++ b/src/neo4j_graphrag/pipeline/pipeline.py
@@ -27,6 +27,20 @@ Because the definition is data, it can also be inspected, validated, or
 rendered without executing it, and alternative interpreters (async,
 multiprocessing, …) can evaluate the same definition differently.
 
+Method names compose from three independent suffixes:
+
+``_safe``
+    Capture per-item exceptions as :class:`~neo4j_graphrag.pipeline.result.Err`
+    instead of aborting the stream.  Returns a :class:`ResultPipeline`.
+``_ok``
+    Operate on the value inside each ``Ok``, passing ``Err`` through
+    untouched.  Only available on :class:`ResultPipeline`.
+``_async_chunked``
+    Apply an async function to ``map_batch_size`` items concurrently.
+
+1-to-many stages are *not* a fourth suffix: use a ``map`` variant followed
+by :meth:`Pipeline.flat_map` or :meth:`ResultPipeline.flatten_ok`.
+
 Example — partial-failure safe pipeline::
 
     from neo4j_graphrag.pipeline import Err, Pipeline
@@ -36,7 +50,7 @@ Example — partial-failure safe pipeline::
         Pipeline.from_source(source)
         .map_async_chunked_safe(load)      # ResultPipeline[Bytes]
         .map_ok(parse)                     # ResultPipeline[Doc]
-        .flat_map_ok(split)                # ResultPipeline[Chunk]
+        .map_ok(split).flatten_ok()        # ResultPipeline[Chunk]
         .map_async_chunked_safe(embed)     # ResultPipeline[EmbeddedChunk]
         .on_error(errors.append)           # Pipeline[EmbeddedChunk]
         .collect()
@@ -61,7 +75,7 @@ T = TypeVar("T")
 S = TypeVar("S")
 U = TypeVar("U")
 A = TypeVar("A")
-ResI = TypeVar("ResI")
+ResI = TypeVar("ResI", covariant=True)
 OutO = TypeVar("OutO")
 
 
@@ -250,15 +264,6 @@ class Pipeline(Generic[T]):
         """
         return ResultPipeline._wrap(ops.TryMap(prev=self._tail, func=func))
 
-    def flat_map_safe(self, func: Callable[[T], Iterable[U]]) -> ResultPipeline[U]:
-        """Apply *func* and flatten one level, capturing exceptions as ``Err``.
-
-        If *func* raises for a given item the exception is yielded as a
-        single ``Err`` and the stream continues with the next item.
-        Successful items are flattened and individually wrapped in ``Ok``.
-        """
-        return ResultPipeline._wrap(ops.TryFlatMap(prev=self._tail, func=func))
-
     def map_async_chunked_safe(
         self,
         func: Callable[[T], Awaitable[U]],
@@ -276,27 +281,6 @@ class Pipeline(Generic[T]):
         _validate_batch_size(map_batch_size)
         return ResultPipeline._wrap(
             ops.TryMapAsyncChunked(
-                prev=self._tail, func=func, map_batch_size=map_batch_size
-            )
-        )
-
-    def flat_map_async_chunked_safe(
-        self,
-        func: Callable[[T], Awaitable[Iterable[U]]],
-        map_batch_size: int = 100,
-    ) -> ResultPipeline[U]:
-        """Like :meth:`map_async_chunked_safe` but *func* returns an iterable
-        that is flattened into the result stream.
-
-        For each successful call the yielded values are individually wrapped
-        in ``Ok``; exceptions become a single ``Err``.
-
-        Raises:
-            ValueError: If *map_batch_size* < 1.
-        """
-        _validate_batch_size(map_batch_size)
-        return ResultPipeline._wrap(
-            ops.TryFlatMapAsyncChunked(
                 prev=self._tail, func=func, map_batch_size=map_batch_size
             )
         )
@@ -381,12 +365,24 @@ class ResultPipeline(Generic[ResI]):
         """
         return self._wrap(ops.MapOk(prev=self._tail, func=func))
 
-    def flat_map_ok(
-        self, func: Callable[[ResI], Iterable[OutO]]
-    ) -> ResultPipeline[OutO]:
-        """Apply *func* to each ``Ok`` value and flatten one level;
-        ``Err`` passes through."""
-        return self._wrap(ops.FlatMapOk(prev=self._tail, func=func))
+    def flatten_ok(self: ResultPipeline[Iterable[OutO]]) -> ResultPipeline[OutO]:
+        """Expand each ``Ok`` holding an iterable into one ``Ok`` per item;
+        ``Err`` passes through unchanged.
+
+        This is how the DSL expresses 1-to-many stages on a result stream:
+        pair it with whichever ``map`` variant has the error semantics you
+        want, instead of a dedicated ``flat_map`` for each combination::
+
+            .map_ok(split).flatten_ok()                 # split must not fail
+            .map_safe(split).flatten_ok()               # capture failures
+            .map_async_chunked_safe(split).flatten_ok()  # async, capture
+
+        The expansion itself is not error-capturing: if a value turns out
+        not to be iterable, or a lazy iterable raises while being consumed,
+        that exception propagates.  Return a materialised sequence from the
+        preceding ``map_safe`` if you need those failures as ``Err``.
+        """
+        return self._wrap(ops.FlattenOk(prev=self._tail))
 
     def map_safe(self, func: Callable[[ResI], OutO]) -> ResultPipeline[OutO]:
         """Apply *func* to each ``Ok`` value, capturing exceptions as ``Err``;
@@ -397,13 +393,6 @@ class ResultPipeline(Generic[ResI]):
         processing remaining items.
         """
         return self._wrap(ops.TryMapOk(prev=self._tail, func=func))
-
-    def flat_map_safe(
-        self, func: Callable[[ResI], Iterable[OutO]]
-    ) -> ResultPipeline[OutO]:
-        """Apply *func* to each ``Ok`` value and flatten one level, capturing
-        exceptions as ``Err``; existing ``Err`` values pass through unchanged."""
-        return self._wrap(ops.TryFlatMapOk(prev=self._tail, func=func))
 
     def map_async_chunked_safe(
         self,
@@ -420,25 +409,6 @@ class ResultPipeline(Generic[ResI]):
         _validate_batch_size(map_batch_size)
         return self._wrap(
             ops.TryMapOkAsyncChunked(
-                prev=self._tail, func=func, map_batch_size=map_batch_size
-            )
-        )
-
-    def flat_map_async_chunked_safe(
-        self,
-        func: Callable[[ResI], Awaitable[Iterable[OutO]]],
-        map_batch_size: int = 100,
-    ) -> ResultPipeline[OutO]:
-        """Apply async *func* to each ``Ok`` value in concurrent chunks,
-        flattening the returned iterable; existing ``Err`` values pass
-        through unchanged and new exceptions are captured as ``Err``.
-
-        Raises:
-            ValueError: If *map_batch_size* < 1.
-        """
-        _validate_batch_size(map_batch_size)
-        return self._wrap(
-            ops.TryFlatMapOkAsyncChunked(
                 prev=self._tail, func=func, map_batch_size=map_batch_size
             )
         )

--- a/src/neo4j_graphrag/pipeline/pipeline.py
+++ b/src/neo4j_graphrag/pipeline/pipeline.py
@@ -302,6 +302,10 @@ class Pipeline(Generic[T]):
         """Evaluate the pipeline with the default interpreter, writing each
         element to *sink*.
 
+        An exception raised by ``sink.write`` propagates and aborts the run;
+        elements already written are not rolled back.  See
+        :class:`~neo4j_graphrag.pipeline.sink.Sink` for the rationale.
+
         Args:
             sink: An object satisfying the
                 :class:`~neo4j_graphrag.pipeline.sink.Sink` protocol.

--- a/src/neo4j_graphrag/pipeline/pipeline.py
+++ b/src/neo4j_graphrag/pipeline/pipeline.py
@@ -180,39 +180,6 @@ class Pipeline(Generic[T]):
         """Keep only elements for which *predicate* is ``True``."""
         return self._wrap(ops.Filter(prev=self._tail, predicate=predicate))
 
-    def tee(self, n: int = 2) -> tuple[Pipeline[T], ...]:
-        """Fork this stream into *n* independent, lazily-buffered copies.
-
-        Each returned :class:`Pipeline` sees every element exactly once, and
-        all branches share a single pass over the upstream
-        (``itertools.tee`` semantics): elements are buffered internally only
-        as far as the fastest consumer has advanced ahead of the slowest.
-
-        .. warning::
-            If the returned pipelines are consumed **sequentially** (one
-            fully before the other), every element is held in the internal
-            buffer until the last branch drains it — equivalent in memory
-            terms to :meth:`collect`.  Prefer this method when branches are
-            consumed in near-lockstep.
-
-        Args:
-            n: Number of independent copies to produce.  Must be >= 2.
-
-        Returns:
-            A tuple of *n* new :class:`Pipeline` instances sharing a single
-            pass over the upstream.
-
-        Raises:
-            ValueError: If *n* < 2.
-        """
-        if n < 2:
-            raise ValueError(f"n must be >= 2, got {n!r}")
-        state = ops.TeeState(n)
-        return tuple(
-            self._wrap(ops.TeeBranch(prev=self._tail, state=state, index=i))
-            for i in range(n)
-        )
-
     def grouped(self, size: int) -> Pipeline[list[T]]:
         """Collect elements into batches of up to *size* items.
 
@@ -496,27 +463,6 @@ class ResultPipeline(Generic[ResI]):
                 item, e.g. a logging callback or a failure counter.
         """
         return Pipeline._wrap(ops.OnError(prev=self._tail, handler=handler))
-
-    def partition(self) -> tuple[Pipeline[ResI], Pipeline[Err]]:
-        """Split the stream into a success branch and a failure branch.
-
-        Materialises the upstream on first evaluation so both branches can
-        be consumed independently without double-iteration.
-
-        Returns:
-            A tuple of ``(successes, failures)`` where *successes* is a
-            :class:`Pipeline` of unwrapped ``Ok`` values and *failures* is
-            a :class:`Pipeline` of ``Err`` values.
-        """
-        state = ops.PartitionState()
-        return (
-            Pipeline._wrap(
-                ops.PartitionBranch(prev=self._tail, state=state, want_ok=True)
-            ),
-            Pipeline._wrap(
-                ops.PartitionBranch(prev=self._tail, state=state, want_ok=False)
-            ),
-        )
 
     def collect(self) -> list[Ok[ResI] | Err]:
         """Evaluate the pipeline and materialise the raw ``Ok``/``Err``

--- a/src/neo4j_graphrag/pipeline/pipeline.py
+++ b/src/neo4j_graphrag/pipeline/pipeline.py
@@ -1,0 +1,527 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Embedded pipeline DSL: fluent builders over a pure-data operator graph.
+
+:class:`Pipeline` and :class:`ResultPipeline` are **builders**.  Every
+operator method appends an
+:class:`~neo4j_graphrag.pipeline.operators.Operator` node to the definition
+and returns a new builder — nothing executes.  Evaluation is deferred to an
+:class:`~neo4j_graphrag.pipeline.interpreter.Interpreter`; the terminal
+methods :meth:`Pipeline.collect` and :meth:`Pipeline.to_sink` (and direct
+iteration) run the pipeline with the default
+:class:`~neo4j_graphrag.pipeline.interpreter.LocalInterpreter`.
+
+Because the definition is data, it can also be inspected, validated, or
+rendered without executing it, and alternative interpreters (async,
+multiprocessing, …) can evaluate the same definition differently.
+
+Example — partial-failure safe pipeline::
+
+    from neo4j_graphrag.pipeline import Err, Pipeline
+
+    errors: list[Err] = []
+    results = (
+        Pipeline.from_source(source)
+        .map_async_chunked_safe(load)      # ResultPipeline[Bytes]
+        .map_ok(parse)                     # ResultPipeline[Doc]
+        .flat_map_ok(split)                # ResultPipeline[Chunk]
+        .map_async_chunked_safe(embed)     # ResultPipeline[EmbeddedChunk]
+        .on_error(errors.append)           # Pipeline[EmbeddedChunk]
+        .collect()
+    )
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Iterable, Iterator
+from typing import Any, Generic, TypeVar
+
+from neo4j_graphrag.pipeline import operators as ops
+from neo4j_graphrag.pipeline.interpreter import LocalInterpreter
+from neo4j_graphrag.pipeline.result import Err, Ok
+from neo4j_graphrag.pipeline.sink import Sink
+from neo4j_graphrag.pipeline.source import Source
+
+__all__ = ["Pipeline", "ResultPipeline"]
+
+T = TypeVar("T")
+S = TypeVar("S")
+U = TypeVar("U")
+A = TypeVar("A")
+ResI = TypeVar("ResI")
+OutO = TypeVar("OutO")
+
+
+def _validate_batch_size(map_batch_size: int) -> None:
+    if map_batch_size < 1:
+        raise ValueError(f"map_batch_size must be >= 1, got {map_batch_size!r}")
+
+
+class _IterableSource:
+    """Adapter wrapping any ``Iterable`` to satisfy the ``Source`` protocol."""
+
+    def __init__(self, iterable: Iterable[Any]) -> None:
+        self._iterable = iterable
+
+    def read(self) -> Iterable[Any]:
+        return self._iterable
+
+
+class Pipeline(Generic[T]):
+    """A lazily-evaluated pipeline definition.
+
+    Construct from any ``Iterable`` or with :meth:`from_source`::
+
+        Pipeline([1, 2, 3]).map(lambda x: x * 2).collect()  # [2, 4, 6]
+
+    Each operator appends a node to the operator graph and returns a fresh
+    ``Pipeline`` — nothing runs until the pipeline is consumed via
+    :meth:`collect`, :meth:`to_sink`, iteration, or an explicit
+    :class:`~neo4j_graphrag.pipeline.interpreter.Interpreter`.
+    """
+
+    def __init__(self, stream: Iterable[T]) -> None:
+        self._tail: ops.Operator = ops.SourceOp(
+            prev=None, source=_IterableSource(stream)
+        )
+
+    @classmethod
+    def from_source(cls, source: Source[S]) -> Pipeline[S]:
+        """Create a pipeline whose elements come from *source*.
+
+        Args:
+            source: Any object satisfying the
+                :class:`~neo4j_graphrag.pipeline.source.Source` protocol.
+
+        Returns:
+            A new :class:`Pipeline` typed to the element type of *source*.
+        """
+        return cls._wrap(ops.SourceOp(prev=None, source=source))
+
+    @staticmethod
+    def _wrap(tail: ops.Operator) -> Pipeline[Any]:
+        """Build a builder instance around an existing tail node."""
+        pipe = Pipeline.__new__(Pipeline)
+        pipe._tail = tail
+        return pipe
+
+    @property
+    def pipeline_operators(self) -> list[ops.Operator]:
+        """The operator chain in evaluation order (source first)."""
+        operators: list[ops.Operator] = []
+        current: ops.Operator | None = self._tail
+        while current is not None:
+            operators.append(current)
+            current = current.prev
+        return operators[::-1]
+
+    # ------------------------------------------------------------------
+    # Synchronous operators
+    # ------------------------------------------------------------------
+
+    def map(self, func: Callable[[T], U]) -> Pipeline[U]:
+        """Apply *func* to every element (1-to-1).
+
+        Args:
+            func: A callable ``T → U``.
+        """
+        return self._wrap(ops.Map(prev=self._tail, func=func))
+
+    def flat_map(self, func: Callable[[T], Iterable[U]]) -> Pipeline[U]:
+        """Apply *func* and flatten one level (1-to-many).
+
+        Args:
+            func: A callable ``T → Iterable[U]``.
+        """
+        return self._wrap(ops.FlatMap(prev=self._tail, func=func))
+
+    def take(self, n: int) -> Pipeline[T]:
+        """Take the first *n* elements from the stream.
+
+        Raises:
+            ValueError: If *n* < 0.
+        """
+        if n < 0:
+            raise ValueError(f"n must be >= 0, got {n!r}")
+        return self._wrap(ops.Take(prev=self._tail, n=n))
+
+    def take_while(self, predicate: Callable[[T], bool]) -> Pipeline[T]:
+        """Take elements while *predicate* is ``True``.
+
+        Stops consuming the stream as soon as *predicate* returns ``False``
+        for the first time — unlike :meth:`filter`, which skips non-matching
+        elements and continues.
+        """
+        return self._wrap(ops.TakeWhile(prev=self._tail, predicate=predicate))
+
+    def skip(self, n: int) -> Pipeline[T]:
+        """Skip the first *n* elements from the stream.
+
+        Raises:
+            ValueError: If *n* < 0.
+        """
+        if n < 0:
+            raise ValueError(f"n must be >= 0, got {n!r}")
+        return self._wrap(ops.Skip(prev=self._tail, n=n))
+
+    def filter(self, predicate: Callable[[T], bool]) -> Pipeline[T]:
+        """Keep only elements for which *predicate* is ``True``."""
+        return self._wrap(ops.Filter(prev=self._tail, predicate=predicate))
+
+    def tee(self, n: int = 2) -> tuple[Pipeline[T], ...]:
+        """Fork this stream into *n* independent, lazily-buffered copies.
+
+        Each returned :class:`Pipeline` sees every element exactly once, and
+        all branches share a single pass over the upstream
+        (``itertools.tee`` semantics): elements are buffered internally only
+        as far as the fastest consumer has advanced ahead of the slowest.
+
+        .. warning::
+            If the returned pipelines are consumed **sequentially** (one
+            fully before the other), every element is held in the internal
+            buffer until the last branch drains it — equivalent in memory
+            terms to :meth:`collect`.  Prefer this method when branches are
+            consumed in near-lockstep.
+
+        Args:
+            n: Number of independent copies to produce.  Must be >= 2.
+
+        Returns:
+            A tuple of *n* new :class:`Pipeline` instances sharing a single
+            pass over the upstream.
+
+        Raises:
+            ValueError: If *n* < 2.
+        """
+        if n < 2:
+            raise ValueError(f"n must be >= 2, got {n!r}")
+        state = ops.TeeState(n)
+        return tuple(
+            self._wrap(ops.TeeBranch(prev=self._tail, state=state, index=i))
+            for i in range(n)
+        )
+
+    def grouped(self, size: int) -> Pipeline[list[T]]:
+        """Collect elements into batches of up to *size* items.
+
+        Raises:
+            ValueError: If *size* < 1.
+        """
+        if size < 1:
+            raise ValueError(f"grouped size must be >= 1, got {size!r}")
+        return self._wrap(ops.Grouped(prev=self._tail, size=size))
+
+    def reduce(self, zero: A, combine: Callable[[A, T], A]) -> Pipeline[A]:
+        """Fold all elements into a single value, emitted as a one-element stream.
+
+        The *zero* / *combine* pair should form a Monoid: *combine* must be
+        associative and *zero* its identity element.
+
+        Args:
+            zero: The identity / initial accumulator value.
+            combine: An associative binary callable ``(A, T) → A``.
+        """
+        return self._wrap(ops.ReduceOp(prev=self._tail, zero=zero, combine=combine))
+
+    # ------------------------------------------------------------------
+    # Async operators (blocking under LocalInterpreter)
+    # ------------------------------------------------------------------
+
+    def map_async_chunked(
+        self,
+        func: Callable[[T], Awaitable[U]],
+        map_batch_size: int = 100,
+    ) -> Pipeline[U]:
+        """Apply async *func* concurrently to elements in chunks.
+
+        Under the :class:`~neo4j_graphrag.pipeline.interpreter.LocalInterpreter`,
+        *map_batch_size* elements at a time are dispatched via
+        ``asyncio.gather``; each chunk's results are yielded before the next
+        chunk is fetched, bounding memory usage.  Evaluation is **blocking**
+        (``asyncio.run`` per chunk) — see the interpreter documentation for
+        the restrictions this implies.
+
+        Args:
+            func: An async callable ``T → Awaitable[U]``.
+            map_batch_size: Items to process concurrently per chunk.
+                Must be >= 1.
+
+        Raises:
+            ValueError: If *map_batch_size* < 1.
+        """
+        _validate_batch_size(map_batch_size)
+        return self._wrap(
+            ops.MapAsyncChunked(
+                prev=self._tail, func=func, map_batch_size=map_batch_size
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # Partial-failure safe operators (Pipeline -> ResultPipeline)
+    # ------------------------------------------------------------------
+
+    def map_safe(self, func: Callable[[T], U]) -> ResultPipeline[U]:
+        """Apply *func* to every element, capturing exceptions as ``Err``.
+
+        Each item is individually wrapped in
+        :class:`~neo4j_graphrag.pipeline.result.Ok` on success or
+        :class:`~neo4j_graphrag.pipeline.result.Err` on failure.  Unlike
+        :meth:`map`, an exception raised by *func* does not abort the stream.
+        """
+        return ResultPipeline._wrap(ops.TryMap(prev=self._tail, func=func))
+
+    def flat_map_safe(self, func: Callable[[T], Iterable[U]]) -> ResultPipeline[U]:
+        """Apply *func* and flatten one level, capturing exceptions as ``Err``.
+
+        If *func* raises for a given item the exception is yielded as a
+        single ``Err`` and the stream continues with the next item.
+        Successful items are flattened and individually wrapped in ``Ok``.
+        """
+        return ResultPipeline._wrap(ops.TryFlatMap(prev=self._tail, func=func))
+
+    def map_async_chunked_safe(
+        self,
+        func: Callable[[T], Awaitable[U]],
+        map_batch_size: int = 100,
+    ) -> ResultPipeline[U]:
+        """Like :meth:`map_async_chunked` but captures per-item exceptions as ``Err``.
+
+        Within each chunk, ``asyncio.gather`` is called with
+        ``return_exceptions=True`` so one failing item does not abort the
+        chunk.
+
+        Raises:
+            ValueError: If *map_batch_size* < 1.
+        """
+        _validate_batch_size(map_batch_size)
+        return ResultPipeline._wrap(
+            ops.TryMapAsyncChunked(
+                prev=self._tail, func=func, map_batch_size=map_batch_size
+            )
+        )
+
+    def flat_map_async_chunked_safe(
+        self,
+        func: Callable[[T], Awaitable[Iterable[U]]],
+        map_batch_size: int = 100,
+    ) -> ResultPipeline[U]:
+        """Like :meth:`map_async_chunked_safe` but *func* returns an iterable
+        that is flattened into the result stream.
+
+        For each successful call the yielded values are individually wrapped
+        in ``Ok``; exceptions become a single ``Err``.
+
+        Raises:
+            ValueError: If *map_batch_size* < 1.
+        """
+        _validate_batch_size(map_batch_size)
+        return ResultPipeline._wrap(
+            ops.TryFlatMapAsyncChunked(
+                prev=self._tail, func=func, map_batch_size=map_batch_size
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # Terminal operators
+    # ------------------------------------------------------------------
+
+    def collect(self) -> list[T]:
+        """Evaluate the pipeline with the default interpreter and
+        materialise the stream into a list.
+
+        Returns:
+            All elements produced by the pipeline in order.
+        """
+        return list(LocalInterpreter().evaluate(self))
+
+    def to_sink(self, sink: Sink[T]) -> None:
+        """Evaluate the pipeline with the default interpreter, writing each
+        element to *sink*.
+
+        Args:
+            sink: An object satisfying the
+                :class:`~neo4j_graphrag.pipeline.sink.Sink` protocol.
+        """
+        LocalInterpreter().evaluate(self._wrap(ops.SinkOp(prev=self._tail, sink=sink)))
+
+    def __iter__(self) -> Iterator[T]:
+        return LocalInterpreter().evaluate(self)
+
+
+class ResultPipeline(Generic[ResI]):
+    """A pipeline whose elements are ``Ok[ResI] | Err`` values.
+
+    Returned by the ``_safe`` operators on :class:`Pipeline`.  All
+    Result-aware combinators pass
+    :class:`~neo4j_graphrag.pipeline.result.Err` values through unchanged
+    unless otherwise noted.
+
+    Construct via the ``_safe`` operators::
+
+        result_stream: ResultPipeline[int] = (
+            Pipeline([1, 2, 3]).map_async_chunked_safe(f)
+        )
+        clean: Pipeline[int] = result_stream.on_error(counter.record)
+    """
+
+    def __init__(self, stream: Iterable[Ok[ResI] | Err]) -> None:
+        self._tail: ops.Operator = ops.SourceOp(
+            prev=None, source=_IterableSource(stream)
+        )
+
+    @staticmethod
+    def _wrap(tail: ops.Operator) -> ResultPipeline[Any]:
+        """Build a builder instance around an existing tail node."""
+        pipe = ResultPipeline.__new__(ResultPipeline)
+        pipe._tail = tail
+        return pipe
+
+    @property
+    def pipeline_operators(self) -> list[ops.Operator]:
+        """The operator chain in evaluation order (source first)."""
+        operators: list[ops.Operator] = []
+        current: ops.Operator | None = self._tail
+        while current is not None:
+            operators.append(current)
+            current = current.prev
+        return operators[::-1]
+
+    # ------------------------------------------------------------------
+    # Result-aware combinators
+    # ------------------------------------------------------------------
+
+    def map_ok(self, func: Callable[[ResI], OutO]) -> ResultPipeline[OutO]:
+        """Apply *func* to the value inside each ``Ok``; ``Err`` passes through.
+
+        Exceptions raised by *func* propagate and abort the stream — use
+        :meth:`map_safe` to capture them as ``Err`` instead.
+        """
+        return self._wrap(ops.MapOk(prev=self._tail, func=func))
+
+    def flat_map_ok(
+        self, func: Callable[[ResI], Iterable[OutO]]
+    ) -> ResultPipeline[OutO]:
+        """Apply *func* to each ``Ok`` value and flatten one level;
+        ``Err`` passes through."""
+        return self._wrap(ops.FlatMapOk(prev=self._tail, func=func))
+
+    def map_safe(self, func: Callable[[ResI], OutO]) -> ResultPipeline[OutO]:
+        """Apply *func* to each ``Ok`` value, capturing exceptions as ``Err``;
+        existing ``Err`` values pass through unchanged.
+
+        Unlike :meth:`map_ok`, an exception raised by *func* does not
+        propagate — it is captured as a new ``Err`` so the stream continues
+        processing remaining items.
+        """
+        return self._wrap(ops.TryMapOk(prev=self._tail, func=func))
+
+    def flat_map_safe(
+        self, func: Callable[[ResI], Iterable[OutO]]
+    ) -> ResultPipeline[OutO]:
+        """Apply *func* to each ``Ok`` value and flatten one level, capturing
+        exceptions as ``Err``; existing ``Err`` values pass through unchanged."""
+        return self._wrap(ops.TryFlatMapOk(prev=self._tail, func=func))
+
+    def map_async_chunked_safe(
+        self,
+        func: Callable[[ResI], Awaitable[OutO]],
+        map_batch_size: int = 100,
+    ) -> ResultPipeline[OutO]:
+        """Apply async *func* to each ``Ok`` value in concurrent chunks;
+        ``Err`` values pass through unchanged and new exceptions are
+        captured as ``Err``.
+
+        Raises:
+            ValueError: If *map_batch_size* < 1.
+        """
+        _validate_batch_size(map_batch_size)
+        return self._wrap(
+            ops.TryMapOkAsyncChunked(
+                prev=self._tail, func=func, map_batch_size=map_batch_size
+            )
+        )
+
+    def flat_map_async_chunked_safe(
+        self,
+        func: Callable[[ResI], Awaitable[Iterable[OutO]]],
+        map_batch_size: int = 100,
+    ) -> ResultPipeline[OutO]:
+        """Apply async *func* to each ``Ok`` value in concurrent chunks,
+        flattening the returned iterable; existing ``Err`` values pass
+        through unchanged and new exceptions are captured as ``Err``.
+
+        Raises:
+            ValueError: If *map_batch_size* < 1.
+        """
+        _validate_batch_size(map_batch_size)
+        return self._wrap(
+            ops.TryFlatMapOkAsyncChunked(
+                prev=self._tail, func=func, map_batch_size=map_batch_size
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # Result terminals
+    # ------------------------------------------------------------------
+
+    def filter_ok(self) -> Pipeline[ResI]:
+        """Drop all ``Err`` values silently and unwrap the ``Ok`` values.
+
+        No handler is called for dropped errors.  Use :meth:`on_error`
+        instead when failures should be logged or counted.
+        """
+        return Pipeline._wrap(ops.FilterOk(prev=self._tail))
+
+    def on_error(self, handler: Callable[[Err], None]) -> Pipeline[ResI]:
+        """Call *handler* for each ``Err``, drop it from the stream, and
+        unwrap ``Ok`` values.
+
+        Returns a plain :class:`Pipeline` with no ``Result`` wrapper,
+        suitable for passing to non-Result-aware operators or sinks.
+
+        Args:
+            handler: A callable ``Err → None`` invoked for every failed
+                item, e.g. a logging callback or a failure counter.
+        """
+        return Pipeline._wrap(ops.OnError(prev=self._tail, handler=handler))
+
+    def partition(self) -> tuple[Pipeline[ResI], Pipeline[Err]]:
+        """Split the stream into a success branch and a failure branch.
+
+        Materialises the upstream on first evaluation so both branches can
+        be consumed independently without double-iteration.
+
+        Returns:
+            A tuple of ``(successes, failures)`` where *successes* is a
+            :class:`Pipeline` of unwrapped ``Ok`` values and *failures* is
+            a :class:`Pipeline` of ``Err`` values.
+        """
+        state = ops.PartitionState()
+        return (
+            Pipeline._wrap(
+                ops.PartitionBranch(prev=self._tail, state=state, want_ok=True)
+            ),
+            Pipeline._wrap(
+                ops.PartitionBranch(prev=self._tail, state=state, want_ok=False)
+            ),
+        )
+
+    def collect(self) -> list[Ok[ResI] | Err]:
+        """Evaluate the pipeline and materialise the raw ``Ok``/``Err``
+        stream into a list."""
+        return list(LocalInterpreter().evaluate(self))
+
+    def __iter__(self) -> Iterator[Ok[ResI] | Err]:
+        return LocalInterpreter().evaluate(self)

--- a/src/neo4j_graphrag/pipeline/result.py
+++ b/src/neo4j_graphrag/pipeline/result.py
@@ -1,0 +1,66 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Result type for partial-failure-safe pipeline stages.
+
+Defines the two variants produced by ``_safe`` operators on
+:class:`~neo4j_graphrag.pipeline.pipeline.Pipeline`:
+
+* :class:`Ok` – a successful value wrapped in the result stream.
+* :class:`Err` – a captured exception that stays in the stream until
+  explicitly handled via
+  :meth:`~neo4j_graphrag.pipeline.pipeline.ResultPipeline.on_error`,
+  :meth:`~neo4j_graphrag.pipeline.pipeline.ResultPipeline.filter_ok`, or
+  :meth:`~neo4j_graphrag.pipeline.pipeline.ResultPipeline.partition`.
+
+Having a shared :class:`Result` base class lets callers write
+``isinstance(item, Result)`` guards and makes the contract visible in
+type annotations.
+"""
+
+from __future__ import annotations
+
+from abc import ABC
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+__all__ = ["Result", "Ok", "Err"]
+
+T = TypeVar("T")
+
+
+class Result(ABC):
+    """Abstract base for :class:`Ok` and :class:`Err`.
+
+    Not intended for direct instantiation.  Use the concrete subclasses
+    produced by the ``_safe`` pipeline operators.
+    """
+
+
+@dataclass(frozen=True)
+class Ok(Result, Generic[T]):
+    """Wraps a successful value in a Result stream."""
+
+    value: T
+
+
+@dataclass(frozen=True)
+class Err(Result):
+    """Wraps a failed computation in a Result stream.
+
+    Attributes:
+        exception: The exception that caused the failure.
+    """
+
+    exception: Exception

--- a/src/neo4j_graphrag/pipeline/result.py
+++ b/src/neo4j_graphrag/pipeline/result.py
@@ -20,9 +20,8 @@ Defines the two variants produced by ``_safe`` operators on
 * :class:`Ok` – a successful value wrapped in the result stream.
 * :class:`Err` – a captured exception that stays in the stream until
   explicitly handled via
-  :meth:`~neo4j_graphrag.pipeline.pipeline.ResultPipeline.on_error`,
-  :meth:`~neo4j_graphrag.pipeline.pipeline.ResultPipeline.filter_ok`, or
-  :meth:`~neo4j_graphrag.pipeline.pipeline.ResultPipeline.partition`.
+  :meth:`~neo4j_graphrag.pipeline.pipeline.ResultPipeline.on_error` or
+  :meth:`~neo4j_graphrag.pipeline.pipeline.ResultPipeline.filter_ok`.
 
 Having a shared :class:`Result` base class lets callers write
 ``isinstance(item, Result)`` guards and makes the contract visible in

--- a/src/neo4j_graphrag/pipeline/sink.py
+++ b/src/neo4j_graphrag/pipeline/sink.py
@@ -35,6 +35,14 @@ class Sink(Protocol[T_contra]):
     Implementors must provide a ``write`` method that accepts a single
     element of type ``T_contra`` and persists it to the backing store.
 
+    Failures are fatal by design: an exception raised by ``write`` is not
+    captured as an :class:`~neo4j_graphrag.pipeline.result.Err`, it
+    propagates out of :meth:`~neo4j_graphrag.pipeline.pipeline.Pipeline.to_sink`
+    and aborts the run.  Elements written before the failure stay written —
+    a sink is not transactional unless the implementation makes it so.  A
+    sink that should tolerate per-element failures must catch them itself,
+    e.g. by recording them and returning normally.
+
     Example::
 
         class InMemorySink:

--- a/src/neo4j_graphrag/pipeline/sink.py
+++ b/src/neo4j_graphrag/pipeline/sink.py
@@ -12,27 +12,27 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-"""Sink protocol for the pipeline DSL.
+"""Sink abstract base class for the pipeline DSL.
 
 A ``Sink`` is the terminal destination for pipeline output (e.g. a file or
-a Neo4j database).  Any object implementing ``write(element)`` satisfies
-the protocol — no inheritance is required.
+a Neo4j database).  Implementations must subclass :class:`Sink` and
+implement :meth:`Sink.write`.
 """
 
 from __future__ import annotations
 
-from typing import Protocol, TypeVar, runtime_checkable
+from abc import ABC, abstractmethod
+from typing import Generic, TypeVar
 
 __all__ = ["Sink"]
 
 T_contra = TypeVar("T_contra", contravariant=True)
 
 
-@runtime_checkable
-class Sink(Protocol[T_contra]):
-    """Protocol satisfied by any object that can receive pipeline elements.
+class Sink(ABC, Generic[T_contra]):
+    """Abstract base class for objects that can receive pipeline elements.
 
-    Implementors must provide a ``write`` method that accepts a single
+    Subclasses must implement :meth:`write`, which accepts a single
     element of type ``T_contra`` and persists it to the backing store.
 
     Failures are fatal by design: an exception raised by ``write`` is not
@@ -45,7 +45,7 @@ class Sink(Protocol[T_contra]):
 
     Example::
 
-        class InMemorySink:
+        class InMemorySink(Sink[Any]):
             def __init__(self) -> None:
                 self.received: list[Any] = []
 
@@ -53,6 +53,7 @@ class Sink(Protocol[T_contra]):
                 self.received.append(element)
     """
 
+    @abstractmethod
     def write(self, element: T_contra) -> None:
         """Write a single *element* to the backing store."""
         ...

--- a/src/neo4j_graphrag/pipeline/sink.py
+++ b/src/neo4j_graphrag/pipeline/sink.py
@@ -1,0 +1,50 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Sink protocol for the pipeline DSL.
+
+A ``Sink`` is the terminal destination for pipeline output (e.g. a file or
+a Neo4j database).  Any object implementing ``write(element)`` satisfies
+the protocol — no inheritance is required.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, TypeVar, runtime_checkable
+
+__all__ = ["Sink"]
+
+T_contra = TypeVar("T_contra", contravariant=True)
+
+
+@runtime_checkable
+class Sink(Protocol[T_contra]):
+    """Protocol satisfied by any object that can receive pipeline elements.
+
+    Implementors must provide a ``write`` method that accepts a single
+    element of type ``T_contra`` and persists it to the backing store.
+
+    Example::
+
+        class InMemorySink:
+            def __init__(self) -> None:
+                self.received: list[Any] = []
+
+            def write(self, element: Any) -> None:
+                self.received.append(element)
+    """
+
+    def write(self, element: T_contra) -> None:
+        """Write a single *element* to the backing store."""
+        ...

--- a/src/neo4j_graphrag/pipeline/source.py
+++ b/src/neo4j_graphrag/pipeline/source.py
@@ -1,0 +1,64 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Source protocol for the pipeline DSL.
+
+A ``Source`` is the entry point for pipeline data (e.g. a Neo4j query, a
+file glob, or an in-memory sequence for testing).  Any object implementing
+``read()`` satisfies the protocol — no inheritance is required.
+
+Variance note
+-------------
+``Source`` is covariant in ``T_co``: a ``Source[Path]`` can be used wherever
+a ``Source[object]`` is expected because a source only *produces* values —
+it never consumes them.  This mirrors ``collections.abc.Iterable[T_co]``
+and is the dual of the contravariant
+:class:`~neo4j_graphrag.pipeline.sink.Sink`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Protocol, TypeVar, runtime_checkable
+
+__all__ = ["Source"]
+
+T_co = TypeVar("T_co", covariant=True)
+
+
+@runtime_checkable
+class Source(Protocol[T_co]):
+    """Protocol satisfied by any object that can emit pipeline elements.
+
+    Implementors must provide a ``read`` method that returns an iterable of
+    elements.  ``read`` is called each time the pipeline is evaluated, so
+    sources that can only be consumed once (e.g. wrapping a generator)
+    produce single-use pipelines.
+
+    The type parameter ``T_co`` is covariant: a ``Source[Path]`` is a valid
+    ``Source[object]``.
+
+    Example::
+
+        class InMemorySource:
+            def __init__(self, items: list[int]) -> None:
+                self._items = items
+
+            def read(self) -> list[int]:
+                return list(self._items)
+    """
+
+    def read(self) -> Iterable[T_co]:
+        """Return an iterable of elements to feed into the pipeline."""
+        ...

--- a/src/neo4j_graphrag/pipeline/source.py
+++ b/src/neo4j_graphrag/pipeline/source.py
@@ -12,11 +12,11 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-"""Source protocol for the pipeline DSL.
+"""Source abstract base class for the pipeline DSL.
 
 A ``Source`` is the entry point for pipeline data (e.g. a Neo4j query, a
-file glob, or an in-memory sequence for testing).  Any object implementing
-``read()`` satisfies the protocol — no inheritance is required.
+file glob, or an in-memory sequence for testing).  Implementations must
+subclass :class:`Source` and implement :meth:`Source.read`.
 
 Variance note
 -------------
@@ -29,19 +29,19 @@ and is the dual of the contravariant
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from collections.abc import Iterable
-from typing import Protocol, TypeVar, runtime_checkable
+from typing import Generic, TypeVar
 
 __all__ = ["Source"]
 
 T_co = TypeVar("T_co", covariant=True)
 
 
-@runtime_checkable
-class Source(Protocol[T_co]):
-    """Protocol satisfied by any object that can emit pipeline elements.
+class Source(ABC, Generic[T_co]):
+    """Abstract base class for objects that can emit pipeline elements.
 
-    Implementors must provide a ``read`` method that returns an iterable of
+    Subclasses must implement :meth:`read`, which returns an iterable of
     elements.  ``read`` is called each time the pipeline is evaluated, so
     sources that can only be consumed once (e.g. wrapping a generator)
     produce single-use pipelines.
@@ -51,7 +51,7 @@ class Source(Protocol[T_co]):
 
     Example::
 
-        class InMemorySource:
+        class InMemorySource(Source[int]):
             def __init__(self, items: list[int]) -> None:
                 self._items = items
 
@@ -59,6 +59,7 @@ class Source(Protocol[T_co]):
                 return list(self._items)
     """
 
+    @abstractmethod
     def read(self) -> Iterable[T_co]:
         """Return an iterable of elements to feed into the pipeline."""
         ...

--- a/tests/unit/pipeline/test_pipeline.py
+++ b/tests/unit/pipeline/test_pipeline.py
@@ -71,6 +71,19 @@ class _CaptureSink:
         self.received.append(element)
 
 
+class _FailingSink:
+    """Records writes until it sees *fail_on*, then raises."""
+
+    def __init__(self, fail_on: int) -> None:
+        self.received: list[int] = []
+        self._fail_on = fail_on
+
+    def write(self, element: int) -> None:
+        if element == self._fail_on:
+            raise RuntimeError(f"write failed: {element}")
+        self.received.append(element)
+
+
 def pipe_tail(pipe: Pipeline[int]) -> ops.Operator:
     """The tail operator of *pipe*, for building a sink graph by hand."""
     return pipe.pipeline_operators[-1]
@@ -365,6 +378,44 @@ class TestToSink:
         sink = _CaptureSink()
         Pipeline([1, 2, 3]).map(lambda x: x * 2).to_sink(sink)
         assert sink.received == [2, 4, 6]
+
+    def test_write_failure_aborts_the_run(self) -> None:
+        """Sink failures are fatal — they are not captured as ``Err``."""
+        sink = _FailingSink(fail_on=2)
+        with pytest.raises(RuntimeError, match="write failed: 2"):
+            Pipeline([1, 2, 3]).to_sink(sink)
+
+    def test_elements_before_a_write_failure_stay_written(self) -> None:
+        sink = _FailingSink(fail_on=2)
+        with pytest.raises(RuntimeError):
+            Pipeline([1, 2, 3]).to_sink(sink)
+        assert sink.received == [1]
+
+    def test_write_failure_stops_reading_the_upstream(self) -> None:
+        """The failure must not drain the rest of the source first."""
+        seen: list[int] = []
+
+        def _record(x: int) -> int:
+            seen.append(x)
+            return x
+
+        with pytest.raises(RuntimeError):
+            Pipeline([1, 2, 3]).map(_record).to_sink(_FailingSink(fail_on=2))
+        assert seen == [1, 2]
+
+    def test_sink_after_chunked_async_stage(self) -> None:
+        sink = _CaptureSink()
+        Pipeline([1, 2, 3]).map_async_chunked(_double, map_batch_size=2).to_sink(sink)
+        assert sink.received == [2, 4, 6]
+
+    def test_sink_receives_result_values_when_errors_are_handled(self) -> None:
+        sink = _CaptureSink()
+        errors: list[Err] = []
+        Pipeline([1, 2, 3]).map_safe(_fail_on_two_sync).on_error(errors.append).to_sink(
+            sink
+        )
+        assert sink.received == [1, 3]
+        assert len(errors) == 1
 
 
 class TestLaziness:

--- a/tests/unit/pipeline/test_pipeline.py
+++ b/tests/unit/pipeline/test_pipeline.py
@@ -70,6 +70,11 @@ class _CaptureSink:
         self.received.append(element)
 
 
+def pipe_tail(pipe: Pipeline[int]) -> ops.Operator:
+    """The tail operator of *pipe*, for building a sink graph by hand."""
+    return pipe.pipeline_operators[-1]
+
+
 async def _double(x: int) -> int:
     return x * 2
 
@@ -373,6 +378,45 @@ class TestLaziness:
         assert calls == []  # nothing has run yet
         pipe.collect()
         assert calls == [1, 2, 3]  # runs on consumption
+
+    def test_evaluate_runs_nothing_before_the_stream_is_consumed(self) -> None:
+        """``evaluate()`` only builds the generator chain.
+
+        Every operator must defer its work, including the ones that drain
+        their whole upstream (``reduce``, ``to_sink``).
+        """
+        source = _CountingSource([1, 2, 3])
+        pipe = Pipeline.from_source(source).map(lambda x: x)
+        LocalInterpreter().evaluate(pipe)
+        assert source.reads == 0
+
+    def test_reduce_does_not_fold_until_consumed(self) -> None:
+        read: list[int] = []
+
+        def _tracked() -> Iterable[int]:
+            for i in [1, 2, 3]:
+                read.append(i)
+                yield i
+
+        pipe = Pipeline(_tracked()).reduce(zero=0, combine=lambda a, b: a + b)
+        stream = LocalInterpreter().evaluate(pipe)
+        assert read == []  # the fold has not touched the upstream yet
+        assert list(stream) == [6]
+        assert read == [1, 2, 3]
+
+    def test_sink_does_not_write_until_consumed(self) -> None:
+        sink = _CaptureSink()
+        base = Pipeline([1, 2, 3])
+        sink_graph = Pipeline._wrap(ops.SinkOp(prev=pipe_tail(base), sink=sink))
+        stream = LocalInterpreter().evaluate(sink_graph)
+        assert sink.received == []  # evaluate() alone writes nothing
+        assert list(stream) == []  # a sink stream yields nothing...
+        assert sink.received == [1, 2, 3]  # ...but writes as it drains
+
+    def test_to_sink_drains_the_stream(self) -> None:
+        sink = _CaptureSink()
+        Pipeline([1, 2, 3]).to_sink(sink)
+        assert sink.received == [1, 2, 3]
 
     def test_full_pipeline(self) -> None:
         result = (

--- a/tests/unit/pipeline/test_pipeline.py
+++ b/tests/unit/pipeline/test_pipeline.py
@@ -43,7 +43,7 @@ from neo4j_graphrag.pipeline import operators as ops
 # ---------------------------------------------------------------------------
 
 
-class _InMemorySource:
+class _InMemorySource(Source[int]):
     def __init__(self, items: list[int]) -> None:
         self._items = items
 
@@ -51,7 +51,7 @@ class _InMemorySource:
         return iter(self._items)
 
 
-class _CountingSource:
+class _CountingSource(Source[int]):
     """Records how many times read() is called."""
 
     def __init__(self, items: list[int]) -> None:
@@ -63,7 +63,7 @@ class _CountingSource:
         return iter(self._items)
 
 
-class _CaptureSink:
+class _CaptureSink(Sink[int]):
     def __init__(self) -> None:
         self.received: list[int] = []
 
@@ -71,7 +71,7 @@ class _CaptureSink:
         self.received.append(element)
 
 
-class _FailingSink:
+class _FailingSink(Sink[int]):
     """Records writes until it sees *fail_on*, then raises."""
 
     def __init__(self, fail_on: int) -> None:
@@ -116,8 +116,12 @@ class TestConstruction:
     def test_empty_source_produces_empty_stream(self) -> None:
         assert Pipeline.from_source(_InMemorySource([])).collect() == []
 
-    def test_source_protocol_satisfied(self) -> None:
+    def test_source_subclass_satisfied(self) -> None:
         assert isinstance(_InMemorySource([1]), Source)
+
+    def test_source_is_abstract(self) -> None:
+        with pytest.raises(TypeError):
+            Source()  # type: ignore[abstract]
 
     def test_wraps_iterable_directly(self) -> None:
         assert Pipeline([1, 2, 3]).collect() == [1, 2, 3]
@@ -371,8 +375,12 @@ class TestToSink:
         Pipeline([]).to_sink(sink)
         assert sink.received == []
 
-    def test_sink_protocol_satisfied(self) -> None:
+    def test_sink_subclass_satisfied(self) -> None:
         assert isinstance(_CaptureSink(), Sink)
+
+    def test_sink_is_abstract(self) -> None:
+        with pytest.raises(TypeError):
+            Sink()  # type: ignore[abstract]
 
     def test_chained_operators_apply_before_sink(self) -> None:
         sink = _CaptureSink()

--- a/tests/unit/pipeline/test_pipeline.py
+++ b/tests/unit/pipeline/test_pipeline.py
@@ -1,0 +1,870 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for the embedded pipeline DSL.
+
+Tests assert on actual data transformations, not internal structure.
+Async operator tests are sync — blocking happens inside the interpreter
+via ``asyncio.run()``, so no running event loop is present during the test.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import pytest
+
+from neo4j_graphrag.pipeline import (
+    Err,
+    LocalInterpreter,
+    Ok,
+    Pipeline,
+    ResultPipeline,
+    Sink,
+    Source,
+)
+from neo4j_graphrag.pipeline import operators as ops
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+class _InMemorySource:
+    def __init__(self, items: list[int]) -> None:
+        self._items = items
+
+    def read(self) -> Iterable[int]:
+        return iter(self._items)
+
+
+class _CountingSource:
+    """Records how many times read() is called."""
+
+    def __init__(self, items: list[int]) -> None:
+        self._items = items
+        self.reads = 0
+
+    def read(self) -> Iterable[int]:
+        self.reads += 1
+        return iter(self._items)
+
+
+class _CaptureSink:
+    def __init__(self) -> None:
+        self.received: list[int] = []
+
+    def write(self, element: int) -> None:
+        self.received.append(element)
+
+
+async def _double(x: int) -> int:
+    return x * 2
+
+
+async def _fail_on_even(x: int) -> int:
+    if x % 2 == 0:
+        raise ValueError(f"even: {x}")
+    return x
+
+
+async def _duplicate(x: int) -> list[int]:
+    return [x, x * 10]
+
+
+# ---------------------------------------------------------------------------
+# Construction / from_source
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_emits_elements_from_source(self) -> None:
+        result = Pipeline.from_source(_InMemorySource([1, 2, 3])).collect()
+        assert result == [1, 2, 3]
+
+    def test_empty_source_produces_empty_stream(self) -> None:
+        assert Pipeline.from_source(_InMemorySource([])).collect() == []
+
+    def test_source_protocol_satisfied(self) -> None:
+        assert isinstance(_InMemorySource([1]), Source)
+
+    def test_wraps_iterable_directly(self) -> None:
+        assert Pipeline([1, 2, 3]).collect() == [1, 2, 3]
+
+    def test_iterable_directly(self) -> None:
+        pipe = Pipeline([1, 2, 3]).map(lambda x: x * 10)
+        assert list(pipe) == [10, 20, 30]
+
+    def test_definition_is_lazy(self) -> None:
+        """Building a pipeline executes nothing — not even source.read()."""
+        source = _CountingSource([1, 2, 3])
+        pipe = Pipeline.from_source(source).map(lambda x: x + 1)
+        assert source.reads == 0
+        assert pipe.collect() == [2, 3, 4]
+        assert source.reads == 1
+
+    def test_explicit_interpreter(self) -> None:
+        pipe = Pipeline([1, 2, 3]).map(lambda x: x + 1)
+        assert list(LocalInterpreter().evaluate(pipe)) == [2, 3, 4]
+
+    def test_pipeline_operators_in_evaluation_order(self) -> None:
+        pipe = Pipeline([1]).map(lambda x: x).filter(lambda x: True)
+        kinds = [type(op) for op in pipe.pipeline_operators]
+        assert kinds == [ops.SourceOp, ops.Map, ops.Filter]
+
+    def test_reiterable_source_can_be_evaluated_twice(self) -> None:
+        pipe = Pipeline([1, 2, 3]).map(lambda x: x + 1)
+        assert pipe.collect() == [2, 3, 4]
+        assert pipe.collect() == [2, 3, 4]
+
+
+# ---------------------------------------------------------------------------
+# map
+# ---------------------------------------------------------------------------
+
+
+class TestMap:
+    def test_transforms_each_element(self) -> None:
+        assert Pipeline([1, 2, 3]).map(lambda x: x * 2).collect() == [2, 4, 6]
+
+    def test_changes_element_type(self) -> None:
+        assert Pipeline([1, 2]).map(str).collect() == ["1", "2"]
+
+    def test_empty_stream(self) -> None:
+        assert Pipeline([]).map(lambda x: x).collect() == []
+
+    def test_chained_maps_compose(self) -> None:
+        result = Pipeline([1]).map(lambda x: x + 1).map(lambda x: x * 10).collect()
+        assert result == [20]
+
+    def test_exception_propagates(self) -> None:
+        def _boom(x: int) -> int:
+            raise ValueError("boom")
+
+        with pytest.raises(ValueError, match="boom"):
+            Pipeline([1]).map(_boom).collect()
+
+
+# ---------------------------------------------------------------------------
+# flat_map
+# ---------------------------------------------------------------------------
+
+
+class TestFlatMap:
+    def test_flattens_one_level(self) -> None:
+        result = Pipeline([1, 2, 3]).flat_map(lambda x: [x, x * 10]).collect()
+        assert result == [1, 10, 2, 20, 3, 30]
+
+    def test_empty_inner_iterables_are_dropped(self) -> None:
+        result = Pipeline([1, 2, 3]).flat_map(lambda x: [] if x == 2 else [x]).collect()
+        assert result == [1, 3]
+
+    def test_empty_stream(self) -> None:
+        assert Pipeline([]).flat_map(lambda x: [x]).collect() == []
+
+
+# ---------------------------------------------------------------------------
+# take / take_while / skip
+# ---------------------------------------------------------------------------
+
+
+class TestTake:
+    def test_takes_first_n_elements(self) -> None:
+        assert Pipeline([1, 2, 3, 4, 5]).take(3).collect() == [1, 2, 3]
+
+    def test_empty_stream(self) -> None:
+        assert Pipeline([]).take(3).collect() == []
+
+    def test_negative_n_raises(self) -> None:
+        with pytest.raises(ValueError, match="n must be >= 0"):
+            Pipeline([1, 2, 3]).take(-1)
+
+    def test_n_larger_than_stream(self) -> None:
+        assert Pipeline([1, 2, 3]).take(4).collect() == [1, 2, 3]
+
+    def test_n_zero(self) -> None:
+        assert Pipeline([1, 2, 3]).take(0).collect() == []
+
+
+class TestTakeWhile:
+    def test_takes_elements_while_predicate_is_true(self) -> None:
+        result = Pipeline([1, 2, 3, 1]).take_while(lambda x: x < 3).collect()
+        assert result == [1, 2]
+
+    def test_stops_at_first_false_not_filter(self) -> None:
+        """take_while stops; it does not skip non-matching elements."""
+        result = Pipeline([2, 4, 3, 6]).take_while(lambda x: x % 2 == 0).collect()
+        assert result == [2, 4]
+
+    def test_predicate_false_on_first_element_returns_empty(self) -> None:
+        assert Pipeline([5, 1]).take_while(lambda x: x < 3).collect() == []
+
+    def test_predicate_always_true_returns_all(self) -> None:
+        assert Pipeline([1, 2]).take_while(lambda x: True).collect() == [1, 2]
+
+
+class TestSkip:
+    def test_skips_first_n_elements(self) -> None:
+        assert Pipeline([1, 2, 3, 4]).skip(2).collect() == [3, 4]
+
+    def test_negative_n_raises(self) -> None:
+        with pytest.raises(ValueError, match="n must be >= 0"):
+            Pipeline([1]).skip(-1)
+
+    def test_n_larger_than_stream(self) -> None:
+        assert Pipeline([1, 2]).skip(5).collect() == []
+
+
+# ---------------------------------------------------------------------------
+# filter
+# ---------------------------------------------------------------------------
+
+
+class TestFilter:
+    def test_keeps_matching_elements(self) -> None:
+        result = Pipeline([1, 2, 3, 4, 5]).filter(lambda x: x % 2 == 0).collect()
+        assert result == [2, 4]
+
+    def test_all_filtered_out(self) -> None:
+        assert Pipeline([1, 3]).filter(lambda x: x % 2 == 0).collect() == []
+
+    def test_none_filtered_out(self) -> None:
+        assert Pipeline([2, 4]).filter(lambda x: x % 2 == 0).collect() == [2, 4]
+
+
+# ---------------------------------------------------------------------------
+# tee
+# ---------------------------------------------------------------------------
+
+
+class TestTee:
+    def test_default_returns_two_branches(self) -> None:
+        branches = Pipeline([1, 2, 3]).tee()
+        assert len(branches) == 2
+
+    def test_each_branch_sees_all_elements(self) -> None:
+        b1, b2 = Pipeline([1, 2, 3]).tee()
+        assert b1.collect() == [1, 2, 3]
+        assert b2.collect() == [1, 2, 3]
+
+    def test_element_order_is_preserved_in_each_branch(self) -> None:
+        b1, b2 = Pipeline([3, 1, 2]).tee()
+        assert b1.collect() == [3, 1, 2]
+        assert b2.collect() == [3, 1, 2]
+
+    def test_branches_are_independent(self) -> None:
+        b1, b2 = Pipeline([1, 2, 3]).tee()
+        assert b1.map(lambda x: x * 10).collect() == [10, 20, 30]
+        assert b2.filter(lambda x: x % 2 == 1).collect() == [1, 3]
+
+    def test_n_controls_number_of_branches(self) -> None:
+        branches = Pipeline([1, 2]).tee(4)
+        assert len(branches) == 4
+        for b in branches:
+            assert b.collect() == [1, 2]
+
+    def test_empty_stream_produces_empty_branches(self) -> None:
+        b1, b2 = Pipeline[int]([]).tee()
+        assert b1.collect() == []
+        assert b2.collect() == []
+
+    def test_tee_after_map(self) -> None:
+        b1, b2 = Pipeline([1, 2]).map(lambda x: x * 5).tee()
+        assert b1.collect() == [5, 10]
+        assert b2.collect() == [5, 10]
+
+    def test_n_less_than_two_raises(self) -> None:
+        with pytest.raises(ValueError, match="n must be >= 2"):
+            Pipeline([1]).tee(1)
+
+    def test_upstream_is_read_once_across_branches(self) -> None:
+        """Evaluating a second branch resumes from shared tee state instead
+        of re-reading the source."""
+        source = _CountingSource([1, 2, 3])
+        b1, b2 = Pipeline.from_source(source).tee()
+        assert b1.collect() == [1, 2, 3]
+        assert b2.collect() == [1, 2, 3]
+        assert source.reads == 1
+
+
+# ---------------------------------------------------------------------------
+# grouped
+# ---------------------------------------------------------------------------
+
+
+class TestGrouped:
+    def test_splits_into_full_batches(self) -> None:
+        result = Pipeline([1, 2, 3, 4, 5, 6]).grouped(2).collect()
+        assert result == [[1, 2], [3, 4], [5, 6]]
+
+    def test_final_batch_may_be_smaller(self) -> None:
+        result = Pipeline([1, 2, 3, 4, 5]).grouped(2).collect()
+        assert result == [[1, 2], [3, 4], [5]]
+
+    def test_size_larger_than_stream(self) -> None:
+        assert Pipeline([1, 2]).grouped(10).collect() == [[1, 2]]
+
+    def test_size_one(self) -> None:
+        assert Pipeline([1, 2]).grouped(1).collect() == [[1], [2]]
+
+    def test_empty_stream(self) -> None:
+        assert Pipeline([]).grouped(3).collect() == []
+
+    def test_size_zero_raises(self) -> None:
+        with pytest.raises(ValueError, match="grouped size must be >= 1"):
+            Pipeline([1]).grouped(0)
+
+    def test_negative_size_raises(self) -> None:
+        with pytest.raises(ValueError, match="grouped size must be >= 1"):
+            Pipeline([1]).grouped(-2)
+
+
+# ---------------------------------------------------------------------------
+# reduce
+# ---------------------------------------------------------------------------
+
+
+class TestReduce:
+    def test_sums_elements(self) -> None:
+        result = Pipeline([1, 2, 3, 4]).reduce(0, lambda a, x: a + x).collect()
+        assert result == [10]
+
+    def test_identity_on_empty_stream(self) -> None:
+        result = Pipeline([]).reduce(0, lambda a, x: a + x).collect()
+        assert result == [0]
+
+    def test_string_concatenation(self) -> None:
+        result = Pipeline(["a", "b", "c"]).reduce("", lambda a, x: a + x).collect()
+        assert result == ["abc"]
+
+    def test_result_can_be_mapped(self) -> None:
+        result = (
+            Pipeline([1, 2, 3])
+            .reduce(0, lambda a, x: a + x)
+            .map(lambda total: total * 10)
+            .collect()
+        )
+        assert result == [60]
+
+
+# ---------------------------------------------------------------------------
+# map_async_chunked
+# ---------------------------------------------------------------------------
+
+
+class TestMapAsyncChunked:
+    def test_transforms_all_elements(self) -> None:
+        result = Pipeline([1, 2, 3]).map_async_chunked(_double).collect()
+        assert result == [2, 4, 6]
+
+    def test_empty_stream_collects_empty_list(self) -> None:
+        assert Pipeline([]).map_async_chunked(_double).collect() == []
+
+    def test_chunk_size_larger_than_stream(self) -> None:
+        result = (
+            Pipeline([1, 2]).map_async_chunked(_double, map_batch_size=100).collect()
+        )
+        assert result == [2, 4]
+
+    def test_map_batch_size_zero_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="map_batch_size must be >= 1"):
+            Pipeline([1]).map_async_chunked(_double, map_batch_size=0)
+
+    def test_results_yielded_per_chunk_in_order(self) -> None:
+        result = (
+            Pipeline([1, 2, 3, 4, 5])
+            .map_async_chunked(_double, map_batch_size=2)
+            .collect()
+        )
+        assert result == [2, 4, 6, 8, 10]
+
+
+# ---------------------------------------------------------------------------
+# to_sink / collect
+# ---------------------------------------------------------------------------
+
+
+class TestToSink:
+    def test_writes_all_elements_to_sink(self) -> None:
+        sink = _CaptureSink()
+        Pipeline([1, 2, 3]).to_sink(sink)
+        assert sink.received == [1, 2, 3]
+
+    def test_empty_stream_writes_nothing(self) -> None:
+        sink = _CaptureSink()
+        Pipeline([]).to_sink(sink)
+        assert sink.received == []
+
+    def test_sink_protocol_satisfied(self) -> None:
+        assert isinstance(_CaptureSink(), Sink)
+
+    def test_chained_operators_apply_before_sink(self) -> None:
+        sink = _CaptureSink()
+        Pipeline([1, 2, 3]).map(lambda x: x * 2).to_sink(sink)
+        assert sink.received == [2, 4, 6]
+
+
+class TestLaziness:
+    def test_operators_do_not_execute_until_consumed(self) -> None:
+        calls: list[int] = []
+
+        def _record(x: int) -> int:
+            calls.append(x)
+            return x
+
+        pipe = Pipeline([1, 2, 3]).map(_record)
+        assert calls == []  # nothing has run yet
+        pipe.collect()
+        assert calls == [1, 2, 3]  # runs on consumption
+
+    def test_full_pipeline(self) -> None:
+        result = (
+            Pipeline([1, 2, 3, 4, 5, 6, 7, 8])
+            .filter(lambda x: x % 2 == 0)  # [2, 4, 6, 8]
+            .map(lambda x: x * 3)  # [6, 12, 18, 24]
+            .flat_map(lambda x: [x, x + 1])  # [6,7,12,13,18,19,24,25]
+            .grouped(4)  # [[6,7,12,13], [18,19,24,25]]
+            .map(sum)  # [38, 86]
+            .reduce(0, lambda a, x: a + x)  # [124]
+            .collect()
+        )
+        assert result == [124]
+
+
+# ---------------------------------------------------------------------------
+# map_safe / flat_map_safe (Pipeline -> ResultPipeline)
+# ---------------------------------------------------------------------------
+
+
+class TestMapSafe:
+    def test_all_succeed_wraps_in_ok(self) -> None:
+        result = Pipeline([1, 2]).map_safe(lambda x: x * 2).collect()
+        assert result == [Ok(2), Ok(4)]
+
+    def test_exception_becomes_err(self) -> None:
+        def _boom(x: int) -> int:
+            raise ValueError(f"bad {x}")
+
+        result = Pipeline([1]).map_safe(_boom).collect()
+        assert len(result) == 1
+        assert isinstance(result[0], Err)
+        assert isinstance(result[0].exception, ValueError)
+
+    def test_failure_does_not_abort_stream(self) -> None:
+        def _fail_on_two(x: int) -> int:
+            if x == 2:
+                raise ValueError("two")
+            return x
+
+        result = Pipeline([1, 2, 3]).map_safe(_fail_on_two).collect()
+        assert result[0] == Ok(1)
+        assert isinstance(result[1], Err)
+        assert result[2] == Ok(3)
+
+    def test_empty_stream(self) -> None:
+        assert Pipeline([]).map_safe(lambda x: x).collect() == []
+
+    def test_returns_result_pipeline(self) -> None:
+        assert isinstance(Pipeline([1]).map_safe(lambda x: x), ResultPipeline)
+
+
+class TestFlatMapSafe:
+    def test_all_succeed_flattened_and_wrapped(self) -> None:
+        result = Pipeline([1, 2]).flat_map_safe(lambda x: [x, x * 10]).collect()
+        assert result == [Ok(1), Ok(10), Ok(2), Ok(20)]
+
+    def test_exception_becomes_single_err(self) -> None:
+        def _boom(x: int) -> list[int]:
+            raise ValueError("boom")
+
+        result = Pipeline([1]).flat_map_safe(_boom).collect()
+        assert len(result) == 1
+        assert isinstance(result[0], Err)
+
+    def test_empty_inner_iterables_produce_no_items(self) -> None:
+        def _empty(x: int) -> list[int]:
+            return []
+
+        result = Pipeline([1, 2]).flat_map_safe(_empty).collect()
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# map_async_chunked_safe / flat_map_async_chunked_safe
+# ---------------------------------------------------------------------------
+
+
+class TestMapAsyncChunkedSafe:
+    def test_all_succeed_wraps_in_ok(self) -> None:
+        result = Pipeline([1, 2]).map_async_chunked_safe(_double).collect()
+        assert result == [Ok(2), Ok(4)]
+
+    def test_partial_failure_within_chunk(self) -> None:
+        result = Pipeline([1, 2, 3]).map_async_chunked_safe(_fail_on_even).collect()
+        assert result[0] == Ok(1)
+        assert isinstance(result[1], Err)
+        assert result[2] == Ok(3)
+
+    def test_failure_in_one_chunk_does_not_abort_next_chunk(self) -> None:
+        result = (
+            Pipeline([2, 1])
+            .map_async_chunked_safe(_fail_on_even, map_batch_size=1)
+            .collect()
+        )
+        assert isinstance(result[0], Err)
+        assert result[1] == Ok(1)
+
+    def test_empty_stream(self) -> None:
+        assert Pipeline([]).map_async_chunked_safe(_double).collect() == []
+
+    def test_invalid_batch_size_raises(self) -> None:
+        with pytest.raises(ValueError, match="map_batch_size must be >= 1"):
+            Pipeline([1]).map_async_chunked_safe(_double, map_batch_size=0)
+
+    def test_fatal_base_exception_is_reraised(self) -> None:
+        async def _interrupt(x: int) -> int:
+            raise KeyboardInterrupt()
+
+        with pytest.raises(KeyboardInterrupt):
+            Pipeline([1]).map_async_chunked_safe(_interrupt).collect()
+
+
+class TestFlatMapAsyncChunkedSafe:
+    def test_all_succeed_flattened_and_wrapped(self) -> None:
+        result = Pipeline([1, 2]).flat_map_async_chunked_safe(_duplicate).collect()
+        assert result == [Ok(1), Ok(10), Ok(2), Ok(20)]
+
+    def test_partial_failure_yields_single_err(self) -> None:
+        async def _fail_on_two(x: int) -> list[int]:
+            if x == 2:
+                raise ValueError("two")
+            return [x]
+
+        result = Pipeline([1, 2, 3]).flat_map_async_chunked_safe(_fail_on_two).collect()
+        assert result[0] == Ok(1)
+        assert isinstance(result[1], Err)
+        assert result[2] == Ok(3)
+
+    def test_empty_inner_iterable(self) -> None:
+        async def _nothing(x: int) -> list[int]:
+            return []
+
+        assert Pipeline([1]).flat_map_async_chunked_safe(_nothing).collect() == []
+
+    def test_invalid_batch_size_raises(self) -> None:
+        with pytest.raises(ValueError, match="map_batch_size must be >= 1"):
+            Pipeline([1]).flat_map_async_chunked_safe(_duplicate, map_batch_size=0)
+
+
+# ---------------------------------------------------------------------------
+# ResultPipeline combinators: map_ok / flat_map_ok
+# ---------------------------------------------------------------------------
+
+
+def _mixed_stream() -> ResultPipeline[int]:
+    return Pipeline([1, 2, 3]).map_safe(_fail_on_two_sync)
+
+
+def _fail_on_two_sync(x: int) -> int:
+    if x == 2:
+        raise ValueError("two")
+    return x
+
+
+class TestMapOk:
+    def test_transforms_ok_values(self) -> None:
+        result = (
+            Pipeline([1, 2]).map_safe(lambda x: x).map_ok(lambda x: x * 10).collect()
+        )
+        assert result == [Ok(10), Ok(20)]
+
+    def test_err_passes_through_unchanged(self) -> None:
+        result = _mixed_stream().map_ok(lambda x: x * 10).collect()
+        assert result[0] == Ok(10)
+        assert isinstance(result[1], Err)
+        assert result[2] == Ok(30)
+
+    def test_err_passes_through_at_original_position(self) -> None:
+        result = _mixed_stream().flat_map_ok(lambda x: [x, x]).collect()
+        assert result[0] == Ok(1)
+        assert result[1] == Ok(1)
+        assert isinstance(result[2], Err)
+        assert result[3] == Ok(3)
+        assert result[4] == Ok(3)
+
+    def test_exception_propagates(self) -> None:
+        def _boom(x: int) -> int:
+            raise ValueError("boom")
+
+        with pytest.raises(ValueError, match="boom"):
+            Pipeline([1]).map_safe(lambda x: x).map_ok(_boom).collect()
+
+    def test_empty_stream(self) -> None:
+        assert Pipeline([]).map_safe(lambda x: x).map_ok(lambda x: x).collect() == []
+
+
+# ---------------------------------------------------------------------------
+# ResultPipeline combinators: map_safe / flat_map_safe
+# ---------------------------------------------------------------------------
+
+
+class TestResultMapSafe:
+    def test_ok_values_are_mapped(self) -> None:
+        result = (
+            Pipeline([1, 2]).map_safe(lambda x: x).map_safe(lambda x: x * 10).collect()
+        )
+        assert result == [Ok(10), Ok(20)]
+
+    def test_existing_err_passes_through(self) -> None:
+        result = _mixed_stream().map_safe(lambda x: x * 10).collect()
+        assert result[0] == Ok(10)
+        assert isinstance(result[1], Err)
+        assert result[2] == Ok(30)
+
+    def test_exception_in_func_becomes_err(self) -> None:
+        result = (
+            Pipeline([1])
+            .map_safe(lambda x: x)
+            .map_safe(_fail_on_two_sync_wrapper)
+            .collect()
+        )
+        assert isinstance(result[0], Err)
+
+    def test_prior_and_new_errs_accumulate(self) -> None:
+        result = (
+            Pipeline([1, 2, 4])
+            .map_safe(_fail_on_two_sync)  # 2 -> Err
+            .map_safe(_fail_on_four_sync)  # 4 -> Err
+            .collect()
+        )
+        assert result[0] == Ok(1)
+        assert isinstance(result[1], Err)
+        assert isinstance(result[2], Err)
+
+
+def _fail_on_two_sync_wrapper(x: int) -> int:
+    raise ValueError(f"wrapped {x}")
+
+
+def _fail_on_four_sync(x: int) -> int:
+    if x == 4:
+        raise ValueError("four")
+    return x
+
+
+class TestResultFlatMapSafe:
+    def test_ok_values_are_flattened(self) -> None:
+        result = (
+            Pipeline([1, 2])
+            .map_safe(lambda x: x)
+            .flat_map_safe(lambda x: [x, x * 10])
+            .collect()
+        )
+        assert result == [Ok(1), Ok(10), Ok(2), Ok(20)]
+
+    def test_existing_err_passes_through(self) -> None:
+        result = _mixed_stream().flat_map_safe(lambda x: [x]).collect()
+        assert result[0] == Ok(1)
+        assert isinstance(result[1], Err)
+        assert result[2] == Ok(3)
+
+    def test_exception_in_func_becomes_single_err(self) -> None:
+        def _boom(x: int) -> list[int]:
+            raise ValueError("boom")
+
+        result = Pipeline([1]).map_safe(lambda x: x).flat_map_safe(_boom).collect()
+        assert len(result) == 1
+        assert isinstance(result[0], Err)
+
+
+# ---------------------------------------------------------------------------
+# ResultPipeline async combinators
+# ---------------------------------------------------------------------------
+
+
+class TestResultMapAsyncChunkedSafe:
+    def test_all_ok_values_are_mapped(self) -> None:
+        result = (
+            Pipeline([1, 2])
+            .map_safe(lambda x: x)
+            .map_async_chunked_safe(_double)
+            .collect()
+        )
+        assert result == [Ok(2), Ok(4)]
+
+    def test_existing_err_values_pass_through_unchanged(self) -> None:
+        result = _mixed_stream().map_async_chunked_safe(_double).collect()
+        assert result[0] == Ok(2)
+        assert isinstance(result[1], Err)
+        assert result[2] == Ok(6)
+
+    def test_func_exception_becomes_err(self) -> None:
+        result = (
+            Pipeline([1, 2])
+            .map_safe(lambda x: x)
+            .map_async_chunked_safe(_fail_on_even)
+            .collect()
+        )
+        assert result[0] == Ok(1)
+        assert isinstance(result[1], Err)
+
+    def test_prior_errs_and_new_errs_accumulate(self) -> None:
+        result = _mixed_stream().map_async_chunked_safe(_fail_on_even).collect()
+        # item 1: Ok(1); item 2: prior Err; item 3: Ok(3)
+        assert result[0] == Ok(1)
+        assert isinstance(result[1], Err)
+        assert result[2] == Ok(3)
+
+    def test_invalid_batch_size_raises(self) -> None:
+        with pytest.raises(ValueError, match="map_batch_size must be >= 1"):
+            Pipeline([1]).map_safe(lambda x: x).map_async_chunked_safe(
+                _double, map_batch_size=0
+            )
+
+
+class TestResultFlatMapAsyncChunkedSafe:
+    def test_ok_values_are_expanded(self) -> None:
+        result = (
+            Pipeline([1, 2])
+            .map_safe(lambda x: x)
+            .flat_map_async_chunked_safe(_duplicate)
+            .collect()
+        )
+        assert result == [Ok(1), Ok(10), Ok(2), Ok(20)]
+
+    def test_existing_err_passes_through(self) -> None:
+        result = _mixed_stream().flat_map_async_chunked_safe(_duplicate).collect()
+        assert result[0] == Ok(1)
+        assert result[1] == Ok(10)
+        assert isinstance(result[2], Err)
+        assert result[3] == Ok(3)
+        assert result[4] == Ok(30)
+
+    def test_func_exception_becomes_err(self) -> None:
+        async def _boom(x: int) -> list[int]:
+            raise ValueError("boom")
+
+        result = (
+            Pipeline([1])
+            .map_safe(lambda x: x)
+            .flat_map_async_chunked_safe(_boom)
+            .collect()
+        )
+        assert len(result) == 1
+        assert isinstance(result[0], Err)
+
+    def test_invalid_batch_size_raises(self) -> None:
+        with pytest.raises(ValueError, match="map_batch_size must be >= 1"):
+            Pipeline([1]).map_safe(lambda x: x).flat_map_async_chunked_safe(
+                _duplicate, map_batch_size=0
+            )
+
+
+# ---------------------------------------------------------------------------
+# filter_ok / on_error
+# ---------------------------------------------------------------------------
+
+
+class TestFilterOk:
+    def test_unwraps_ok_and_drops_err(self) -> None:
+        result = _mixed_stream().filter_ok().collect()
+        assert result == [1, 3]
+
+    def test_all_err_returns_empty(self) -> None:
+        result = Pipeline([2, 2]).map_safe(_fail_on_two_sync).filter_ok().collect()
+        assert result == []
+
+    def test_returns_pipeline(self) -> None:
+        assert isinstance(_mixed_stream().filter_ok(), Pipeline)
+
+
+class TestOnError:
+    def test_calls_handler_for_each_err(self) -> None:
+        errors: list[Err] = []
+        result = _mixed_stream().on_error(errors.append).collect()
+        assert result == [1, 3]
+        assert len(errors) == 1
+
+    def test_handler_receives_err_with_exception(self) -> None:
+        errors: list[Err] = []
+        _mixed_stream().on_error(errors.append).collect()
+        assert isinstance(errors[0].exception, ValueError)
+
+    def test_no_errors_handler_never_called(self) -> None:
+        errors: list[Err] = []
+        result = Pipeline([1]).map_safe(lambda x: x).on_error(errors.append).collect()
+        assert result == [1]
+        assert errors == []
+
+    def test_returns_pipeline(self) -> None:
+        assert isinstance(_mixed_stream().on_error(lambda e: None), Pipeline)
+
+
+# ---------------------------------------------------------------------------
+# partition
+# ---------------------------------------------------------------------------
+
+
+class TestPartition:
+    def test_successes_contain_unwrapped_ok_values(self) -> None:
+        successes, _ = _mixed_stream().partition()
+        assert successes.collect() == [1, 3]
+
+    def test_failures_contain_err_values(self) -> None:
+        _, failures = _mixed_stream().partition()
+        errs = failures.collect()
+        assert len(errs) == 1
+        assert isinstance(errs[0], Err)
+
+    def test_branches_are_independent(self) -> None:
+        successes, failures = _mixed_stream().partition()
+        assert failures.collect()[0].exception.args == ("two",)
+        assert successes.collect() == [1, 3]
+
+    def test_all_ok_empty_failure_branch(self) -> None:
+        successes, failures = Pipeline([1]).map_safe(lambda x: x).partition()
+        assert successes.collect() == [1]
+        assert failures.collect() == []
+
+    def test_all_err_empty_success_branch(self) -> None:
+        successes, failures = Pipeline([2]).map_safe(_fail_on_two_sync).partition()
+        assert successes.collect() == []
+        assert len(failures.collect()) == 1
+
+    def test_upstream_is_read_once_across_branches(self) -> None:
+        source = _CountingSource([1, 2])
+        successes, failures = (
+            Pipeline.from_source(source).map_safe(_fail_on_two_sync).partition()
+        )
+        assert successes.collect() == [1]
+        assert len(failures.collect()) == 1
+        assert source.reads == 1
+
+
+# ---------------------------------------------------------------------------
+# ResultPipeline.collect / direct construction
+# ---------------------------------------------------------------------------
+
+
+class TestResultCollect:
+    def test_returns_mixed_list(self) -> None:
+        result = _mixed_stream().collect()
+        assert result[0] == Ok(1)
+        assert isinstance(result[1], Err)
+        assert result[2] == Ok(3)
+
+    def test_direct_construction_from_result_stream(self) -> None:
+        pipe: ResultPipeline[int] = ResultPipeline([Ok(1), Err(ValueError("x"))])
+        assert pipe.filter_ok().collect() == [1]

--- a/tests/unit/pipeline/test_pipeline.py
+++ b/tests/unit/pipeline/test_pipeline.py
@@ -245,61 +245,6 @@ class TestFilter:
 
 
 # ---------------------------------------------------------------------------
-# tee
-# ---------------------------------------------------------------------------
-
-
-class TestTee:
-    def test_default_returns_two_branches(self) -> None:
-        branches = Pipeline([1, 2, 3]).tee()
-        assert len(branches) == 2
-
-    def test_each_branch_sees_all_elements(self) -> None:
-        b1, b2 = Pipeline([1, 2, 3]).tee()
-        assert b1.collect() == [1, 2, 3]
-        assert b2.collect() == [1, 2, 3]
-
-    def test_element_order_is_preserved_in_each_branch(self) -> None:
-        b1, b2 = Pipeline([3, 1, 2]).tee()
-        assert b1.collect() == [3, 1, 2]
-        assert b2.collect() == [3, 1, 2]
-
-    def test_branches_are_independent(self) -> None:
-        b1, b2 = Pipeline([1, 2, 3]).tee()
-        assert b1.map(lambda x: x * 10).collect() == [10, 20, 30]
-        assert b2.filter(lambda x: x % 2 == 1).collect() == [1, 3]
-
-    def test_n_controls_number_of_branches(self) -> None:
-        branches = Pipeline([1, 2]).tee(4)
-        assert len(branches) == 4
-        for b in branches:
-            assert b.collect() == [1, 2]
-
-    def test_empty_stream_produces_empty_branches(self) -> None:
-        b1, b2 = Pipeline[int]([]).tee()
-        assert b1.collect() == []
-        assert b2.collect() == []
-
-    def test_tee_after_map(self) -> None:
-        b1, b2 = Pipeline([1, 2]).map(lambda x: x * 5).tee()
-        assert b1.collect() == [5, 10]
-        assert b2.collect() == [5, 10]
-
-    def test_n_less_than_two_raises(self) -> None:
-        with pytest.raises(ValueError, match="n must be >= 2"):
-            Pipeline([1]).tee(1)
-
-    def test_upstream_is_read_once_across_branches(self) -> None:
-        """Evaluating a second branch resumes from shared tee state instead
-        of re-reading the source."""
-        source = _CountingSource([1, 2, 3])
-        b1, b2 = Pipeline.from_source(source).tee()
-        assert b1.collect() == [1, 2, 3]
-        assert b2.collect() == [1, 2, 3]
-        assert source.reads == 1
-
-
-# ---------------------------------------------------------------------------
 # grouped
 # ---------------------------------------------------------------------------
 
@@ -810,47 +755,6 @@ class TestOnError:
 
     def test_returns_pipeline(self) -> None:
         assert isinstance(_mixed_stream().on_error(lambda e: None), Pipeline)
-
-
-# ---------------------------------------------------------------------------
-# partition
-# ---------------------------------------------------------------------------
-
-
-class TestPartition:
-    def test_successes_contain_unwrapped_ok_values(self) -> None:
-        successes, _ = _mixed_stream().partition()
-        assert successes.collect() == [1, 3]
-
-    def test_failures_contain_err_values(self) -> None:
-        _, failures = _mixed_stream().partition()
-        errs = failures.collect()
-        assert len(errs) == 1
-        assert isinstance(errs[0], Err)
-
-    def test_branches_are_independent(self) -> None:
-        successes, failures = _mixed_stream().partition()
-        assert failures.collect()[0].exception.args == ("two",)
-        assert successes.collect() == [1, 3]
-
-    def test_all_ok_empty_failure_branch(self) -> None:
-        successes, failures = Pipeline([1]).map_safe(lambda x: x).partition()
-        assert successes.collect() == [1]
-        assert failures.collect() == []
-
-    def test_all_err_empty_success_branch(self) -> None:
-        successes, failures = Pipeline([2]).map_safe(_fail_on_two_sync).partition()
-        assert successes.collect() == []
-        assert len(failures.collect()) == 1
-
-    def test_upstream_is_read_once_across_branches(self) -> None:
-        source = _CountingSource([1, 2])
-        successes, failures = (
-            Pipeline.from_source(source).map_safe(_fail_on_two_sync).partition()
-        )
-        assert successes.collect() == [1]
-        assert len(failures.collect()) == 1
-        assert source.reads == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/pipeline/test_pipeline.py
+++ b/tests/unit/pipeline/test_pipeline.py
@@ -22,6 +22,7 @@ via ``asyncio.run()``, so no running event loop is present during the test.
 from __future__ import annotations
 
 from collections.abc import Iterable
+from typing import Any
 
 import pytest
 
@@ -433,7 +434,7 @@ class TestLaziness:
 
 
 # ---------------------------------------------------------------------------
-# map_safe / flat_map_safe (Pipeline -> ResultPipeline)
+# map_safe (Pipeline -> ResultPipeline)
 # ---------------------------------------------------------------------------
 
 
@@ -469,16 +470,29 @@ class TestMapSafe:
         assert isinstance(Pipeline([1]).map_safe(lambda x: x), ResultPipeline)
 
 
-class TestFlatMapSafe:
-    def test_all_succeed_flattened_and_wrapped(self) -> None:
-        result = Pipeline([1, 2]).flat_map_safe(lambda x: [x, x * 10]).collect()
+# ---------------------------------------------------------------------------
+# flatten_ok — the 1-to-many stage for result streams
+# ---------------------------------------------------------------------------
+
+
+class TestFlattenOk:
+    def test_expands_each_ok_into_one_ok_per_item(self) -> None:
+        result = Pipeline([1, 2]).map_safe(lambda x: [x, x * 10]).flatten_ok().collect()
         assert result == [Ok(1), Ok(10), Ok(2), Ok(20)]
 
-    def test_exception_becomes_single_err(self) -> None:
+    def test_err_passes_through_at_original_position(self) -> None:
+        result = _mixed_stream().map_safe(lambda x: [x, x]).flatten_ok().collect()
+        assert result[0] == Ok(1)
+        assert result[1] == Ok(1)
+        assert isinstance(result[2], Err)
+        assert result[3] == Ok(3)
+        assert result[4] == Ok(3)
+
+    def test_upstream_exception_stays_a_single_err(self) -> None:
         def _boom(x: int) -> list[int]:
             raise ValueError("boom")
 
-        result = Pipeline([1]).flat_map_safe(_boom).collect()
+        result = Pipeline([1]).map_safe(_boom).flatten_ok().collect()
         assert len(result) == 1
         assert isinstance(result[0], Err)
 
@@ -486,12 +500,21 @@ class TestFlatMapSafe:
         def _empty(x: int) -> list[int]:
             return []
 
-        result = Pipeline([1, 2]).flat_map_safe(_empty).collect()
-        assert result == []
+        assert Pipeline([1, 2]).map_safe(_empty).flatten_ok().collect() == []
+
+    def test_non_iterable_ok_propagates(self) -> None:
+        """flatten_ok is not error-capturing — see its docstring.
+
+        The upstream is deliberately untyped here: ``flatten_ok`` requires
+        a stream of iterables, so this misuse is a type error by design.
+        """
+        not_iterables: ResultPipeline[Any] = Pipeline([1]).map_safe(lambda x: x)
+        with pytest.raises(TypeError):
+            not_iterables.flatten_ok().collect()
 
 
 # ---------------------------------------------------------------------------
-# map_async_chunked_safe / flat_map_async_chunked_safe
+# map_async_chunked_safe
 # ---------------------------------------------------------------------------
 
 
@@ -530,10 +553,12 @@ class TestMapAsyncChunkedSafe:
             Pipeline([1]).map_async_chunked_safe(_interrupt).collect()
 
 
-class TestFlatMapAsyncChunkedSafe:
+class TestAsyncChunkedSafeThenFlattenOk:
+    """The async 1-to-many stage: map_async_chunked_safe + flatten_ok."""
+
     def test_all_succeed_flattened_and_wrapped(self) -> None:
-        result = Pipeline([1, 2]).flat_map_async_chunked_safe(_duplicate).collect()
-        assert result == [Ok(1), Ok(10), Ok(2), Ok(20)]
+        result = Pipeline([1, 2]).map_async_chunked_safe(_duplicate).flatten_ok()
+        assert result.collect() == [Ok(1), Ok(10), Ok(2), Ok(20)]
 
     def test_partial_failure_yields_single_err(self) -> None:
         async def _fail_on_two(x: int) -> list[int]:
@@ -541,7 +566,12 @@ class TestFlatMapAsyncChunkedSafe:
                 raise ValueError("two")
             return [x]
 
-        result = Pipeline([1, 2, 3]).flat_map_async_chunked_safe(_fail_on_two).collect()
+        result = (
+            Pipeline([1, 2, 3])
+            .map_async_chunked_safe(_fail_on_two)
+            .flatten_ok()
+            .collect()
+        )
         assert result[0] == Ok(1)
         assert isinstance(result[1], Err)
         assert result[2] == Ok(3)
@@ -550,15 +580,13 @@ class TestFlatMapAsyncChunkedSafe:
         async def _nothing(x: int) -> list[int]:
             return []
 
-        assert Pipeline([1]).flat_map_async_chunked_safe(_nothing).collect() == []
-
-    def test_invalid_batch_size_raises(self) -> None:
-        with pytest.raises(ValueError, match="map_batch_size must be >= 1"):
-            Pipeline([1]).flat_map_async_chunked_safe(_duplicate, map_batch_size=0)
+        assert (
+            Pipeline([1]).map_async_chunked_safe(_nothing).flatten_ok().collect() == []
+        )
 
 
 # ---------------------------------------------------------------------------
-# ResultPipeline combinators: map_ok / flat_map_ok
+# ResultPipeline combinators: map_ok
 # ---------------------------------------------------------------------------
 
 
@@ -586,12 +614,16 @@ class TestMapOk:
         assert result[2] == Ok(30)
 
     def test_err_passes_through_at_original_position(self) -> None:
-        result = _mixed_stream().flat_map_ok(lambda x: [x, x]).collect()
+        result = _mixed_stream().map_ok(lambda x: x * 10).collect()
+        assert result[0] == Ok(10)
+        assert isinstance(result[1], Err)
+        assert result[2] == Ok(30)
+
+    def test_expands_via_flatten_ok(self) -> None:
+        result = _mixed_stream().map_ok(lambda x: [x, x]).flatten_ok().collect()
         assert result[0] == Ok(1)
         assert result[1] == Ok(1)
         assert isinstance(result[2], Err)
-        assert result[3] == Ok(3)
-        assert result[4] == Ok(3)
 
     def test_exception_propagates(self) -> None:
         def _boom(x: int) -> int:
@@ -605,7 +637,7 @@ class TestMapOk:
 
 
 # ---------------------------------------------------------------------------
-# ResultPipeline combinators: map_safe / flat_map_safe
+# ResultPipeline combinators: map_safe
 # ---------------------------------------------------------------------------
 
 
@@ -653,31 +685,6 @@ def _fail_on_four_sync(x: int) -> int:
     return x
 
 
-class TestResultFlatMapSafe:
-    def test_ok_values_are_flattened(self) -> None:
-        result = (
-            Pipeline([1, 2])
-            .map_safe(lambda x: x)
-            .flat_map_safe(lambda x: [x, x * 10])
-            .collect()
-        )
-        assert result == [Ok(1), Ok(10), Ok(2), Ok(20)]
-
-    def test_existing_err_passes_through(self) -> None:
-        result = _mixed_stream().flat_map_safe(lambda x: [x]).collect()
-        assert result[0] == Ok(1)
-        assert isinstance(result[1], Err)
-        assert result[2] == Ok(3)
-
-    def test_exception_in_func_becomes_single_err(self) -> None:
-        def _boom(x: int) -> list[int]:
-            raise ValueError("boom")
-
-        result = Pipeline([1]).map_safe(lambda x: x).flat_map_safe(_boom).collect()
-        assert len(result) == 1
-        assert isinstance(result[0], Err)
-
-
 # ---------------------------------------------------------------------------
 # ResultPipeline async combinators
 # ---------------------------------------------------------------------------
@@ -723,42 +730,26 @@ class TestResultMapAsyncChunkedSafe:
             )
 
 
-class TestResultFlatMapAsyncChunkedSafe:
+class TestResultAsyncChunkedSafeThenFlattenOk:
     def test_ok_values_are_expanded(self) -> None:
         result = (
             Pipeline([1, 2])
             .map_safe(lambda x: x)
-            .flat_map_async_chunked_safe(_duplicate)
+            .map_async_chunked_safe(_duplicate)
+            .flatten_ok()
             .collect()
         )
         assert result == [Ok(1), Ok(10), Ok(2), Ok(20)]
 
     def test_existing_err_passes_through(self) -> None:
-        result = _mixed_stream().flat_map_async_chunked_safe(_duplicate).collect()
+        result = (
+            _mixed_stream().map_async_chunked_safe(_duplicate).flatten_ok().collect()
+        )
         assert result[0] == Ok(1)
         assert result[1] == Ok(10)
         assert isinstance(result[2], Err)
         assert result[3] == Ok(3)
         assert result[4] == Ok(30)
-
-    def test_func_exception_becomes_err(self) -> None:
-        async def _boom(x: int) -> list[int]:
-            raise ValueError("boom")
-
-        result = (
-            Pipeline([1])
-            .map_safe(lambda x: x)
-            .flat_map_async_chunked_safe(_boom)
-            .collect()
-        )
-        assert len(result) == 1
-        assert isinstance(result[0], Err)
-
-    def test_invalid_batch_size_raises(self) -> None:
-        with pytest.raises(ValueError, match="map_batch_size must be >= 1"):
-            Pipeline([1]).map_safe(lambda x: x).flat_map_async_chunked_safe(
-                _duplicate, map_batch_size=0
-            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Description

Adds a lazily-evaluated dataflow pipeline DSL (`neo4j_graphrag.pipeline`) plus a local interpreter to run it.

A `Pipeline` is **pure data** — building one produces an operator graph and executes nothing. Evaluation is deferred to an `Interpreter`, triggered by `.collect()`, `.to_sink()`, iteration, or by passing an interpreter explicitly. This separation means the same pipeline definition can later be run by alternative interpreters (batched, distributed, instrumented) without touching the definition site.

```python
from neo4j_graphrag.pipeline import Pipeline

results = (
    Pipeline.from_source(my_source)
    .map(transform)
    .flat_map(expand)
    .map_async_chunked(async_transform)
    .reduce(zero=identity, combine=merge)
    .collect()
)
```

## What's included

- **`pipeline.py`** — the `Pipeline` / `ResultPipeline` builder API.
- **`operators.py`** — the operator graph: `Map`, `FlatMap`, `Filter`, `Take`, `TakeWhile`, `Skip`, `Grouped`, `ReduceOp`, `MapAsyncChunked`, the `Try*` error-capturing variants, the `*Ok` variants that operate inside a `Result`, plus `Tee` / `Partition` for fan-out.
- **`interpreter.py`** — `Interpreter` protocol and `LocalInterpreter`, which evaluates a graph in-process with bounded-concurrency chunking for the async operators.
- **`result.py`** — `Result` / `Ok` / `Err`, so a failing element becomes a value in the stream rather than an exception that tears down the whole run.
- **`source.py`** / **`sink.py`** — the `Source` and `Sink` boundary protocols.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

Purely additive — a new subpackage with no changes to existing modules, so nothing currently importable changes behaviour.

## Complexity

Complexity: High — new subsystem, ~1,500 lines of implementation and a fair amount of design surface in the operator set.

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [ ] Manual tests

`tests/unit/pipeline/test_pipeline.py` (~870 lines) covers the builder, each operator, laziness/short-circuiting, error propagation through the `Try*` and `*Ok` variants, and the tee/partition fan-out paths.

# Checklist

- [ ] Documentation has been updated — module and method docstrings are in place, but there's no `docs/` entry yet
- [x] Unit tests have been updated
- [ ] E2E tests have been updated — not applicable, no I/O in this PR
- [ ] Examples have been updated — a `SimpleKGBuilder` built on this DSL is the planned follow-up PR
- [x] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate

## Note on review order

This is the first of two changes. The follow-up rewrites `SimpleKGBuilder` on top of this DSL and adds a worked example; it's parked on `pipeline-dsl-example` until this lands. Reviewing the DSL on its own first is the intent — happy to open the second as a draft now if seeing the consumer helps judge the API.
