### PR TITLE
Convert `GeoPoint` to a compatible format for parquet file output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed `BaseGeminiLLM`/`GeminiLLM` silently dropping token usage on every call: `invoke`/`ainvoke` (both the string and message-list paths, sync and async) built `LLMResponse` from `response.text` alone, ignoring `response.usage_metadata` entirely. `LLMResponse.usage` is now populated from it, matching `AnthropicLLM`/`OpenAILLM`/`VertexAILLM`.
+- Fixed Parquet writes aborting with `ArrowInvalid` when a node or relationship property was a GraphRAG `GeoPoint`. `Neo4jGraphParquetFormatter` now serializes those values as WKT `POINT(longitude latitude height)` before Arrow type inference, and writer file metadata reports `target_type: POINT` (Parquet source type remains `STRING`).
 
 ## 1.19.0
 

--- a/src/neo4j_graphrag/components/kg_writer.py
+++ b/src/neo4j_graphrag/components/kg_writer.py
@@ -28,6 +28,7 @@ from neo4j_graphrag.components.filename_collision_handler import (
 from neo4j_graphrag.components.parquet_formatter import (
     INTERNAL_ID_PROPERTY,
     Neo4jGraphParquetFormatter,
+    PARQUET_NEO4J_TYPE_METADATA_KEY,
 )
 from neo4j_graphrag.components.parquet_output import (
     ParquetOutputDestination,
@@ -66,14 +67,24 @@ def _build_columns_from_schema(
         field = schema.field(i)
         type_info = Neo4jGraphParquetFormatter.pyarrow_type_to_type_info(field.type)
         name = field.name
-        columns.append(
-            {
-                "name": name,
-                "type": type_info.source_type,
-                "is_primary_key": name in primary_key_names,
-                "is_unique": name in uniqueness_names,
-            }
-        )
+        column: dict[str, Any] = {
+            "name": name,
+            "type": type_info.source_type,
+            "is_primary_key": name in primary_key_names,
+            "is_unique": name in uniqueness_names,
+        }
+        field_meta = field.metadata or {}
+        raw_neo4j_type = field_meta.get(PARQUET_NEO4J_TYPE_METADATA_KEY)
+        if raw_neo4j_type is not None:
+            neo4j_type = (
+                raw_neo4j_type.decode()
+                if isinstance(raw_neo4j_type, bytes)
+                else str(raw_neo4j_type)
+            )
+            column["target_type"] = neo4j_type.upper()
+        elif type_info.target_type != type_info.source_type:
+            column["target_type"] = type_info.target_type
+        columns.append(column)
     return columns
 
 

--- a/src/neo4j_graphrag/components/parquet_formatter.py
+++ b/src/neo4j_graphrag/components/parquet_formatter.py
@@ -35,6 +35,7 @@ from neo4j_graphrag.components.schema import (
     GraphSchema,
 )
 from neo4j_graphrag.components.types import (
+    GeoPoint,
     LexicalGraphConfig,
     Neo4jGraph,
     Neo4jNode,
@@ -46,7 +47,24 @@ logger = logging.getLogger(__name__)
 INTERNAL_ID_PROPERTY = "__id__"
 """Parquet column name for the graph-internal node identifier (not a user property)."""
 
+PARQUET_NEO4J_TYPE_METADATA_KEY = b"neo4j_type"
+"""Arrow field metadata key for the Neo4j / import-spec target property type."""
+
 _FALLBACK_FILESTEM = "unnamed"
+
+
+def _geopoint_like_to_wkt(value: Any) -> Optional[str]:
+    """Return WKT for a ``GeoPoint`` or a dumped ``{latitude, longitude, height?}`` dict."""
+    if isinstance(value, GeoPoint):
+        return value.to_wkt()
+    if isinstance(value, dict) and "latitude" in value and "longitude" in value:
+        height = value.get("height", 0.0)
+        return GeoPoint(
+            latitude=float(value["latitude"]),
+            longitude=float(value["longitude"]),
+            height=float(height if height is not None else 0.0),
+        ).to_wkt()
+    return None
 
 
 def _is_allowed_filestem_char(c: str) -> bool:
@@ -696,6 +714,26 @@ class Neo4jGraphParquetFormatter:
                     except (ValueError, TypeError):
                         row[col] = str(row[col])
 
+    @staticmethod
+    def _serialize_geopoint_values(rows: list[dict[str, Any]]) -> set[str]:
+        """Replace GeoPoint (and dumped dict) values with WKT; return POINT column names.
+
+        A column is treated as POINT when every non-null value was GeoPoint-like.
+        """
+        saw_geopoint: set[str] = set()
+        saw_other: set[str] = set()
+        for row in rows:
+            for key, value in row.items():
+                if value is None:
+                    continue
+                wkt = _geopoint_like_to_wkt(value)
+                if wkt is not None:
+                    row[key] = wkt
+                    saw_geopoint.add(key)
+                else:
+                    saw_other.add(key)
+        return saw_geopoint - saw_other
+
     def format_parquet(
         self,
         rows: list[dict[str, Any]],
@@ -717,6 +755,7 @@ class Neo4jGraphParquetFormatter:
             import pyarrow as pa
             import pyarrow.parquet as pq
 
+            point_columns = self._serialize_geopoint_values(rows)
             self._normalize_column_types(rows)
 
             # Build an explicit schema from the union of all keys to avoid
@@ -752,7 +791,10 @@ class Neo4jGraphParquetFormatter:
                     t = pa.list_(pa.null())
                 else:
                     t = pa.null()
-                fields.append(pa.field(k, t))
+                field_metadata = None
+                if k in point_columns:
+                    field_metadata = {PARQUET_NEO4J_TYPE_METADATA_KEY: b"POINT"}
+                fields.append(pa.field(k, t, metadata=field_metadata))
 
             schema = pa.schema(fields) if fields else None
             table = pa.Table.from_pylist(rows, schema=schema)

--- a/src/neo4j_graphrag/components/types.py
+++ b/src/neo4j_graphrag/components/types.py
@@ -44,6 +44,14 @@ class GeoPoint(BaseModel):
     longitude: float
     height: float
 
+    def to_wkt(self) -> str:
+        """Serialize as WKT ``POINT(longitude latitude height)``.
+
+        Axis order is longitude then latitude (x then y), then height.
+        Height is always included so 3D values round-trip losslessly.
+        """
+        return f"POINT({self.longitude} {self.latitude} {self.height})"
+
 
 # Define primitive value types
 PrimitiveValue = Union[bool, int, float, str]

--- a/tests/unit/components/test_kg_writer.py
+++ b/tests/unit/components/test_kg_writer.py
@@ -38,6 +38,7 @@ from neo4j_graphrag.components.kg_writer import (
 )
 from neo4j_graphrag.components.schema import GraphSchema
 from neo4j_graphrag.components.types import (
+    GeoPoint,
     LexicalGraphConfig,
     Neo4jGraph,
     Neo4jNode,
@@ -1886,3 +1887,132 @@ def test_formatter_embedding_keys_unioned_across_nodes_of_same_label() -> None:
             "similarity": "cosine",
         }
     ]
+
+
+# ---------------------------------------------------------------------------
+# GeoPoint / POINT Parquet serialization
+# ---------------------------------------------------------------------------
+
+
+def test_format_parquet_geopoint_node_property_writes_wkt() -> None:
+    """GeoPoint on a node property writes as WKT and is typed as POINT."""
+    pytest.importorskip("pyarrow")
+    import pyarrow.parquet as pq
+
+    formatter = Neo4jGraphParquetFormatter()
+    point = GeoPoint(latitude=0.0, longitude=0.0, height=0.0)
+    rows: list[dict[str, Any]] = [
+        {
+            INTERNAL_ID_PROPERTY: "n1",
+            "name": "Alice",
+            "location": point,
+        }
+    ]
+
+    parquet_bytes, schema = formatter.format_parquet(rows, "node label 'Person'")
+
+    location_field = schema.field("location")
+    assert location_field.metadata is not None
+    assert location_field.metadata.get(b"neo4j_type") == b"POINT"
+
+    table = pq.read_table(BytesIO(parquet_bytes))
+    assert table.column("location")[0].as_py() == "POINT(0.0 0.0 0.0)"
+
+
+def test_format_parquet_geopoint_relationship_property_writes_wkt() -> None:
+    """GeoPoint on a relationship property writes as WKT (Person_KILLS_Creature)."""
+    pytest.importorskip("pyarrow")
+    import pyarrow.parquet as pq
+
+    formatter = Neo4jGraphParquetFormatter()
+    point = GeoPoint(latitude=12.5, longitude=-3.25, height=4.0)
+    rows: list[dict[str, Any]] = [
+        {
+            "from": "p1",
+            "to": "c1",
+            "from_label": "Person",
+            "to_label": "Creature",
+            "type": "KILLS",
+            "where": point,
+        }
+    ]
+
+    parquet_bytes, schema = formatter.format_parquet(
+        rows, "relationship 'Person_KILLS_Creature'"
+    )
+
+    where_field = schema.field("where")
+    assert where_field.metadata is not None
+    assert where_field.metadata.get(b"neo4j_type") == b"POINT"
+
+    table = pq.read_table(BytesIO(parquet_bytes))
+    assert table.column("where")[0].as_py() == point.to_wkt()
+
+
+def test_format_parquet_geopoint_mixed_with_none() -> None:
+    """Nulls alongside GeoPoint do not break type inference or WKT conversion."""
+    pytest.importorskip("pyarrow")
+    import pyarrow.parquet as pq
+
+    formatter = Neo4jGraphParquetFormatter()
+    point = GeoPoint(latitude=1.0, longitude=2.0, height=3.0)
+    rows: list[dict[str, Any]] = [
+        {INTERNAL_ID_PROPERTY: "n1", "location": None},
+        {INTERNAL_ID_PROPERTY: "n2", "location": point},
+    ]
+
+    parquet_bytes, schema = formatter.format_parquet(rows, "node label 'Person'")
+
+    location_field = schema.field("location")
+    assert location_field.metadata is not None
+    assert location_field.metadata.get(b"neo4j_type") == b"POINT"
+
+    table = pq.read_table(BytesIO(parquet_bytes))
+    values = table.column("location").to_pylist()
+    assert values[0] is None
+    assert values[1] == point.to_wkt()
+
+
+@pytest.mark.asyncio
+async def test_parquet_writer_geopoint_column_metadata_target_type_point() -> None:
+    """ParquetWriter files metadata: GeoPoint columns are STRING source, POINT target."""
+    pytest.importorskip("pyarrow")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = Path(tmpdir)
+        dest = _LocalParquetDestination(out)
+        writer = ParquetWriter(
+            nodes_dest=dest,
+            relationships_dest=dest,
+            collision_handler=FilenameCollisionHandler(),
+        )
+        location = GeoPoint(latitude=0.0, longitude=0.0, height=0.0)
+        node1 = Neo4jNode(
+            id="p1",
+            label="Person",
+            properties={"name": "Alice", "location": location},
+        )
+        node2 = Neo4jNode(id="c1", label="Creature", properties={"name": "Beast"})
+        rel = Neo4jRelationship(
+            start_node_id="p1",
+            end_node_id="c1",
+            type="KILLS",
+            properties={"where": location},
+        )
+        graph = Neo4jGraph(nodes=[node1, node2], relationships=[rel])
+
+        result = await writer.run(graph=graph)
+
+    assert result.status == "SUCCESS"
+    assert result.metadata is not None
+    files = result.metadata["files"]
+    node_file = next(f for f in files if f.get("name") == "Person")
+    rel_file = next(f for f in files if not f["is_node"])
+
+    node_cols = {c["name"]: c for c in node_file["columns"]}
+    assert node_cols["location"]["type"] == "STRING"
+    assert node_cols["location"]["target_type"] == "POINT"
+
+    rel_cols = {c["name"]: c for c in rel_file["columns"]}
+    assert rel_cols["where"]["type"] == "STRING"
+    assert rel_cols["where"]["target_type"] == "POINT"

--- a/tests/unit/components/test_types.py
+++ b/tests/unit/components/test_types.py
@@ -51,3 +51,17 @@ def test_getattr_unknown_raises() -> None:
 
     with pytest.raises(AttributeError, match="no attribute 'not_a_real_export'"):
         _ = types_mod.not_a_real_export
+
+
+def test_geopoint_to_wkt_includes_lon_lat_height() -> None:
+    from neo4j_graphrag.components.types import GeoPoint
+
+    point = GeoPoint(latitude=1.5, longitude=2.25, height=10.0)
+    assert point.to_wkt() == "POINT(2.25 1.5 10.0)"
+
+
+def test_geopoint_to_wkt_zero_origin() -> None:
+    from neo4j_graphrag.components.types import GeoPoint
+
+    point = GeoPoint(latitude=0.0, longitude=0.0, height=0.0)
+    assert point.to_wkt() == "POINT(0.0 0.0 0.0)"


### PR DESCRIPTION
# Description

Fixes [GENKGB-2040](https://linear.app/neo4j/issue/GENKGB-2040/parquet-write-fails-on-graphrag-geopoint-properties): Parquet writes aborted with `ArrowInvalid` when a node or relationship still had a GraphRAG `GeoPoint` at write time. PyArrow cannot infer a type from the pydantic object.

`Neo4jGraphParquetFormatter.format_parquet` now converts `GeoPoint` (and dumped `{latitude, longitude, height}` dicts) to WKT `POINT(longitude latitude height)` before type inference. POINT columns are tagged in Arrow field metadata. Writer file metadata keeps the Parquet source type as `STRING` and sets `target_type: POINT` for Aura import-spec.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Low

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [x] CHANGELOG.md updated if appropriate